### PR TITLE
docs: baseline, goal_drift, ml_ensemble, autogen/crewai adapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,8 +99,36 @@ The full architecture reference is in [docs/ADAPTER_GUIDE.md](docs/ADAPTER_GUIDE
 | **Loop detector** | Retry storms, stuck agents | Sliding window of action signatures. If the same signature appears N times within W steps, emit a risk. | O(1) amortized |
 | **Error cascade detector** | Fast cascades and slow-burn degradations | Two modes: N consecutive errors (fast), or N errors within a recent window (slow). | O(1) amortized |
 | **Latency anomaly detector** | Sustained performance regression | Welford running mean/variance per tool, frozen baseline, CUSUM statistic. Short warm-up prevents false positives on normal jitter. | O(1) amortized |
+| **Goal-drift detector** (opt-in) | A run diverging from its known-healthy behavior | Compares a live run's per-tool error rate and latency against a persisted `BaselineProfile` built by `snagline baseline`. Flags rising error rate, latency blowing past the healthy mean, or tools that never appeared in the baseline. | O(1) amortized |
+| **ML ensemble** (opt-in) | A stronger, combined signal | Wraps the base detectors and combines their scores with a transparent noisy-OR. A real model can be injected via `MLOrchestrator(model=...)` (the `ml` extra provides scikit-learn). | O(1) amortized |
 
 Detection is deterministic and `O(1)` amortized per step. It runs with no network calls and no LLM calls. The CUSUM detector uses only the Python standard library (`statistics` module) -- no numpy required.
+
+### Baseline and advanced detection
+
+The `goal_drift` and `ml_ensemble` detectors are opt-in (default off) so the zero-dependency preset is unchanged. They unlock once you capture a healthy run:
+
+```bash
+# 1. Capture a known-good trajectory (one JSON StepEvent per line)...
+python -m your_agent --trace run.jsonl
+# 2. Build a healthy baseline profile from it.
+snagline baseline run.jsonl --output baseline.json
+```
+
+```python
+from snagline import Monitor, Config, load_baseline
+from snagline.detectors.goal_drift import GoalDriftDetector
+
+baseline = load_baseline("baseline.json")
+config = Config(
+    goal_drift_enabled=True,
+    goal_drift_baseline=baseline,
+    ml_ensemble_enabled=True,   # combine all base detectors into one signal
+)
+monitor = Monitor.default(config=config)
+```
+
+With `ml_ensemble_enabled`, `Monitor.default()` wraps the base detectors in a single `MLOrchestrator` instead of exposing them individually, so there is no double counting. Both detectors are documented in [docs/DETECTOR_GUIDE.md](docs/DETECTOR_GUIDE.md).
 
 ## Features
 
@@ -215,7 +243,7 @@ snagline replay tests/fixtures/trajectories/healthy_run.jsonl --summary
 
 ## Framework Integration
 
-SNAGLINE plugs into agent frameworks without becoming one. Four adapters ship in `src/snagline/adapters/`, all optional installs so the core stays zero-dependency:
+SNAGLINE plugs into agent frameworks without becoming one. Six adapters ship in `src/snagline/adapters/`, all optional installs so the core stays zero-dependency:
 
 | Adapter | Module | Install | Notes |
 |:--|:--|:--|:--|
@@ -223,6 +251,8 @@ SNAGLINE plugs into agent frameworks without becoming one. Four adapters ship in
 | LangChain | `langchain_adapter.py` | `pip install snagline-agent[langchain]` | `SnaglineCallbackHandler` subclassing `BaseCallbackHandler`. |
 | LangGraph | `langgraph_adapter.py` | `pip install snagline-agent[langgraph]` | `watch_graph` pass-through iterator wrapping `graph.stream(...)`. |
 | Claude Code | `claude_code.py` | (built-in) | Maps native hook payloads via `ingest_payload`. Works over HTTP sidecar or file bridge. |
+| Autogen | `autogen.py` | `pip install snagline-agent[autogen]` | `SnaglineAutogenHandler` + `run_and_monitor` wrapping `agent.run_stream`. Duck-typed, no hard Autogen version pin. |
+| CrewAI | `crewai.py` | `pip install snagline-agent[crewai]` | `snagline_step_callback` for `Agent(step_callback=...)`, plus `observe_crewai_step`. Duck-typed, no hard CrewAI version pin. |
 
 Each adapter translates framework-specific events into `StepEvent`s and calls `monitor.ingest()`. None of them contain detection logic.
 

--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -60,11 +60,16 @@ it. Everything detection needs fits in the hash + timings + booleans.
 | `adapters/raw.py` | plain Python loop | context manager yielding a `step()` callable |
 | `adapters/langchain_adapter.py` | LangChain / LangGraph `create_agent` | `BaseCallbackHandler` subclass |
 | `adapters/langgraph_adapter.py` | LangGraph `graph.stream()` | pass-through iterator wrapper |
+| `adapters/autogen.py` | Autogen `agent.run_stream(task)` | `SnaglineAutogenHandler` observer + `run_and_monitor` wrapper |
+| `adapters/crewai.py` | CrewAI `Agent(step_callback=...)` | `snagline_step_callback` returning the hook callable |
 | `server/http_server.py` | any non-Python runtime | stdlib HTTP sidecar, `POST /events` |
 
-Adapters for AutoGen, CrewAI, raw OpenAI/Anthropic SDKs, and CONTINUUM are
-planned (project.md §13 step 10 / §6) - the raw adapter is usually a fine
-stand-in for any of them, since they all bottom out in a tool-calling loop.
+Both the Autogen and CrewAI adapters are duck-typed: they read event objects via
+`model_dump()` with attribute/dict fallbacks, so they import without the
+framework installed and never hard-couple to a specific release. Adapters for
+raw OpenAI/Anthropic SDKs and CONTINUUM remain planned (project.md §13 step 10 /
+§6) - the raw adapter is usually a fine stand-in for any of them, since they all
+bottom out in a tool-calling loop.
 
 ## Testing your adapter
 

--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -61,7 +61,42 @@ monitor._detectors.append(MyDetector())   # or: Monitor(default_detectors + [min
 - `detectors/loop.py` - sliding-window repetition count on `action_signature`
 - `detectors/error_cascade.py` - consecutive and windowed error counts
 - `detectors/latency_anomaly.py` - Welford baseline + CUSUM deviation per tool
+- `detectors/goal_drift.py` - compares a live run to a persisted `BaselineProfile`
+- `detectors/ml_ensemble.py` - `MLOrchestrator` combining base detector scores
 
 Each has a matching test in `tests/detectors/` showing the synthetic-sequence
 pattern (injected failure fires; healthy sequence stays silent). Copy that
 test shape for your own detector.
+
+## Optional detectors: baseline, goal-drift, and ensemble
+
+`LoopDetector`, `ErrorCascadeDetector`, and `LatencyAnomalyDetector` ship in
+`Monitor.default()`. Two further detectors are opt-in behind config flags so the
+zero-dependency preset is unchanged.
+
+### `BaselineProfile` and the `baseline` command
+
+`src/snagline/baseline.py` fits a `BaselineProfile` (per-tool latency
+mean/std/min/max and error rate) from a JSONL trajectory. The `snagline
+baseline <trajectory> [--output baseline.json]` CLI command persists one, and
+`load_baseline` / `save_baseline` round-trip it.
+
+### `GoalDriftDetector`
+
+`GoalDriftDetector(baseline=profile, config=cfg)` flags a live run that
+diverges from that healthy reference: rising error rate (beyond
+`goal_drift_error_tolerance`), latency blowing past the healthy mean by
+`goal_drift_latency_k` sigmas, or tools that never appeared in the baseline. A
+zero-variance baseline uses a floored spread (5% of mean, min 1 ms) so tiny
+deviations are not treated as infinite z. Enable it with
+`Config(goal_drift_enabled=True, goal_drift_baseline=profile)`.
+
+### `MLOrchestrator`
+
+`MLOrchestrator(detectors, config, model=None)` combines base detector scores
+into one stronger risk. The default combiner is a transparent noisy-OR
+(`1 - prod(1 - score_i)`), which boosts confidence when multiple independent
+detectors agree. Pass `model=callable(scores) -> float` (e.g. a fitted
+scikit-learn pipeline from the `ml` extra) to replace the combiner. Enable it
+with `Config(ml_ensemble_enabled=True)`; `Monitor.default()` then wraps the
+base detectors in one orchestrator so there is no double counting.

--- a/examples/baseline_to_monitor.py
+++ b/examples/baseline_to_monitor.py
@@ -1,0 +1,114 @@
+"""End-to-end example: baseline a healthy run, then monitor live traffic.
+
+This walks the full next-phase pipeline without any optional dependency:
+
+1. Write a small "known-good" trajectory (one JSON StepEvent per line).
+2. Fit a healthy ``BaselineProfile`` from it via ``snagline baseline`` (or the
+   ``fit_baseline_from_jsonl`` API).
+3. Start a ``Monitor`` with ``goal_drift`` and ``ml_ensemble`` enabled, pointing
+   at that baseline.
+4. Feed a healthy episode (should stay silent) and a drifting episode (rising
+   error rate) and print the risks the ensemble emits.
+
+Run it directly::
+
+    python examples/baseline_to_monitor.py
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from snagline import (
+    Config,
+    Monitor,
+    fit_baseline_from_jsonl,
+    load_baseline,
+    save_baseline,
+)
+from snagline.adapters.raw import watch
+from snagline.risk import FailureRisk
+from snagline.sinks.base import AlertSink
+
+
+class Collector(AlertSink):
+    """A sink that just remembers every risk it receives."""
+
+    def __init__(self) -> None:
+        self.risks: list[FailureRisk] = []
+
+    def emit(self, risk: FailureRisk) -> None:
+        self.risks.append(risk)
+
+
+def _write_healthy_trajectory(path: Path) -> None:
+    # A known-good run: tool "search" runs fast and never errors.
+    with path.open("a", encoding="utf-8") as fh:
+        for i in range(40):
+            evt = {
+                "step_id": str(i),
+                "episode_id": "baseline",
+                "timestamp": float(i),
+                "action_type": "tool_call",
+                "action_signature": f"search:{i % 5}",
+                "tool_name": "search",
+                "latency_ms": 100.0 + (i % 3),
+                "error": False,
+            }
+            fh.write(json.dumps(evt) + "\n")
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory() as tmp:
+        traj = Path(tmp) / "healthy.jsonl"
+        _write_healthy_trajectory(traj)
+
+        # Step 1+2: fit and persist a healthy baseline.
+        baseline = fit_baseline_from_jsonl(str(traj))
+        baseline_path = Path(tmp) / "baseline.json"
+        save_baseline(baseline, str(baseline_path))
+        loaded = load_baseline(str(baseline_path))
+        print(f"Fitted baseline for tools: {sorted(loaded.tools)}")
+
+        # Step 3: monitor with goal-drift + ml ensemble enabled.
+        config = Config(
+            goal_drift_enabled=True,
+            goal_drift_baseline=loaded,
+            goal_drift_min_samples=5,
+            ml_ensemble_enabled=True,
+        )
+        collector = Collector()
+        monitor = Monitor.default(config=config, sinks=[collector])
+
+        # Step 4a: a healthy live episode -> should stay silent.
+        with watch(monitor, "live-healthy") as step:
+            for i in range(10):
+                step(
+                    "tool_call",
+                    tool_name="search",
+                    args=f"query={i}",
+                    latency_ms=100.0 + (i % 3),
+                )
+        print(f"Healthy episode risks: {len(collector.risks)} (expect 0)")
+
+        # Step 4b: a drifting episode -> rising error rate trips goal_drift
+        # (and the error-cascade detector), which the ml ensemble elevates.
+        collector.risks.clear()
+        with watch(monitor, "live-drift") as step:
+            for i in range(10):
+                step(
+                    "tool_call",
+                    tool_name="search",
+                    args=f"query={i}",
+                    latency_ms=100.0,
+                    error=True,
+                )
+        print(f"Drifting episode risks: {len(collector.risks)} (expect >= 1)")
+        for risk in collector.risks:
+            print(f"  - {risk.trigger} score={risk.score:.2f}: {risk.detail}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -12,7 +12,13 @@ Public API (core, zero third-party dependencies):
 from __future__ import annotations
 
 from snagline.adapters.raw import watch
-from snagline.baseline import BaselineProfile, ToolBaseline, fit_baseline_from_jsonl
+from snagline.baseline import (
+    BaselineProfile,
+    ToolBaseline,
+    fit_baseline_from_jsonl,
+    load_baseline,
+    save_baseline,
+)
 from snagline.config import Config
 from snagline.detectors.goal_drift import GoalDriftDetector
 from snagline.detectors.ml_ensemble import MLOrchestrator
@@ -32,6 +38,8 @@ __all__ = [
     "BaselineProfile",
     "ToolBaseline",
     "fit_baseline_from_jsonl",
+    "save_baseline",
+    "load_baseline",
     "GoalDriftDetector",
     "MLOrchestrator",
 ]


### PR DESCRIPTION
## Summary
Documents and demonstrates the four next-phase features (baseline command, `goal_drift`, `ml_ensemble`, Autogen/CrewAI adapters) so they are discoverable and runnable.

- README: new detector-table rows for goal-drift and ML ensemble; a "Baseline and advanced detection" section with the `snagline baseline` + `Monitor.default(config=...)` wiring; six-adapter Framework Integration table (added Autogen, CrewAI).
- `docs/DETECTOR_GUIDE.md`: `GoalDriftDetector` and `MLOrchestrator` reference entries.
- `docs/ADAPTER_GUIDE.md`: Autogen/CrewAI reference rows; removed the "planned" note (they now ship).
- Exposed `save_baseline`/`load_baseline` in the top-level `snagline` API.
- Added `examples/baseline_to_monitor.py`: a runnable end-to-end walkthrough that fits a healthy baseline, enables `goal_drift` + `ml_ensemble`, and prints 0 risks on healthy traffic and fires on a drifting run (verified locally).

Deferred (lower priority): wiring the real `ml`/`drift` extras (scikit-learn combiner, sentence-transformers semantics) since those deps are heavy and not CI-testable.

## Verification
Local gate before push: `ruff check`, `ruff format --check`, `mypy src`, and `pytest` all green at ~90% coverage; example runs and behaves as documented.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for optional goal-drift, machine-learning ensemble, and baseline detectors.
  * Added guidance for AutoGen and CrewAI integrations.
  * Added an end-to-end monitoring example covering baseline creation, live detection, and risk alerts.
  * Added public helpers for saving and loading monitoring baselines.

* **Documentation**
  * Clarified detector configuration, baseline persistence, event extraction, and planned integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->