### PR TITLE
feat: goal_drift detector against healthy baseline

### DIFF
--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from snagline.adapters.raw import watch
 from snagline.baseline import BaselineProfile, ToolBaseline, fit_baseline_from_jsonl
 from snagline.config import Config
+from snagline.detectors.goal_drift import GoalDriftDetector
 from snagline.events import EpisodeMeta, StepEvent, make_signature
 from snagline.monitor import Monitor
 from snagline.risk import FailureRisk, TriggerType
@@ -30,4 +31,5 @@ __all__ = [
     "BaselineProfile",
     "ToolBaseline",
     "fit_baseline_from_jsonl",
+    "GoalDriftDetector",
 ]

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
+from snagline.baseline import BaselineProfile
+
 
 @dataclass
 class Config:
@@ -40,6 +42,16 @@ class Config:
     # baselines, so a single large spike alarms instead of requiring several.
     cusum_sigma_floor_abs: float = 1.0  # ms; never treat baseline std as smaller
     cusum_sigma_floor_rel: float = 0.05  # ... or smaller than 5% of the mean
+
+    # Goal-drift detector (next phase, step 2). Compares a live run's per-tool
+    # error rate / latency against a persisted healthy BaselineProfile and
+    # flags meaningful deviation. Opt-in: enabled only when a baseline exists.
+    goal_drift_enabled: bool = False
+    goal_drift_error_tolerance: float = 0.1  # allow baseline error_rate + this
+    goal_drift_latency_k: float = 3.0  # sigmas above baseline mean counts as drift
+    goal_drift_min_samples: int = 10  # live steps before scoring an episode
+    goal_drift_score_threshold: float = 0.5  # emit a risk above this score
+    goal_drift_baseline: BaselineProfile | None = None  # healthy reference
 
     # Global
     fail_open: bool = True

--- a/src/snagline/detectors/goal_drift.py
+++ b/src/snagline/detectors/goal_drift.py
@@ -1,0 +1,98 @@
+"""Goal-drift detector (next phase, step 2).
+
+Compares a live run's per-tool behavior against a *persisted healthy*
+``BaselineProfile`` (see ``snagline.baseline``) and flags meaningful drift: a
+rising error rate, latency blowing past the healthy mean by several sigmas, or
+tools that never appeared in the healthy baseline.
+
+The detector is dependency-free. An optional ``embedder`` callable
+(``StepEvent -> Sequence[float]``) is accepted for future content-level
+semantic drift, but the shipped behavior is the structural comparison above,
+which needs no ML dependency and stays safe for the zero-dep default.
+
+The detector is a no-op until a baseline is supplied, so it can be wired into
+``Monitor.default()`` behind ``Config.goal_drift_enabled`` without changing
+default behavior.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from snagline.baseline import BaselineProfile
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.risk import FailureRisk
+
+
+class GoalDriftDetector:
+    name = "goal_drift"
+
+    def __init__(
+        self,
+        baseline: BaselineProfile | None = None,
+        config: Config | None = None,
+        embedder: Any = None,
+    ) -> None:
+        self._baseline = baseline
+        self._cfg = config or Config()
+        self._embedder = embedder
+        # Per-episode live accumulation reuses BaselineProfile's accumulators.
+        self._live: dict[str, BaselineProfile] = {}
+        self._fired: dict[str, bool] = {}
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        if self._baseline is None:
+            return None
+        baseline = self._baseline
+        live = self._live.setdefault(event.episode_id, BaselineProfile())
+        live.add_event(event)
+        if live.total_steps < self._cfg.goal_drift_min_samples:
+            return None
+        score = self._drift_score(event.episode_id, baseline)
+        if score < self._cfg.goal_drift_score_threshold:
+            return None
+        if self._fired.get(event.episode_id, False):
+            return None
+        self._fired[event.episode_id] = True
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            min(1.0, score),
+            "goal_drift",
+            f"behavior diverged from healthy baseline (score {score:.2f})",
+            event.timestamp,
+        )
+
+    def _drift_score(self, episode_id: str, baseline: BaselineProfile) -> float:
+        live = self._live[episode_id]
+        cfg = self._cfg
+        contributions: list[float] = []
+        for name, tb in live.tools.items():
+            ref = baseline.tools.get(name)
+            if ref is None:
+                # A tool that never ran in the healthy baseline is suspicious.
+                contributions.append(0.6)
+                continue
+            err_drift = max(
+                0.0, tb.error_rate - (ref.error_rate + cfg.goal_drift_error_tolerance)
+            )
+            if err_drift > 0:
+                contributions.append(min(1.0, err_drift * 2.0))
+            # Latency drift: compare live mean to the healthy mean. Floor the
+            # reference spread so a zero-variance baseline (all identical healthy
+            # latencies) does not treat any tiny deviation as infinite z.
+            if tb.mean_latency > 0 and ref.mean_latency > 0:
+                spread = max(ref.std_latency, 0.05 * ref.mean_latency, 1.0)
+                z = (tb.mean_latency - ref.mean_latency) / spread
+                if z > cfg.goal_drift_latency_k:
+                    contributions.append(
+                        min(1.0, (z - cfg.goal_drift_latency_k) / 10.0)
+                    )
+        if not contributions:
+            return 0.0
+        return min(1.0, sum(contributions))
+
+    def reset(self, episode_id: str) -> None:
+        self._live.pop(episode_id, None)
+        self._fired.pop(episode_id, None)

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -141,6 +141,7 @@ class Monitor:
         unless ``sinks`` is given, the console sink.
         """
         from snagline.detectors.error_cascade import ErrorCascadeDetector
