### PR TITLE
feat: LangChain auto-instrumentation

### DIFF
--- a/src/snagline/auto/__init__.py
+++ b/src/snagline/auto/__init__.py
@@ -2,6 +2,12 @@
 
 from snagline.auto.anthropic import instrument_anthropic
 from snagline.auto.anthropic import wrap_client as wrap_anthropic
+from snagline.auto.langchain import (
+    instrument_langchain,
+)
+from snagline.auto.langchain import (
+    wrap_client as wrap_langchain,
+)
 from snagline.auto.openai import instrument_openai, wrap_client
 
 __all__ = [
@@ -9,4 +15,6 @@ __all__ = [
     "wrap_client",
     "instrument_anthropic",
     "wrap_anthropic",
+    "instrument_langchain",
+    "wrap_langchain",
 ]

--- a/src/snagline/auto/langchain.py
+++ b/src/snagline/auto/langchain.py
@@ -1,0 +1,107 @@
+"""Auto-instrumentation for LangChain (ATTACH_ANY_SYSTEM P0).
+
+Wraps the common ``invoke`` / ``generate`` entrypoints on a LangChain model
+or chain so each call emits a ``StepEvent``. Import-safe: a no-op when
+LangChain is absent, and handles synchronous and asynchronous methods.
+"""
+
+from __future__ import annotations
+
+import inspect
+import itertools
+import logging
+import time
+
+from snagline.events import StepEvent, make_signature
+
+logger = logging.getLogger("snagline")
+
+# Entrypoints we patch on a model or chain instance.
+_LANGCHAIN_METHODS = ("invoke", "generate", "ainvoke", "agenerate")
+
+
+def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
+    latency = (time.time() - start) * 1000.0
+    event = StepEvent(
+        step_id=str(next(counter)),
+        episode_id="langchain-auto",
+        timestamp=time.time(),
+        action_type="tool_call",
+        action_signature=make_signature("langchain_call", model, sig_text),
+        tool_name=tool_name,
+        latency_ms=latency,
+        error=error,
+    )
+    monitor.ingest(event)
+
+
+def _wrap_one(monitor, original, tool_name):
+    counter = itertools.count()
+    is_async = inspect.iscoroutinefunction(original)
+
+    def _sync(*args, **kwargs):
+        sig_text = str(kwargs.get("input") or kwargs.get("prompts") or args)
+        model = getattr(original, "__self__", None)
+        model_name = getattr(model, "model_name", None) or getattr(
+            model, "model", "langchain"
+        )
+        start = time.time()
+        error = False
+        try:
+            result = original(*args, **kwargs)
+        except Exception:
+            error = True
+            raise
+        finally:
+            _emit(monitor, counter, model_name, tool_name, sig_text, start, error)
+        return result
+
+    async def _async(*args, **kwargs):
+        sig_text = str(kwargs.get("input") or kwargs.get("prompts") or args)
+        model = getattr(original, "__self__", None)
+        model_name = getattr(model, "model_name", None) or getattr(
+            model, "model", "langchain"
+        )
+        start = time.time()
+        error = False
+        try:
+            result = await original(*args, **kwargs)
+        except Exception:
+            error = True
+            raise
+        finally:
+            _emit(monitor, counter, model_name, tool_name, sig_text, start, error)
+        return result
+
+    return _async if is_async else _sync
+
+
+def wrap_client(monitor, client):
+    """Patch the invoke/generate entrypoints on ``client`` in place."""
+    for name in _LANGCHAIN_METHODS:
+        method = getattr(client, name, None)
+        if method is None or not callable(method):
+            continue
+        setattr(client, name, _wrap_one(monitor, method, "langchain." + name))
+    return client
+
+
+def instrument_langchain(monitor, client=None) -> bool:
+    """Instrument LangChain.
+
+    If ``client`` is provided, only that instance is wrapped. Otherwise the
+    installed ``langchain`` base classes are patched globally (best effort).
+    Returns True if anything was patched, False if LangChain is absent.
+    """
+    if client is not None:
+        wrap_client(monitor, client)
+        return True
+    try:  # pragma: no cover - exercised only with LangChain installed
+        from langchain.chains.base import Chain  # type: ignore
+        from langchain_core.language_models import BaseLanguageModel  # type: ignore
+    except Exception:
+        logger.warning("snagline.auto: LangChain not installed; nothing to patch")
+        return False
+    wrap_client(monitor, BaseLanguageModel)
+    wrap_client(monitor, Chain)
+    return True

--- a/tests/test_auto_langchain.py
+++ b/tests/test_auto_langchain.py
@@ -1,0 +1,63 @@
+"""Tests for LangChain auto-instrumentation (ATTACH_ANY_SYSTEM P0)."""
+
+from __future__ import annotations
+
+from snagline.auto.langchain import instrument_langchain, wrap_client
+
+
+class _SpyMonitor:
+    def __init__(self):
+        self.events: list = []
+
+    def ingest(self, event) -> None:
+        self.events.append(event)
+
+
+class _FakeLLM:
+    model_name = "gpt-4o"
+
+    def invoke(self, prompt, **kw):
+        return "ok"
+
+    def generate(self, prompts, **kw):
+        return "result"
+
+
+def test_wrap_client_records_invoke_and_generate():
+    mon = _SpyMonitor()
+    llm = wrap_client(mon, _FakeLLM())
+    assert llm.invoke("hello") == "ok"
+    assert llm.generate(["a", "b"]) == "result"
+    assert len(mon.events) == 2
+    tools = {e.tool_name for e in mon.events}
+    assert tools == {"langchain.invoke", "langchain.generate"}
+    for ev in mon.events:
+        assert ev.error is False
+        assert ev.latency_ms is not None
+
+
+def test_wrap_client_records_error_and_propagates():
+    class _BoomLLM:
+        def invoke(self, *a, **kw):
+            raise RuntimeError("boom")
+
+    mon = _SpyMonitor()
+    llm = wrap_client(mon, _BoomLLM())
+    raised = False
+    try:
+        llm.invoke("hi")
+    except RuntimeError:
+        raised = True
+    assert raised
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+
+
+def test_instrument_langchain_without_sdk_is_safe_noop():
+    mon = _SpyMonitor()
+    assert instrument_langchain(mon) is False
+
+
+def test_instrument_langchain_with_explicit_client():
+    mon = _SpyMonitor()
+    assert instrument_langchain(mon, client=_FakeLLM()) is True


### PR DESCRIPTION
## Summary
Adds LangChain auto-instrumentation (P0 of `docs/ATTACH_ANY_SYSTEM.md`), mirroring the OpenAI/Anthropic wrappers.

- `snagline.auto.langchain.wrap_client(monitor, client)` patches the `invoke` / `generate` (and async `ainvoke` / `agenerate`) entrypoints on a model or chain in place.
- `instrument_langchain(monitor, client=None)` wraps a single client, or with `client=None` patches installed LangChain base classes globally.
- Import-safe: with no LangChain present, `instrument_langchain` is a clean no-op.

Each wrapped call emits a `StepEvent` (model, latency, error flag) to the monitor.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, and `pytest tests/test_auto_langchain.py` (4 passed) all green.