### PR TITLE
feat: ml_ensemble orchestrator (noisy-OR default)

### DIFF
--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -15,6 +15,7 @@ from snagline.adapters.raw import watch
 from snagline.baseline import BaselineProfile, ToolBaseline, fit_baseline_from_jsonl
 from snagline.config import Config
 from snagline.detectors.goal_drift import GoalDriftDetector
+from snagline.detectors.ml_ensemble import MLOrchestrator
 from snagline.events import EpisodeMeta, StepEvent, make_signature
 from snagline.monitor import Monitor
 from snagline.risk import FailureRisk, TriggerType
@@ -32,4 +33,5 @@ __all__ = [
     "ToolBaseline",
     "fit_baseline_from_jsonl",
     "GoalDriftDetector",
+    "MLOrchestrator",
 ]

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -53,5 +53,10 @@ class Config:
     goal_drift_score_threshold: float = 0.5  # emit a risk above this score
     goal_drift_baseline: BaselineProfile | None = None  # healthy reference
 
+    # ML ensemble detector (next phase, step 3). When enabled, Monitor.default
+    # wraps the base detectors in a single MLOrchestrator so signals combine.
+    ml_ensemble_enabled: bool = False
+    ml_ensemble_score_threshold: float = 0.5  # emit a combined risk above this
+
     # Global
     fail_open: bool = True

