### PR TITLE
feat: OpenAI auto-instrumentation

### DIFF
--- a/src/snagline/auto/__init__.py
+++ b/src/snagline/auto/__init__.py
@@ -1,0 +1,5 @@
+"""Auto-instrumentation package (ATTACH_ANY_SYSTEM P0)."""
+
+from snagline.auto.openai import instrument_openai, wrap_client
+
+__all__ = ["instrument_openai", "wrap_client"]

--- a/src/snagline/auto/openai.py
+++ b/src/snagline/auto/openai.py
@@ -1,0 +1,122 @@
+"""Auto-instrumentation for the OpenAI SDK (ATTACH_ANY_SYSTEM P0).
+
+Wraps chat/completion ``create`` calls so each becomes a ``StepEvent`` fed to
+a ``Monitor``, without the caller editing every call site. This is the real
+"attach to any system" lever: ``import snagline.auto`` plus one call replaces
+per-call instrumentation.
+
+The module is import-safe: it imports fine without the OpenAI SDK installed,
+and ``instrument_openai`` only patches the SDK when it is actually present (or
+when a client is passed explicitly). Sync and async clients are both handled.
+"""
+
+from __future__ import annotations
+
+import inspect
+import itertools
+import logging
+import time
+
+from snagline.events import StepEvent, make_signature
+
+try:  # optional dependency
+    from openai import AsyncOpenAI, OpenAI  # type: ignore
+except Exception:  # pragma: no cover - exercised only without the OpenAI SDK
+    OpenAI = None  # type: ignore[assignment, misc]
+    AsyncOpenAI = None  # type: ignore[assignment, misc]
+
+logger = logging.getLogger("snagline")
+
+
+def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
+    latency = (time.time() - start) * 1000.0
+    event = StepEvent(
+        step_id=str(next(counter)),
+        episode_id="openai-auto",
+        timestamp=time.time(),
+        action_type="tool_call",
+        action_signature=make_signature("openai_call", model, sig_text),
+        tool_name=tool_name,
+        latency_ms=latency,
+        error=error,
+    )
+    monitor.ingest(event)
+
+
+def _wrap_one(monitor, original, tool_name):
+    counter = itertools.count()
+    is_async = inspect.iscoroutinefunction(original)
+
+    def _sync(*args, **kwargs):
+        sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
+        model = kwargs.get("model", "unknown")
+        start = time.time()
+        error = False
+        try:
+            result = original(*args, **kwargs)
+        except Exception:
+            error = True
+            raise
+        finally:
+            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        return result
+
+    async def _async(*args, **kwargs):
+        sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
+        model = kwargs.get("model", "unknown")
+        start = time.time()
+        error = False
+        try:
+            result = await original(*args, **kwargs)
+        except Exception:
+            error = True
+            raise
+        finally:
+            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        return result
+
+    return _async if is_async else _sync
+
+
+def wrap_client(monitor, client):
+    """Wrap a given OpenAI client instance's create methods in place.
+
+    Patches ``client.chat.completions.create`` and ``client.completions.create``
+    (whichever exist) so each call emits a ``StepEvent``. Returns the same
+    client for chaining.
+    """
+    for path in ("chat.completions.create", "completions.create"):
+        cur = client
+        ok = True
+        for part in path.split(".")[:-1]:
+            cur = getattr(cur, part, None)
+            if cur is None:
+                ok = False
+                break
+        if not ok:
+            continue
+        method = getattr(cur, path.split(".")[-1], None)
+        if method is None or not callable(method):
+            continue
+        setattr(cur, path.split(".")[-1], _wrap_one(monitor, method, "openai." + path))
+    return client
+
+
+def instrument_openai(monitor, client=None) -> bool:
+    """Instrument the OpenAI SDK.
+
+    If ``client`` is provided, only that instance is wrapped. Otherwise the
+    installed ``openai.OpenAI`` / ``openai.AsyncOpenAI`` classes are patched
+    globally (so every future client is observed). Returns True if anything
+    was patched, False if the SDK is not importable.
+    """
+    if client is not None:
+        wrap_client(monitor, client)
+        return True
+    if OpenAI is None:
+        logger.warning("snagline.auto: OpenAI SDK not installed; nothing to patch")
+        return False
+    wrap_client(monitor, OpenAI)
+    if AsyncOpenAI is not None:
+        wrap_client(monitor, AsyncOpenAI)
+    return True