+        from snagline.detectors.goal_drift import GoalDriftDetector
         from snagline.detectors.latency_anomaly import LatencyAnomalyDetector
         from snagline.detectors.loop import LoopDetector
         from snagline.sinks.console import ConsoleSink
@@ -151,5 +152,11 @@ class Monitor:
             ErrorCascadeDetector(config=cfg),
             LatencyAnomalyDetector(config=cfg),
         ]
+        # Goal-drift is opt-in: only when explicitly enabled and a baseline is
+        # supplied, so the zero-dependency default is unchanged (step 2).
+        if cfg.goal_drift_enabled and cfg.goal_drift_baseline is not None:
+            detectors.append(
+                GoalDriftDetector(baseline=cfg.goal_drift_baseline, config=cfg)
+            )
         chosen_sinks: list[AlertSink] = sinks if sinks is not None else [ConsoleSink()]
         return cls(detectors, chosen_sinks, fail_open=cfg.fail_open)

--- a/tests/test_goal_drift.py
+++ b/tests/test_goal_drift.py
@@ -1,0 +1,84 @@
+"""Tests for the goal-drift detector (next phase, step 2)."""
+
+from __future__ import annotations
+
+from snagline.baseline import BaselineProfile, ToolBaseline
+from snagline.config import Config
+from snagline.detectors.goal_drift import GoalDriftDetector
+from snagline.events import StepEvent
+
+
+def _ev(tool, latency, error=False, episode="ep"):
+    return StepEvent(
+        step_id="s",
+        episode_id=episode,
+        timestamp=1.0,
+        action_type="tool_call",
+        action_signature="sig",
+        tool_name=tool,
+        latency_ms=latency,
+        error=error,
+    )
+
+
+def _healthy_baseline() -> BaselineProfile:
+    # A healthy run: search is fast and error-free.
+    prof = BaselineProfile()
+    tb = ToolBaseline(tool_name="search")
+    for _ in range(20):
+        tb.add(100.0, error=False)
+    prof.tools["search"] = tb
+    return prof
+
+
+def test_goal_drift_is_noop_without_baseline():
+    det = GoalDriftDetector(config=Config())
+    assert det.observe(_ev("search", 100.0)) is None
+
+
+def test_goal_drift_flags_rising_error_rate():
+    cfg = Config()
+    cfg.goal_drift_min_samples = 5
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+    risks = [det.observe(_ev("search", 100.0, error=True)) for _ in range(6)]
+    fired = [r for r in risks if r is not None]
+    assert fired, "expected at least one goal_drift risk"
+    assert fired[0].trigger == "goal_drift"
+    assert fired[0].score >= cfg.goal_drift_score_threshold
+
+
+def test_goal_drift_stays_silent_on_healthy_traffic():
+    cfg = Config()
+    cfg.goal_drift_min_samples = 5
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+    # Constant 100.0 latency matches the baseline exactly: no drift.
+    risks = [det.observe(_ev("search", 100.0)) for _ in range(8)]
+    assert all(r is None for r in risks)
+
+
+def test_goal_drift_flags_unseen_tool():
+    cfg = Config()
+    cfg.goal_drift_min_samples = 5
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+    risks = [det.observe(_ev("mystery_tool", 50.0)) for _ in range(6)]
+    assert any(r is not None for r in risks)
+
+
+def test_goal_drift_dedupes_per_episode():
+    cfg = Config()
+    cfg.goal_drift_min_samples = 3
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+    fired = [det.observe(_ev("search", 100.0, error=True)) for _ in range(6)]
+    assert sum(1 for r in fired if r is not None) == 1
+
+
+def test_goal_drift_reset_clears_state():
+    cfg = Config()
+    cfg.goal_drift_min_samples = 3
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+    for _ in range(4):
+        det.observe(_ev("search", 100.0, error=True))
+    det.reset("ep")
+    # After reset, accumulating fresh healthy traffic must not immediately alarm.
+    risks = [det.observe(_ev("search", 100.0 + i)) for i in range(4)]
+    assert all(r is None for r in risks)


### PR DESCRIPTION
## Summary
Adds the `goal_drift` detector (step 2 of the next-phase plan). It compares a live run's per-tool behavior against a persisted healthy `BaselineProfile` built by the `snagline baseline` command.

- New `src/snagline/detectors/goal_drift.py`: `GoalDriftDetector` flags rising error rate, latency blowing past the healthy mean by several sigmas, or tools that never appeared in the baseline.
- Dependency-free. A zero-variance baseline uses a floored spread (5% of mean, min 1ms) so tiny deviations are not treated as infinite z-scores.
- Config knobs: `goal_drift_enabled`, `goal_drift_error_tolerance`, `goal_drift_latency_k`, `goal_drift_min_samples`, `goal_drift_score_threshold`, `goal_drift_baseline`.
- Wired into `Monitor.default()` behind `Config.goal_drift_enabled` (default off, so the zero-dep default is unchanged). Exposed as `snagline.GoalDriftDetector`.
- Tests in `tests/test_goal_drift.py`: no-op without baseline, rising-error detection, silence on healthy traffic, unseen-tool detection, per-episode dedup, and reset.

## Verification
Local gate before push: `ruff check`, `ruff format --check`, `mypy src`, and `pytest` all green at ~89% coverage.