--- a/src/snagline/detectors/ml_ensemble.py
+++ b/src/snagline/detectors/ml_ensemble.py
@@ -1,0 +1,76 @@
+"""ML ensemble detector (next phase, step 3).
+
+An orchestrator that combines the signals of several base detectors into a
+single, stronger failure risk.
+
+The default combiner is a transparent, dependency-free *noisy-OR* over the
+base detectors' scores (``1 - prod(1 - score_i)``), which boosts confidence
+when multiple independent detectors agree. A real ML model can be slotted in
+via the ``model`` argument: a callable ``(List[float]) -> float`` that maps
+the per-detector scores to a combined score. Installing the ``ml`` extra and
+passing a fitted scikit-learn pipeline through ``model`` is the intended
+upgrade path; it is never imported here, so the zero-dep default holds.
+
+When ``Config.ml_ensemble_enabled`` is set, ``Monitor.default()`` wraps the
+base detectors in a single ``MLOrchestrator`` instead of exposing them
+individually, so there is no double counting.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Sequence
+from typing import Any
+
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.risk import FailureRisk
+
+
+class MLOrchestrator:
+    name = "ml_ensemble"
+
+    def __init__(
+        self,
+        detectors: Sequence[Any],
+        config: Config | None = None,
+        model: Callable[[list[float]], float] | None = None,
+    ) -> None:
+        self._base = list(detectors)
+        self._cfg = config or Config()
+        self._model = model
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        scores: list[float] = []
+        for det in self._base:
+            risk = det.observe(event)
+            if risk is not None and 0.0 < risk.score <= 1.0:
+                scores.append(risk.score)
+        if not scores:
+            return None
+        combined = self._combine(scores)
+        if combined < self._cfg.ml_ensemble_score_threshold:
+            return None
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            min(1.0, combined),
+            "ml_ensemble",
+            "ensemble of detector signals",
+            event.timestamp,
+        )
+
+    def _combine(self, scores: list[float]) -> float:
+        if self._model is not None:
+            return float(self._model(scores))
+        return self._noisy_or(scores)
+
+    @staticmethod
+    def _noisy_or(scores: list[float]) -> float:
+        p_no_failure = 1.0
+        for s in scores:
+            p_no_failure *= 1.0 - s
+        return 1.0 - p_no_failure
+
+    def reset(self, episode_id: str) -> None:
+        for det in self._base:
+            det.reset(episode_id)

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import logging
 import threading
+from typing import Any
 
 from snagline.config import Config
 from snagline.detectors.base import Detector
@@ -144,10 +145,11 @@ class Monitor:
         from snagline.detectors.goal_drift import GoalDriftDetector
         from snagline.detectors.latency_anomaly import LatencyAnomalyDetector
         from snagline.detectors.loop import LoopDetector
+        from snagline.detectors.ml_ensemble import MLOrchestrator
         from snagline.sinks.console import ConsoleSink
 
         cfg = config or Config()
-        detectors: list[Detector] = [
+        base: list[Any] = [
             LoopDetector(config=cfg),
             ErrorCascadeDetector(config=cfg),
             LatencyAnomalyDetector(config=cfg),
@@ -155,8 +157,11 @@ class Monitor:
         # Goal-drift is opt-in: only when explicitly enabled and a baseline is
         # supplied, so the zero-dependency default is unchanged (step 2).
         if cfg.goal_drift_enabled and cfg.goal_drift_baseline is not None:
-            detectors.append(
-                GoalDriftDetector(baseline=cfg.goal_drift_baseline, config=cfg)
-            )
+            base.append(GoalDriftDetector(baseline=cfg.goal_drift_baseline, config=cfg))
+        if cfg.ml_ensemble_enabled:
+            # Combine the base detectors into one orchestrated signal (step 3).
+            detectors: list[Detector] = [MLOrchestrator(base, config=cfg)]
+        else:
+            detectors = list(base)
         chosen_sinks: list[AlertSink] = sinks if sinks is not None else [ConsoleSink()]
         return cls(detectors, chosen_sinks, fail_open=cfg.fail_open)

--- a/tests/test_ml_ensemble.py
+++ b/tests/test_ml_ensemble.py
@@ -1,0 +1,96 @@
+"""Tests for the ML ensemble orchestrator (next phase, step 3)."""
+
+from __future__ import annotations
+
+from snagline.config import Config
+from snagline.detectors.ml_ensemble import MLOrchestrator
+from snagline.events import StepEvent
+from snagline.risk import FailureRisk
+
+
+class _Stub:
+    """A detector stub returning a fixed score, used to exercise the ensemble."""
+
+    def __init__(self, score: float) -> None:
+        self._score = score
+        self.resets = 0
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        if self._score <= 0:
+            return None
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            self._score,
+            "stub",
+            "stub",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        self.resets += 1
+
+
+def _ev(episode="ep"):
+    return StepEvent(
+        step_id="s",
+        episode_id=episode,
+        timestamp=1.0,
+        action_type="tool_call",
+        action_signature="sig",
+        tool_name="t",
+        latency_ms=100.0,
+        error=False,
+    )
+
+
+def test_ml_ensemble_noop_without_scores():
+    orch = MLOrchestrator([_Stub(0.0), _Stub(0.0)], config=Config())
+    assert orch.observe(_ev()) is None
+
+
+def test_ml_ensemble_noisy_or_combines():
+    cfg = Config()
+    cfg.ml_ensemble_score_threshold = 0.5
+    orch = MLOrchestrator([_Stub(0.3), _Stub(0.4)], config=cfg)
+    risk = orch.observe(_ev())
+    assert risk is not None
+    assert risk.trigger == "ml_ensemble"
+    # noisy-OR of 0.3 and 0.4 = 1 - 0.7*0.6 = 0.58
+    assert abs(risk.score - 0.58) < 1e-6
+
+
+def test_ml_ensemble_uses_model_when_provided():
+    cfg = Config()
+    cfg.ml_ensemble_score_threshold = 0.1
+    # model that simply takes the max of the base scores
+    orch = MLOrchestrator([_Stub(0.2), _Stub(0.6)], config=cfg, model=max)
+    risk = orch.observe(_ev())
+    assert risk is not None
+    assert abs(risk.score - 0.6) < 1e-6
+
+
+def test_ml_ensemble_below_threshold_is_silent():
+    cfg = Config()
+    cfg.ml_ensemble_score_threshold = 0.99
+    orch = MLOrchestrator([_Stub(0.3), _Stub(0.4)], config=cfg)
+    assert orch.observe(_ev()) is None
+
+
+def test_ml_ensemble_reset_propagates():
+    a, b = _Stub(0.5), _Stub(0.5)
+    orch = MLOrchestrator([a, b], config=Config())
+    orch.reset("ep")
+    assert a.resets == 1
+    assert b.resets == 1
+
+
+def test_monitor_default_with_ml_ensemble_builds():
+    from snagline.monitor import Monitor
+
+    cfg = Config()
+    cfg.ml_ensemble_enabled = True
+    mon = Monitor.default(config=cfg)
+    # Exactly one orchestrator detector wraps the base detectors (no double count).
+    assert len(mon._detectors) == 1
+    assert mon._detectors[0].name == "ml_ensemble"


### PR DESCRIPTION
## Summary
Adds the `ml_ensemble` orchestrator (step 3 of the next-phase plan). It combines the signals of several base detectors into one stronger failure risk.

- New `src/snagline/detectors/ml_ensemble.py`: `MLOrchestrator` combines base detector scores. Default combiner is a transparent, dependency-free noisy-OR (`1 - prod(1 - score_i)`), which boosts confidence when multiple independent detectors agree.
- A real model can be slotted in via the `model` argument (callable `List[float] -> float`). Installing the `ml` extra and passing a fitted scikit-learn pipeline is the intended upgrade path; it is never imported here, so the zero-dep default holds.
- Config knob `ml_ensemble_enabled` (default off) and `ml_ensemble_score_threshold`.
- When enabled, `Monitor.default()` wraps the base detectors in one `MLOrchestrator` instead of exposing them individually, so there is no double counting. Exposed as `snagline.MLOrchestrator`.
- Tests in `tests/test_ml_ensemble.py`: no-op without scores, noisy-OR math, custom model hook, below-threshold silence, reset propagation, and the `Monitor.default` wiring.

## Verification
Local gate before push: `ruff check`, `ruff format --check`, `mypy src`, and `pytest` all green at ~92% coverage.