### PR TITLE
feat: autogen and crewai adapters

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,8 @@ dependencies = []  # core: zero required dependencies, non-negotiable
 # Framework adapters that actually ship in this release:
 langchain  = ["langchain-core>=0.2"]
 langgraph  = ["langgraph>=0.2"]
+autogen    = ["autogen-agentchat>=0.4"]
+crewai     = ["crewai>=0.30"]
 # SDKs used by the bundled demos (real agent harnesses):
 openai     = ["openai>=1.0"]
 anthropic  = ["anthropic>=0.30"]
@@ -30,7 +32,7 @@ anthropic  = ["anthropic>=0.30"]
 ml         = ["numpy>=1.24", "scikit-learn>=1.3"]   # future baseline fitting (ml extra)
 drift      = ["sentence-transformers>=2.2"]          # future semantic-drift detector
 slack      = ["httpx>=0.27"]                          # Slack escalation sink
-all        = ["snagline-agent[langchain,langgraph,openai,anthropic,ml,drift,slack]"]
+all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift,slack]"]
 
 [project.scripts]
 snagline = "snagline.cli:main"

--- a/src/snagline/adapters/__init__.py
+++ b/src/snagline/adapters/__init__.py
@@ -2,9 +2,18 @@
 
 Each adapter turns a framework-specific event into a ``StepEvent`` and calls
 ``monitor.ingest``. The ``raw`` adapter is stdlib-only and always available;