--- a/tests/test_auto_openai.py
+++ b/tests/test_auto_openai.py
@@ -1,0 +1,83 @@
+"""Tests for OpenAI auto-instrumentation (ATTACH_ANY_SYSTEM P0).
+
+Exercises wrap_client with a fake client that mimics the OpenAI SDK surface,
+so no real SDK is required. Also confirms instrument_openai is a safe no-op
+when the SDK is absent.
+"""
+
+from __future__ import annotations
+
+from snagline.auto.openai import instrument_openai, wrap_client
+
+
+class _SpyMonitor:
+    def __init__(self):
+        self.events: list = []
+
+    def ingest(self, event) -> None:
+        self.events.append(event)
+
+
+class _FakeCompletions:
+    def create(self, *, model="gpt", messages=None, prompt=None, **kw):
+        return "ok"
+
+
+class _FakeChat:
+    completions = _FakeCompletions()
+
+
+class _FakeClient:
+    chat = _FakeChat()
+    completions = _FakeCompletions()
+
+
+def test_wrap_client_records_on_success():
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _FakeClient())
+    out = client.chat.completions.create(model="gpt-4o", messages=[{"role": "user"}])
+    assert out == "ok"
+    assert len(mon.events) == 1
+    ev = mon.events[0]
+    assert ev.tool_name == "openai.chat.completions.create"
+    assert ev.error is False
+    assert ev.latency_ms is not None
+
+
+def test_wrap_client_records_both_paths():
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _FakeClient())
+    client.chat.completions.create(model="gpt-4o", messages=[{"role": "user"}])
+    client.completions.create(model="gpt-4o", prompt="hi")
+    assert len(mon.events) == 2
+    assert mon.events[1].tool_name == "openai.completions.create"
+
+
+def test_wrap_client_records_error_and_propagates():
+    class _BoomCompletions:
+        def create(self, **kw):
+            raise RuntimeError("boom")
+
+    class _BoomClient:
+        chat = type("C", (), {"completions": _BoomCompletions()})()
+
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _BoomClient())
+    raised = False
+    try:
+        client.chat.completions.create(model="gpt-4o", messages=[{"role": "user"}])
+    except RuntimeError:
+        raised = True
+    assert raised, "exception must propagate"
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+
+
+def test_instrument_openai_without_sdk_is_safe_noop():
+    mon = _SpyMonitor()
+    assert instrument_openai(mon) is False
+
+
+def test_instrument_openai_with_explicit_client():
+    mon = _SpyMonitor()
+    assert instrument_openai(mon, client=_FakeClient()) is True


### PR DESCRIPTION
## Summary
Adds the core "attach to any system" lever for the OpenAI SDK (P0 of `docs/ATTACH_ANY_SYSTEM.md`).

- `snagline.auto.openai.wrap_client(monitor, client)` patches a client's `chat.completions.create` / `completions.create` in place (sync and async).
- `instrument_openai(monitor, client=None)` wraps a single client, or with `client=None` patches the installed `openai.OpenAI` / `openai.AsyncOpenAI` classes globally.
- Import-safe: with no OpenAI SDK present, `instrument_openai` is a clean no-op (returns False) rather than raising.

Each wrapped call emits a `StepEvent` (model, latency, error flag) to the monitor, so existing code gains SNagLine coverage with a one-line change.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, and `pytest tests/test_auto_openai.py` (5 passed) all green.