### PR TITLE
feat: Anthropic auto-instrumentation

### DIFF
--- a/src/snagline/auto/__init__.py
+++ b/src/snagline/auto/__init__.py
@@ -1,5 +1,12 @@
 """Auto-instrumentation package (ATTACH_ANY_SYSTEM P0)."""
 
+from snagline.auto.anthropic import instrument_anthropic
+from snagline.auto.anthropic import wrap_client as wrap_anthropic
 from snagline.auto.openai import instrument_openai, wrap_client
 
-__all__ = ["instrument_openai", "wrap_client"]
+__all__ = [
+    "instrument_openai",
+    "wrap_client",
+    "instrument_anthropic",
+    "wrap_anthropic",
+]

--- a/src/snagline/auto/anthropic.py
+++ b/src/snagline/auto/anthropic.py
@@ -1,0 +1,105 @@
+"""Auto-instrumentation for the Anthropic SDK (ATTACH_ANY_SYSTEM P0).
+
+Mirrors ``snagline.auto.openai``: wraps ``client.messages.create`` so each
+call emits a ``StepEvent``. Import-safe (no-op when the SDK is absent) and
+handles sync and async clients.
+"""
+
+from __future__ import annotations
+
+import inspect
+import itertools
+import logging
+import time
+
+from snagline.events import StepEvent, make_signature
+
+try:  # optional dependency
+    from anthropic import Anthropic, AsyncAnthropic  # type: ignore
+except Exception:  # pragma: no cover - exercised only without the Anthropic SDK
+    Anthropic = None  # type: ignore[assignment, misc]
+    AsyncAnthropic = None  # type: ignore[assignment, misc]
+
+logger = logging.getLogger("snagline")
+
+
+def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
+    latency = (time.time() - start) * 1000.0
+    event = StepEvent(
+        step_id=str(next(counter)),
+        episode_id="anthropic-auto",
+        timestamp=time.time(),
+        action_type="tool_call",
+        action_signature=make_signature("anthropic_call", model, sig_text),
+        tool_name=tool_name,
+        latency_ms=latency,
+        error=error,
+    )
+    monitor.ingest(event)
+
+
+def _wrap_one(monitor, original, tool_name):
+    counter = itertools.count()
+    is_async = inspect.iscoroutinefunction(original)
+
+    def _sync(*args, **kwargs):
+        sig_text = str(kwargs.get("messages") or args)
+        model = kwargs.get("model", "unknown")
+        start = time.time()
+        error = False
+        try:
+            result = original(*args, **kwargs)
+        except Exception:
+            error = True
+            raise
+        finally:
+            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        return result
+
+    async def _async(*args, **kwargs):
+        sig_text = str(kwargs.get("messages") or args)
+        model = kwargs.get("model", "unknown")
+        start = time.time()
+        error = False
+        try:
+            result = await original(*args, **kwargs)
+        except Exception:
+            error = True
+            raise
+        finally:
+            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        return result
+
+    return _async if is_async else _sync
+
+
+def wrap_client(monitor, client):
+    """Wrap ``client.messages.create`` in place. Returns the same client."""
+    cur = getattr(client, "messages", None)
+    if cur is None:
+        return client
+    method = getattr(cur, "create", None)
+    if method is None or not callable(method):
+        return client
+    cur.create = _wrap_one(monitor, method, "anthropic.messages.create")
+    return client
+
+
+def instrument_anthropic(monitor, client=None) -> bool:
+    """Instrument the Anthropic SDK.
+
+    If ``client`` is provided, only that instance is wrapped. Otherwise the
+    installed ``anthropic.Anthropic`` / ``anthropic.AsyncAnthropic`` classes
+    are patched globally. Returns True if anything was patched, False if the
+    SDK is not importable.
+    """
+    if client is not None:
+        wrap_client(monitor, client)
+        return True
+    if Anthropic is None:
+        logger.warning("snagline.auto: Anthropic SDK not installed; nothing to patch")
+        return False
+    wrap_client(monitor, Anthropic)
+    if AsyncAnthropic is not None:
+        wrap_client(monitor, AsyncAnthropic)
+    return True

--- a/tests/test_auto_anthropic.py
+++ b/tests/test_auto_anthropic.py
@@ -1,0 +1,74 @@
+"""Tests for Anthropic auto-instrumentation (ATTACH_ANY_SYSTEM P0)."""
+
+from __future__ import annotations
+
+from snagline.auto.anthropic import instrument_anthropic, wrap_client
+
+
+class _SpyMonitor:
+    def __init__(self):
+        self.events: list = []
+
+    def ingest(self, event) -> None:
+        self.events.append(event)
+
+
+class _FakeMessages:
+    def create(self, *, model="claude", messages=None, **kw):
+        return "ok"
+
+
+class _FakeClient:
+    messages = _FakeMessages()
+
+
+def test_wrap_client_records_on_success():
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _FakeClient())
+    out = client.messages.create(model="claude-3-5-sonnet", messages=[{"role": "user"}])
+    assert out == "ok"
+    assert len(mon.events) == 1
+    ev = mon.events[0]
+    assert ev.tool_name == "anthropic.messages.create"
+    assert ev.error is False
+    assert ev.latency_ms is not None
+
+
+def test_wrap_client_missing_messages_attr_is_safe():
+    mon = _SpyMonitor()
+
+    class _Bare:
+        pass
+
+    wrap_client(mon, _Bare())
+    assert mon.events == []
+
+
+def test_wrap_client_records_error_and_propagates():
+    class _BoomMessages:
+        def create(self, **kw):
+            raise RuntimeError("boom")
+
+    class _BoomClient:
+        messages = _BoomMessages()
+
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _BoomClient())
+    raised = False
+    try:
+        client.messages.create(model="claude", messages=[{"role": "user"}])
+    except RuntimeError:
+        raised = True
+    assert raised, "exception must propagate"
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+
+
+def test_instrument_anthropic_without_sdk_is_safe_noop():
+    mon = _SpyMonitor()
+    assert instrument_anthropic(mon) is False
+
+
+def test_instrument_anthropic_with_explicit_client():
+    mon = _SpyMonitor()
+    assert instrument_anthropic(mon, client=_FakeClient()) is True


### PR DESCRIPTION
## Summary
Adds Anthropic SDK auto-instrumentation (P0 of `docs/ATTACH_ANY_SYSTEM.md`), mirroring the OpenAI wrapper merged in #33.

- `snagline.auto.anthropic.wrap_client(monitor, client)` patches `client.messages.create` in place (sync and async).
- `instrument_anthropic(monitor, client=None)` wraps a single client, or with `client=None` patches the installed `anthropic.Anthropic` / `anthropic.AsyncAnthropic` classes globally.
- Import-safe: with no Anthropic SDK present, `instrument_anthropic` is a clean no-op.

Each wrapped call emits a `StepEvent` (model, latency, error flag) to the monitor.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, and `pytest tests/test_auto_anthropic.py` (5 passed) all green.