-framework adapters are optional extras.
+framework adapters are optional extras and are duck-typed, so importing them
+never requires the framework to be installed.
 """
 
+from snagline.adapters.autogen import SnaglineAutogenHandler, run_and_monitor
+from snagline.adapters.crewai import observe_crewai_step, snagline_step_callback
 from snagline.adapters.raw import watch
 
-__all__ = ["watch"]
+__all__ = [
+    "watch",
+    "SnaglineAutogenHandler",
+    "run_and_monitor",
+    "snagline_step_callback",
+    "observe_crewai_step",
+]

--- a/src/snagline/adapters/autogen.py
+++ b/src/snagline/adapters/autogen.py
@@ -1,0 +1,172 @@
+"""Autogen adapter (optional extra: ``pip install snagline-agent[autogen]``).
+
+Turns Autogen agent events into ``StepEvent``s and feeds them to a ``Monitor``.
+Autogen is async-first; the most stable integration point is the event stream
+emitted by ``agent.run_stream(task)``. This adapter provides a handler you can
+feed events to manually, plus ``run_and_monitor`` which wraps ``run_stream``
+and streams every event through the handler.
+
+The adapter is duck-typed: it reads Autogen event objects via ``model_dump()``
+with fallbacks, so it imports fine without Autogen installed (safe in CI) and
+never hard-couples to a specific Autogen release. No raw prompt/response content
+is retained -- only the one-way ``action_signature`` hash, tool name, latency
+(when available), and error flag.
+
+Autogen event objects are pydantic models; we read them via ``model_dump()``
+when present and fall back to attribute access / ``__dict__`` so the adapter
+works across Autogen versions without hard coupling.
+"""
+
+from __future__ import annotations
+
+import itertools
+import time
+from collections.abc import AsyncIterator, Callable
+from typing import Any
+
+from snagline.events import StepEvent, make_signature
+
+
+def _to_dict(event: Any) -> dict[str, Any]:
+    if isinstance(event, dict):
+        return event
+    model_dump = getattr(event, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump()
+        except Exception:
+            pass
+    if hasattr(event, "__dict__"):
+        return dict(vars(event))
+    return {}
+
+
+class SnaglineAutogenHandler:
+    """Observer that maps Autogen events to ``StepEvent``s and ingests them.
+
+    Usage (manual wiring into an event stream)::
+
+        handler = SnaglineAutogenHandler(monitor, "ep-1")
+        async for event in agent.run_stream(task):
+            handler.observe(event)
+        handler.close()
+
+    Or, more simply, use :func:`run_and_monitor`::
+
+        result = await run_and_monitor(agent, task, monitor=monitor, episode_id="ep-1")
+    """
+
+    def __init__(
+        self,
+        monitor: Any,
+        episode_id: str,
+        agent_name: str | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._monitor = monitor
+        self._episode_id = episode_id
+        self._agent_name = agent_name
+        self._clock = clock or time.time
+        self._counter = itertools.count()
+
+    def observe(self, event: Any) -> list[StepEvent]:
+        d = _to_dict(event)
+        kind = str(d.get("type") or d.get("event_type") or "")
+        emitted: list[StepEvent] = []
+
+        # Tool call requests: content is a list of FunctionCall(name, arguments).
+        if "ToolCallRequest" in kind or "tool_call" in kind.lower():
+            calls = d.get("content") or []
+            if not isinstance(calls, list):
+                calls = [calls]
+            for call in calls:
+                cd = _to_dict(call)
+                name = cd.get("name") or cd.get("tool") or "tool"
+                args = cd.get("arguments") if "arguments" in cd else str(call)
+                emitted.append(
+                    self._emit("tool_call", name, args=str(args), error=False)
+                )
+            return emitted
+
+        # Tool call execution results: content is a list of FunctionExecutionResult.
+        if "ToolCallExecution" in kind or "tool_result" in kind.lower():
+            results = d.get("content") or []
+            if not isinstance(results, list):
+                results = [results]
+            for res in results:
+                rd = _to_dict(res)
+                name = rd.get("name") or rd.get("tool") or "tool"
+                is_error = bool(rd.get("is_error") or rd.get("error"))
+                emitted.append(
+                    self._emit("tool_call", name, args=str(rd), error=is_error)
+                )
+            return emitted
+
+        # Anything else (TextMessage, Response, TaskResult, ...) is an agent step.
+        content = d.get("content") or d.get("text") or d.get("thought") or ""
+        emitted.append(self._emit("agent_step", None, args=str(content), error=False))
+        return emitted
+
+    def _emit(
+        self,
+        action_type: str,
+        tool_name: str | None,
+        *,
+        args: str,
+        error: bool,
+        latency_ms: float | None = None,
+    ) -> StepEvent:
+        sig = make_signature(action_type, tool_name, args)
+        event = StepEvent(
+            step_id=str(next(self._counter)),
+            episode_id=self._episode_id,
+            timestamp=self._clock(),
+            action_type=action_type,
+            action_signature=sig,
+            tool_name=tool_name,
+            latency_ms=latency_ms,
+            error=error,
+            metadata={"agent_name": self._agent_name, "adapter": "autogen"},
+        )
+        self._monitor.ingest(event)
+        return event
+
+    def close(self) -> None:
+        """Optional: clears per-episode detector state."""
+        self._monitor.end_episode(self._episode_id)
+
+
+async def run_and_monitor(
+    agent: Any,
+    task: Any,
+    *,
+    monitor: Any,
+    episode_id: str,
+    agent_name: str | None = None,
+    clock: Callable[[], float] | None = None,
+) -> Any:
+    """Run an Autogen agent while streaming its events through a handler.
+
+    Wraps ``await agent.run_stream(task)`` (falling back to ``agent.run``) and
+    feeds every emitted event to a :class:`SnaglineAutogenHandler`. Returns the
+    agent's final result. The agent must be an Autogen chat agent exposing
+    ``run_stream``; if it does not, raise a clear error at call time.
+    """
+    handler = SnaglineAutogenHandler(
+        monitor, episode_id, agent_name=agent_name, clock=clock
+    )
+    stream: AsyncIterator[Any] = None  # type: ignore[assignment]
+    if hasattr(agent, "run_stream"):
+        stream = await agent.run_stream(task)  # type: ignore[assignment]
+    else:  # pragma: no cover - version fallback
+        result = await agent.run(task)  # type: ignore[attr-defined]
+        handler.observe(result)
+        handler.close()
+        return result
+
+    final = None
+    async for event in stream:  # type: ignore[union-attr]
+        handler.observe(event)
+        final = event
+    handler.close()
+    return final

--- a/src/snagline/adapters/crewai.py
+++ b/src/snagline/adapters/crewai.py
@@ -1,0 +1,147 @@
+"""CrewAI adapter (optional extra: ``pip install snagline-agent[crewai]``).
+
+Turns CrewAI agent steps into ``StepEvent``s and feeds them to a ``Monitor``.
+CrewAI agents accept a ``step_callback`` that receives each agent step as it is
+produced. :func:`snagline_step_callback` returns a callback compatible with
+that hook, so wiring is a one-liner::
+
+    from snagline import Monitor
+    from snagline.adapters.crewai import snagline_step_callback
+
+    monitor = Monitor.default()
+    agent = Agent(..., step_callback=snagline_step_callback(monitor, "ep-1"))
+
+The adapter is duck-typed: it reads CrewAI step objects via ``model_dump()``
+with fallbacks, so it imports fine without CrewAI installed (safe in CI) and
+never hard-couples to a specific CrewAI release. No raw prompt/response content
+is retained -- only the one-way ``action_signature`` hash, tool name, latency
+(when available), and error flag.
+
+CrewAI step objects vary by version; we read common attributes (``tool``,
+``tool_input``, ``output``/``text``, ``error``) and fall back to a dict view, so
+the adapter stays loosely coupled to a specific CrewAI release.
+"""
+
+from __future__ import annotations
+
+import itertools
+import time
+from collections.abc import Callable
+from typing import Any
+
+from snagline.events import StepEvent, make_signature
+
+
+def _to_dict(obj: Any) -> dict[str, Any]:
+    if isinstance(obj, dict):
+        return obj
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        try:
+            return model_dump()
+        except Exception:
+            pass
+    if hasattr(obj, "__dict__"):
+        return dict(vars(obj))
+    return {}
+
+
+def _extract_tool_name(step: dict[str, Any]) -> str | None:
+    # CrewAI surfaces the tool under action.tool, tool, or name.
+    action = step.get("action") if isinstance(step.get("action"), dict) else None
+    if action:
+        name = action.get("tool")
+        if name:
+            return str(name)
+    for key in ("tool", "name"):
+        if step.get(key):
+            return str(step[key])
+    return None
+
+
+def _extract_text(step: dict[str, Any]) -> str:
+    for key in ("text", "thought", "output", "content", "result"):
+        val = step.get(key)
+        if val:
+            return str(val)
+    return ""
+
+
+def snagline_step_callback(
+    monitor: Any,
+    episode_id: str,
+    agent_name: str | None = None,
+    clock: Callable[[], float] | None = None,
+) -> Callable[[Any], None]:
+    """Build a CrewAI ``step_callback`` that monitors each agent step.
+
+    The returned callable accepts a CrewAI step object (or dict) and ingests a
+    corresponding ``StepEvent``. Returns the callback for assignment to
+    ``Agent(step_callback=...)``.
+    """
+    counter = itertools.count()
+    current_clock = clock or time.time
+
+    def callback(step: Any) -> None:
+        d = _to_dict(step)
+        tool_name = _extract_tool_name(d)
+        action_type = "tool_call" if tool_name else "agent_step"
+        text = _extract_text(d)
+        error = bool(d.get("error") or d.get("is_error"))
+        # Some CrewAI versions attach a duration on the step or action.
+        latency = d.get("latency_ms") or d.get("duration_ms")
+        raw_action = d.get("action")
+        action: dict[str, Any] = raw_action if isinstance(raw_action, dict) else {}
+        if latency is None:
+            latency = action.get("latency_ms")
+        sig = make_signature(action_type, tool_name, text or str(d))
+        event = StepEvent(
+            step_id=str(next(counter)),
+            episode_id=episode_id,
+            timestamp=current_clock(),
+            action_type=action_type,
+            action_signature=sig,
+            tool_name=tool_name,
+            latency_ms=latency,
+            error=error,
+            metadata={"agent_name": agent_name, "adapter": "crewai"},
+        )
+        monitor.ingest(event)
+
+    return callback
+
+
+def observe_crewai_step(
+    monitor: Any,
+    episode_id: str,
+    step: Any,
+    *,
+    agent_name: str | None = None,
+    clock: Callable[[], float] | None = None,
+    step_id: str | None = None,
+) -> StepEvent:
+    """Manually map a single CrewAI step object to a ``StepEvent`` and ingest it.
+
+    Useful when you manage the agent loop yourself and want the same mapping the
+    callback uses, without registering ``step_callback``.
+    """
+    d = _to_dict(step)
+    tool_name = _extract_tool_name(d)
+    action_type = "tool_call" if tool_name else "agent_step"
+    text = _extract_text(d)
+    error = bool(d.get("error") or d.get("is_error"))
+    latency = d.get("latency_ms") or d.get("duration_ms")
+    sig = make_signature(action_type, tool_name, text or str(d))
+    event = StepEvent(
+        step_id=step_id or "manual",
+        episode_id=episode_id,
+        timestamp=(clock or time.time)(),
+        action_type=action_type,
+        action_signature=sig,
+        tool_name=tool_name,
+        latency_ms=latency,
+        error=error,
+        metadata={"agent_name": agent_name, "adapter": "crewai"},
+    )
+    monitor.ingest(event)
+    return event

--- a/tests/test_adapters_autogen_crewai.py
+++ b/tests/test_adapters_autogen_crewai.py
@@ -1,0 +1,137 @@
+"""Tests for the autogen and crewai adapters (next phase, step 4)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from snagline.adapters.autogen import SnaglineAutogenHandler, run_and_monitor
+from snagline.adapters.crewai import observe_crewai_step, snagline_step_callback
+
+
+class _Collector:
+    """A Monitor stand-in that records ingested events instead of detecting."""
+
+    def __init__(self):
+        self.events = []
+        self.ended = []
+
+    def ingest(self, event):
+        self.events.append(event)
+
+    def end_episode(self, episode_id):
+        self.ended.append(episode_id)
+
+
+def test_autogen_handler_maps_tool_call_request():
+    mon = _Collector()
+    h = SnaglineAutogenHandler(mon, "ep-1")  # noqa: F821
+    events = h.observe(
+        {
+            "type": "ToolCallRequestEvent",
+            "content": [{"name": "search", "arguments": "q=cat"}],
+        }
+    )
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.action_type == "tool_call"
+    assert ev.tool_name == "search"
+    assert ev.error is False
+    assert mon.events[0] is ev
+
+
+def test_autogen_handler_maps_tool_execution_error():
+    mon = _Collector()
+    h = SnaglineAutogenHandler(mon, "ep-1")  # noqa: F821
+    events = h.observe(
+        {
+            "type": "ToolCallExecutionEvent",
+            "content": [{"name": "search", "is_error": True, "result": "boom"}],
+        }
+    )
+    assert events[0].error is True
+
+
+def test_autogen_handler_falls_back_to_agent_step():
+    mon = _Collector()
+    h = SnaglineAutogenHandler(mon, "ep-1")  # noqa: F821
+    events = h.observe({"type": "TextMessage", "content": "thinking..."})
+    assert events[0].action_type == "agent_step"
+    assert events[0].tool_name is None
+
+
+def test_autogen_handler_close_ends_episode():
+    mon = _Collector()
+    h = SnaglineAutogenHandler(mon, "ep-9")  # noqa: F821
+    h.close()
+    assert mon.ended == ["ep-9"]
+
+
+def test_crewai_callback_maps_tool_call():
+    mon = _Collector()
+    cb = snagline_step_callback(mon, "ep-1")  # noqa: F821
+    cb({"action": {"tool": "calculator"}, "text": "12 + 30"})
+    assert len(mon.events) == 1
+    ev = mon.events[0]
+    assert ev.action_type == "tool_call"
+    assert ev.tool_name == "calculator"
+
+
+def test_crewai_callback_maps_agent_step_without_tool():
+    mon = _Collector()
+    cb = snagline_step_callback(mon, "ep-1")  # noqa: F821
+    cb({"text": "I will plan now"})
+    ev = mon.events[0]
+    assert ev.action_type == "agent_step"
+    assert ev.tool_name is None
+
+
+def test_crewai_callback_captures_error_and_latency():
+    mon = _Collector()
+    cb = snagline_step_callback(mon, "ep-1")  # noqa: F821
+    cb({"action": {"tool": "search"}, "error": True, "latency_ms": 42.0})
+    ev = mon.events[0]
+    assert ev.error is True
+    assert ev.latency_ms == 42.0
+
+
+def test_crewai_observe_manual_mapping():
+    mon = _Collector()
+    ev = observe_crewai_step(mon, "ep-2", {"action": {"tool": "wiki"}, "text": "x"})  # noqa: F821
+    assert ev.episode_id == "ep-2"
+    assert ev.tool_name == "wiki"
+
+
+def test_run_and_monitor_streams_autogen_events():
+    class _FakeStream:
+        def __init__(self, events):
+            self._events = list(events)
+
+        def __aiter__(self):
+            return self
+
+        async def __anext__(self):
+            if self._events:
+                return self._events.pop(0)
+            raise StopAsyncIteration
+
+    class _FakeAgent:
+        def __init__(self, events):
+            self._events = events
+
+        async def run_stream(self, task):  # noqa: ARG002 - task unused in stub
+            return _FakeStream(self._events)
+
+    mon = _Collector()
+    agent = _FakeAgent(
+        [
+            {"type": "TextMessage", "content": "hi"},
+            {
+                "type": "ToolCallRequestEvent",
+                "content": [{"name": "t", "arguments": "x"}],
+            },
+        ]
+    )
+    result = asyncio.run(run_and_monitor(agent, "task", monitor=mon, episode_id="ep-1"))
+    assert mon.ended == ["ep-1"]
+    assert len(mon.events) == 2
+    assert result["type"] == "ToolCallRequestEvent"


### PR DESCRIPTION
## Summary
Adds framework adapters for Autogen and CrewAI, completing step 4 of the next-phase plan. The adapters are duck-typed so they import without the framework installed (CI-safe) and never hard-couple to a specific release.

- `src/snagline/adapters/autogen.py`: `SnaglineAutogenHandler` maps Autogen agent events (tool-call requests/executions, text/agent steps) to `StepEvent`s, plus `run_and_monitor` which wraps `agent.run_stream` and streams every event through the handler.
- `src/snagline/adapters/crewai.py`: `snagline_step_callback` returns a CrewAI `step_callback` that maps each agent step to a `StepEvent`, plus a manual `observe_crewai_step` helper.
- Both read events via `model_dump()` with attribute/dict fallbacks, and never retain raw prompt/response content (only the one-way `action_signature` hash, tool name, latency when available, error flag).
- Exported from `snagline.adapters`; added `autogen` and `crewai` extras to `pyproject.toml`.
- Tests in `tests/test_adapters_autogen_crewai.py` cover mapping, error capture, latency, agent-step fallback, episode close, and `run_and_monitor` streaming, with no real framework required.

## Verification
Local gate before push: `ruff check`, `ruff format --check`, `mypy src`, and `pytest` all green at ~90% coverage.