### PR TITLE
feat: implement snagline baseline healthy-run profiler

### DIFF
--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -12,6 +12,7 @@ Public API (core, zero third-party dependencies):
 from __future__ import annotations
 
 from snagline.adapters.raw import watch
+from snagline.baseline import BaselineProfile, ToolBaseline, fit_baseline_from_jsonl
 from snagline.config import Config
 from snagline.events import EpisodeMeta, StepEvent, make_signature
 from snagline.monitor import Monitor
@@ -26,4 +27,7 @@ __all__ = [
     "TriggerType",
     "Config",
     "watch",
+    "BaselineProfile",
+    "ToolBaseline",
+    "fit_baseline_from_jsonl",
 ]

--- a/src/snagline/baseline.py
+++ b/src/snagline/baseline.py
@@ -1,0 +1,155 @@
+"""Healthy-run baseline fitting (project.md §5 / the `snagline baseline` CLI).
+
+Fits a per-tool profile (latency mean/std/min/max and error rate) from a
+JSONL trajectory of a *known-healthy* agent run. The profile is persisted as
+JSON so later build phases (the `goal_drift` and `ml_ensemble` detectors) have
+a reference to compare live traffic against.
+
+This is intentionally dependency-free: the basic statistics are computed with
+Welford-style online accumulators, so `snagline baseline` works with no extra
+installed. Heavier model-based baselines (the `ml` extra) can build on top of
+the same persisted profile later.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import IO
+
+from snagline.events import StepEvent
+
+
+@dataclass
+class ToolBaseline:
+    """Per-tool healthy-run statistics."""
+
+    tool_name: str
+    count: int = 0
+    latency_sum: float = 0.0
+    latency_sum_sq: float = 0.0
+    error_count: int = 0
+    min_latency: float | None = None
+    max_latency: float | None = None
+
+    def add(self, latency_ms: float, error: bool) -> None:
+        self.count += 1
+        self.latency_sum += latency_ms
+        self.latency_sum_sq += latency_ms * latency_ms
+        if self.min_latency is None or latency_ms < self.min_latency:
+            self.min_latency = latency_ms
+        if self.max_latency is None or latency_ms > self.max_latency:
+            self.max_latency = latency_ms
+        if error:
+            self.error_count += 1
+
+    @property
+    def mean_latency(self) -> float:
+        return self.latency_sum / self.count if self.count else 0.0
+
+    @property
+    def std_latency(self) -> float:
+        if self.count < 2:
+            return 0.0
+        var = (self.latency_sum_sq - self.latency_sum**2 / self.count) / (
+            self.count - 1
+        )
+        return max(0.0, var) ** 0.5
+
+    @property
+    def error_rate(self) -> float:
+        return self.error_count / self.count if self.count else 0.0
+
+    def to_dict(self) -> dict:
+        return {
+            "tool_name": self.tool_name,
+            "count": self.count,
+            "mean_latency": self.mean_latency,
+            "std_latency": self.std_latency,
+            "min_latency": self.min_latency,
+            "max_latency": self.max_latency,
+            "error_count": self.error_count,
+            "error_rate": self.error_rate,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> ToolBaseline:
+        tb = cls(tool_name=data["tool_name"])
+        tb.count = data["count"]
+        tb.latency_sum = data.get("mean_latency", 0.0) * tb.count
+        tb.latency_sum_sq = (
+            data.get("std_latency", 0.0) ** 2 * max(1, tb.count - 1)
+            + tb.latency_sum**2 / tb.count
+            if tb.count
+            else 0.0
+        )
+        tb.error_count = data.get("error_count", 0)
+        tb.min_latency = data.get("min_latency")
+        tb.max_latency = data.get("max_latency")
+        return tb
+
+
+@dataclass
+class BaselineProfile:
+    """Aggregated healthy-run profile across all tools."""
+
+    tools: dict[str, ToolBaseline] = field(default_factory=dict)
+    total_steps: int = 0
+
+    def add_event(self, event: StepEvent) -> None:
+        self.total_steps += 1
+        if event.action_type == "tool_call" and event.latency_ms is not None:
+            name = event.tool_name or "default"
+            tb = self.tools.get(name)
+            if tb is None:
+                tb = ToolBaseline(tool_name=name)
+                self.tools[name] = tb
+            tb.add(event.latency_ms, event.error)
+
+    def to_dict(self) -> dict:
+        return {
+            "version": 1,
+            "total_steps": self.total_steps,
+            "tools": {name: tb.to_dict() for name, tb in sorted(self.tools.items())},
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict) -> BaselineProfile:
+        profile = cls(total_steps=data.get("total_steps", 0))
+        for name, tb in data.get("tools", {}).items():
+            profile.tools[name] = ToolBaseline.from_dict(tb)
+        return profile
+
+
+def fit_baseline_from_jsonl(path: str) -> BaselineProfile:
+    """Fit a ``BaselineProfile`` from a JSONL trajectory (mirrors replay's
+    fail-soft line handling: malformed lines are skipped, not fatal)."""
+    profile = BaselineProfile()
+    with open(path, encoding="utf-8") as fh:
+        for _lineno, line in enumerate(fh, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+                event = StepEvent(**obj)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                # Fail-soft, like replay(): a bad line must not abort the fit.
+                continue
+            profile.add_event(event)
+    return profile
+
+
+def save_baseline(profile: BaselineProfile, path: str) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        _write_json(fh, profile.to_dict())
+
+
+def load_baseline(path: str) -> BaselineProfile:
+    with open(path, encoding="utf-8") as fh:
+        return BaselineProfile.from_dict(json.load(fh))
+
+
+def _write_json(stream: IO[str], data: dict) -> None:
+    json.dump(data, stream, indent=2, sort_keys=True)
+    stream.write("\n")

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -167,11 +167,19 @@ def _build_parser() -> argparse.ArgumentParser:
         help="HTTP timeout when --url is used [s].",
     )
 
-    # Registered but not yet implemented: belongs to the ml extra (later phase).
+    # Fits a per-tool healthy-run profile from a trajectory and persists it as
+    # JSON. Dependency-free (stdlib only); model-based baselines can build on
+    # the same persisted profile later.
     sp = sub.add_parser(
-        "baseline", help="Fit a healthy-run baseline. [ml extra, not built yet]"
+        "baseline",
+        help="Fit a healthy-run baseline (per-tool latency/error profile) from a trajectory.",
     )
-    sp.add_argument("__rest", nargs="*", help=argparse.SUPPRESS)
+    sp.add_argument("trajectory", help="Path to a .jsonl trajectory of a healthy run.")
+    sp.add_argument(
+        "--output",
+        default="baseline.json",
+        help="Where to write the fitted baseline JSON [default: baseline.json].",
+    )
 
     return parser
 
@@ -306,6 +314,26 @@ def _event_to_json(event: StepEvent) -> dict:
     }
 
 
+def _cmd_baseline(args: argparse.Namespace) -> int:
+    """Fit a healthy-run baseline from a trajectory and persist it as JSON."""
+    from snagline.baseline import fit_baseline_from_jsonl, save_baseline
+
+    profile = fit_baseline_from_jsonl(args.trajectory)
+    save_baseline(profile, args.output)
+
+    tools = profile.tools
+    print(
+        f"snagline baseline: fitted {len(tools)} tool(s) from {profile.total_steps} step(s)"
+    )
+    for name, tb in sorted(tools.items()):
+        print(
+            f"  {name}: n={tb.count} mean={tb.mean_latency:.1f}ms "
+            f"std={tb.std_latency:.1f}ms errors={tb.error_count}"
+        )
+    print(f"snagline baseline: wrote {args.output}")
+    return 0
+
+
 def _cmd_serve(args: argparse.Namespace) -> int:
     from snagline.server.http_server import serve
 
@@ -411,12 +439,7 @@ def main(argv: list[str] | None = None) -> int:
         return _cmd_serve(args)
 
     if args.command == "baseline":
-        print(
-            f"snagline {args.command} is not implemented in this build phase (v0.1). "
-            "It will arrive in a later, explicitly-ordered step.",
-            file=sys.stderr,
-        )
-        return 2
+        return _cmd_baseline(args)
 
     parser.print_help()
     return 0

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -1,0 +1,106 @@
+"""Tests for the healthy-run baseline fitter and the `snagline baseline` CLI."""
+
+from __future__ import annotations
+
+import json
+
+from snagline.baseline import (
+    BaselineProfile,
+    ToolBaseline,
+    fit_baseline_from_jsonl,
+    load_baseline,
+    save_baseline,
+)
+from snagline.cli import main
+
+
+def _event(tool, latency, error=False, episode="ep"):
+    return {
+        "step_id": "0",
+        "episode_id": episode,
+        "timestamp": 1.0,
+        "action_type": "tool_call",
+        "action_signature": "sig",
+        "tool_name": tool,
+        "latency_ms": latency,
+        "error": error,
+    }
+
+
+def test_tool_baseline_statistics():
+    tb = ToolBaseline(tool_name="search")
+    for lat in (100.0, 110.0, 90.0):
+        tb.add(lat, error=False)
+    tb.add(100.0, error=True)
+    assert tb.count == 4
+    assert tb.mean_latency == 100.0
+    # sample std of [100,110,90,100]: mean 100, var 200/3, std ~8.165
+    assert abs(tb.std_latency - 8.165) < 0.1
+    assert tb.error_count == 1
+    assert tb.error_rate == 0.25
+    assert tb.min_latency == 90.0
+    assert tb.max_latency == 110.0
+
+
+def test_fit_baseline_aggregates_per_tool(tmp_path):
+    traj = tmp_path / "healthy.jsonl"
+    rows = [
+        _event("search", 100.0),
+        _event("search", 120.0),
+        _event("lookup", 50.0),
+        # non-tool events and missing latency are ignored for tool stats
+        {
+            "step_id": "1",
+            "episode_id": "ep",
+            "timestamp": 1.0,
+            "action_type": "message",
+            "action_signature": "m",
+            "error": False,
+        },
+    ]
+    traj.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+
+    profile = fit_baseline_from_jsonl(str(traj))
+    assert profile.total_steps == 4
+    assert set(profile.tools) == {"search", "lookup"}
+    assert abs(profile.tools["search"].mean_latency - 110.0) < 1e-6
+    assert abs(profile.tools["lookup"].mean_latency - 50.0) < 1e-6
+
+
+def test_baseline_skips_malformed_lines(tmp_path):
+    traj = tmp_path / "mixed.jsonl"
+    traj.write_text(json.dumps(_event("search", 100.0)) + "\n" + "not json\n")
+    profile = fit_baseline_from_jsonl(str(traj))
+    assert "search" in profile.tools
+
+
+def test_baseline_save_and_load_roundtrip(tmp_path):
+    profile = BaselineProfile()
+    for lat in (100.0, 110.0, 90.0):
+        profile.add_event(type("E", (), _event("search", lat))())
+    out = tmp_path / "baseline.json"
+    save_baseline(profile, str(out))
+    loaded = load_baseline(str(out))
+    assert loaded.total_steps == profile.total_steps
+    assert loaded.tools["search"].count == 3
+    assert abs(loaded.tools["search"].mean_latency - 100.0) < 1e-6
+    assert (
+        abs(loaded.tools["search"].std_latency - profile.tools["search"].std_latency)
+        < 1e-6
+    )
+
+
+def test_cli_baseline_command(tmp_path, capsys):
+    traj = tmp_path / "healthy.jsonl"
+    traj.write_text(
+        "\n".join(json.dumps(_event("search", lat)) for lat in (100.0, 120.0, 110.0))
+        + "\n"
+    )
+    out = tmp_path / "baseline.json"
+    rc = main(["baseline", str(traj), "--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    out_text = capsys.readouterr().out
+    assert "fitted 1 tool(s)" in out_text
+    loaded = load_baseline(str(out))
+    assert "search" in loaded.tools


### PR DESCRIPTION
## Summary
Implements the previously-stubbed `snagline baseline` command (step 1 of the next-phase plan).

- New `src/snagline/baseline.py`: dependency-free `BaselineProfile` / `ToolBaseline` that aggregate per-tool latency (mean/std/min/max) and error rate from a JSONL trajectory, persist the profile as JSON, and load it back.
- Wire the `baseline` CLI subcommand (positional `trajectory`, `--output`) to the fitter.
- Fail-soft line handling mirrors `replay()` so a malformed line never aborts the fit.
- Expose `BaselineProfile`, `ToolBaseline`, `fit_baseline_from_jsonl` in `snagline.__init__`.
- Tests in `tests/test_baseline.py` cover statistics, per-tool aggregation, malformed-line skipping, save/load round-trip, and the CLI command.

This unblocks the `goal_drift` and `ml_ensemble` detectors, which will compare live traffic against the persisted healthy profile.

## Verification
Local gate before push: `ruff check`, `ruff format --check`, `mypy src`, and `pytest` all green at ~89% coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added baseline profiling for healthy agent runs, including per-tool latency and error statistics.
  * Added JSON serialization and file save/load support for baseline profiles.
  * Added a functional `baseline` command to generate profiles from trajectory files and report tool statistics.
  * Exposed baseline profiling capabilities through the package’s public interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->