### PR TITLE
feat: wire Config.resolve into CLI

### DIFF
--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -18,6 +18,7 @@ import time
 from collections.abc import Iterator
 from contextlib import suppress
 
+from snagline.config import Config
 from snagline.events import StepEvent
 from snagline.monitor import Monitor
 from snagline.risk import FailureRisk
@@ -84,12 +85,27 @@ def replay(path: str, monitor: Monitor | None = None) -> int:
     return steps
 
 
+def _build_config(args: argparse.Namespace) -> Config:
+    """Resolve the effective Config from --config and SNAGLINE_* env vars."""
+    path = getattr(args, "config", None)
+    return Config.resolve(path=path)
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         prog="snagline",
         description="Real-time failure detection for AI agents (v0.1).",
     )
     sub = parser.add_subparsers(dest="command")
+
+    # 12-factor configuration applies across all subcommands: a config file
+    # and/or SNAGLINE_* environment variables tune the detectors (P0).
+    parser.add_argument(
+        "--config",
+        default=None,
+        help="Path to a JSON/TOML config file. Environment variables "
+        "(SNAGLINE_*) override it. See docs/ATTACH_ANY_SYSTEM.md.",
+    )
 
     p_replay = sub.add_parser(
         "replay", help="Replay a JSONL trajectory through the detectors (offline)."
@@ -209,7 +225,7 @@ def _cmd_watch(args: argparse.Namespace) -> int:
         from snagline.sinks.webhook import WebhookSink
 
         sinks.append(WebhookSink(args.webhook_url))
-    monitor = Monitor.default(sinks=sinks or None)
+    monitor = Monitor.default(config=_build_config(args), sinks=sinks or None)
     episode = args.episode_id or (args.file or "stdin")
     steps = 0
     try:
@@ -293,7 +309,7 @@ def _cmd_hook(args: argparse.Namespace) -> int:
     if not args.url and not args.out:
         # Fail-open by construction; Monitor.default() is also fail-open.
         with suppress(Exception):
-            monitor = Monitor.default()
+            monitor = Monitor.default(config=_build_config(args))
             monitor.ingest(event)
     return 0
 
@@ -342,7 +358,11 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         file=sys.stderr,
     )
     with suppress(KeyboardInterrupt):
-        serve(Monitor.default(), host=args.host, port=args.port)
+        serve(
+            Monitor.default(config=_build_config(args)),
+            host=args.host,
+            port=args.port,
+        )
     return 0
 
 
@@ -417,7 +437,7 @@ def main(argv: list[str] | None = None) -> int:
 
             sinks.append(ConsoleSink())
         sinks.append(counter)
-        monitor = Monitor.default(sinks=sinks)
+        monitor = Monitor.default(config=_build_config(args), sinks=sinks)
         steps = replay(args.trajectory, monitor=monitor)
         if args.summary:
             print(

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -133,3 +133,31 @@ class Config:
             data = json.loads(text)
         valid = {f.name for f in fields(cls)}  # noqa: F821
         return cls(**{k: v for k, v in data.items() if k in valid})
+
+    @classmethod
+    def resolve(
+        cls,
+        path: str | None = None,
+        environ: Mapping[str, str] | None = None,
+        prefix: str = "SNAGLINE_",
+    ) -> Config:
+        """Build the effective ``Config`` by layering sources (12-factor).
+
+        Precedence (lowest to highest): built-in defaults -> optional config
+        file (``path``) -> environment variables (``prefix``). Environment
+        overrides win over the file, which wins over defaults. Unknown file
+        keys and unset environment keys do not change anything.
+
+        This is the single entrypoint the CLI and host integrations should use
+        so behavior is consistent across ``snagline serve``, ``watch``,
+        ``replay``, and embedded use.
+        """
+        cfg = cls()
+        if path:
+            cfg = cls.load_file(path)
+        env = cls.from_env(environ=environ, prefix=prefix)
+        defaults = cls()
+        for fld in fields(cls):
+            if getattr(env, fld.name) != getattr(defaults, fld.name):
+                setattr(cfg, fld.name, getattr(env, fld.name))
+        return cfg

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -61,3 +61,23 @@ def test_load_file_toml(tmp_path):
     cfg = Config.load_file(str(path))
     assert cfg.cusum_h == 7.0
     assert cfg.loop_window_size == 20
+
+
+def test_resolve_layers_file_then_env(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps({"cusum_k": 1.2, "loop_repeat_threshold": 9}))
+    env = {"SNAGLINE_LOOP_REPEAT_THRESHOLD": "15"}
+    cfg = Config.resolve(path=str(path), environ=env)
+    # From file:
+    assert cfg.cusum_k == 1.2
+    # From env, overriding the file:
+    assert cfg.loop_repeat_threshold == 15
+    # Untouched default:
+    assert cfg.fail_open is True
+
+
+def test_resolve_env_only():
+    env = {"SNAGLINE_FAIL_OPEN": "false"}
+    cfg = Config.resolve(environ=env)
+    assert cfg.fail_open is False
+    assert cfg.cusum_k == 0.5  # default unchanged


### PR DESCRIPTION
## Summary
Makes the 12-factor config loaders actually used (P0 of `docs/ATTACH_ANY_SYSTEM.md`).

- Added `Config.resolve(path=None, environ=None, prefix="SNAGLINE_")` which layers sources: built-in defaults -> optional config file -> environment variables (env wins).
- The CLI now accepts a top-level `--config <json|toml>` flag. `SNAGLINE_*` env vars apply to every subcommand (`serve`, `watch`, `replay`, `hook`). The resolved `Config` is passed into `Monitor.default(...)`, so detectors are tuned uniformly across all entrypoints and embedded use.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (154 passed, 1 skipped, 88.5% coverage, above the 80% floor) all green.