### PR TITLE
feat: 12-factor config env/file loaders

### DIFF
--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -7,9 +7,36 @@ detector constructors (project.md §5.4).
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+import json
+import logging
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass, fields
+from typing import Any, get_type_hints
 
 from snagline.baseline import BaselineProfile
+
+logger = logging.getLogger("snagline")
+
+
+def _coerce(hint: type, value: str) -> Any:
+    if hint is bool:
+        return value.strip().lower() in ("1", "true", "yes", "on", "t")
+    if hint is int:
+        return int(value)
+    if hint is float:
+        return float(value)
+    return value
+
+
+def _load_toml(text: str) -> dict[str, Any]:
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # pragma: no cover - exercised only on <3.11
+        raise RuntimeError(
+            "TOML config requires Python 3.11+ (tomllib); use JSON or upgrade."
+        ) from None
+    return tomllib.loads(text)
 
 
 @dataclass
@@ -60,3 +87,49 @@ class Config:
 
     # Global
     fail_open: bool = True
+
+    # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
+    @classmethod
+    def from_env(
+        cls, environ: Mapping[str, str] | None = None, prefix: str = "SNAGLINE_"
+    ) -> Config:
+        """Build a ``Config`` from environment variables (12-factor).
+
+        Reads ``<prefix><FIELD>`` (case-insensitive) and overrides the matching
+        scalar field. Unknown prefixes, unknown keys, and values that fail to
+        coerce are ignored (logged at warning) rather than fatal, so a host can
+        pass through unrelated environment without breaking startup.
+        """
+        environ = os.environ if environ is None else environ
+        hints = get_type_hints(cls)
+        overrides: dict[str, Any] = {}
+        for key, value in environ.items():
+            if not key.startswith(prefix):
+                continue
+            name = key[len(prefix) :].lower()
+            if name not in hints:
+                continue
+            hint = hints[name]
+            if hint in (bool, int, float, str):
+                try:
+                    overrides[name] = _coerce(hint, value)
+                except ValueError:
+                    logger.warning("snagline: ignoring bad env %s=%r", key, value)
+        return cls(**overrides)
+
+    @classmethod
+    def load_file(cls, path: str) -> Config:
+        """Load a ``Config`` from a JSON or TOML file.
+
+        ``.json`` is parsed with the stdlib ``json`` module; ``.toml`` requires
+        Python 3.11+ (``tomllib``). Unknown keys are ignored so a config file
+        can carry extra metadata without breaking construction.
+        """
+        with open(path, encoding="utf-8") as fh:
+            text = fh.read()
+        if path.endswith(".toml"):
+            data: dict[str, Any] = _load_toml(text)
+        else:
+            data = json.loads(text)
+        valid = {f.name for f in fields(cls)}  # noqa: F821
+        return cls(**{k: v for k, v in data.items() if k in valid})

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,63 @@
+"""Tests for the 12-factor Config loaders (ATTACH_ANY_SYSTEM P0)."""
+
+from __future__ import annotations
+
+import json
+
+from snagline.config import Config
+
+
+def test_from_env_overrides_scalar_fields():
+    env = {
+        "SNAGLINE_FAIL_OPEN": "false",
+        "SNAGLINE_CUSUM_K": "0.9",
+        "SNAGLINE_LOOP_REPEAT_THRESHOLD": "7",
+        "SNAGLINE_GOAL_DRIFT_ENABLED": "true",
+    }
+    cfg = Config.from_env(environ=env)
+    assert cfg.fail_open is False
+    assert cfg.cusum_k == 0.9
+    assert cfg.loop_repeat_threshold == 7
+    assert cfg.goal_drift_enabled is True
+
+
+def test_from_env_ignores_unknown_prefix_and_keys():
+    env = {
+        "PATH": "/usr/bin",
+        "SNAGLINE_BOGUS_FIELD": "1",
+        "SNAGLINE_GOAL_DRIFT_BASELINE": "cannot-load-this",  # complex type -> skipped
+    }
+    cfg = Config.from_env(environ=env)
+    assert cfg.fail_open is True  # default unchanged
+    assert cfg.goal_drift_enabled is False
+
+
+def test_from_env_skips_uncoercible_values():
+    env = {"SNAGLINE_CUSUM_K": "not-a-float"}
+    cfg = Config.from_env(environ=env)
+    assert cfg.cusum_k == 0.5  # default unchanged, no raise
+
+
+def test_load_file_json(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text(
+        json.dumps({"cusum_k": 1.2, "loop_repeat_threshold": 9, "extra_ignored": "x"})
+    )
+    cfg = Config.load_file(str(path))
+    assert cfg.cusum_k == 1.2
+    assert cfg.loop_repeat_threshold == 9
+    assert cfg.fail_open is True  # untouched default
+
+
+def test_load_file_toml(tmp_path):
+    try:
+        import tomllib  # noqa: F401
+    except ModuleNotFoundError:
+        import pytest
+
+        pytest.skip("tomllib requires Python 3.11+")
+    path = tmp_path / "cfg.toml"
+    path.write_text("cusum_h = 7.0\nloop_window_size = 20\n")
+    cfg = Config.load_file(str(path))
+    assert cfg.cusum_h == 7.0
+    assert cfg.loop_window_size == 20


### PR DESCRIPTION
## Summary
Adds `Config.from_env()` and `Config.load_file()` so SNAGLINE can be configured from the environment or a JSON/TOML file rather than only by constructing a dataclass in code. This is the config/secrets-management piece of the P0 plan in `docs/ATTACH_ANY_SYSTEM.md`.

- `from_env(prefix="SNAGLINE_")` overrides matching scalar fields from environment variables; ignores unknown prefixes/keys and uncoercible values (logged at warning, never fatal).
- `load_file()` parses `.json` (stdlib) or `.toml` (tomllib, 3.11+), ignoring unknown keys.
- Tests in `tests/test_config_loader.py` cover env override, prefix/key/value skipping, JSON load, and TOML load (skipped below 3.11).

## Verification
Local gate before push: `ruff check`, `ruff format --check`, `mypy src`, and `pytest` all green.