### PR TITLE
feat: Slack escalation sink

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,8 +38,9 @@ anthropic  = ["anthropic>=0.30"]
 # Optional extras (not required for the core fail-open detector):
 ml         = ["numpy>=1.24", "scikit-learn>=1.3"]   # future baseline fitting (ml extra)
 drift      = ["sentence-transformers>=2.2"]          # future semantic-drift detector
-slack      = ["httpx>=0.27"]                          # Slack escalation sink
-all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift,slack]"]
+# Slack and PagerDuty sinks ship in the core and use only the stdlib, so they
+# need no extra dependency; the `all` extra pulls in the framework/SDK extras.
+all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift]"]
 
 [project.scripts]
 snagline = "snagline.cli:main"

--- a/src/snagline/sinks/slack.py
+++ b/src/snagline/sinks/slack.py
@@ -1,0 +1,77 @@
+"""Slack sink -- post ``FailureRisk`` alerts to a Slack incoming webhook.
+
+Zero dependency (stdlib ``urllib.request``), mirroring the webhook sink.
+Fire-and-forget with a short timeout: ``emit`` never raises and never blocks
+``ingest()`` for long. An optional ``min_severity`` filter lets a host route
+only warnings/criticals to Slack while still sending everything elsewhere.
+
+Privacy: only ``FailureRisk`` fields are transmitted, never raw content
+(project.md §11).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Any
+
+from snagline.risk import (
+    SEVERITY_CRITICAL,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    FailureRisk,
+)
+
+logger = logging.getLogger("snagline")
+
+_SEVERITY_ORDER = {
+    SEVERITY_INFO: 0,
+    SEVERITY_WARNING: 1,
+    SEVERITY_CRITICAL: 2,
+}
+
+
+def _order(severity: str) -> int:
+    return _SEVERITY_ORDER.get(severity, 1)
+
+
+class SlackSink:
+    """POSTs each ``FailureRisk`` as a Slack message to ``webhook_url``."""
+
+    def __init__(
+        self,
+        webhook_url: str,
+        timeout: float = 2.0,
+        min_severity: str | None = None,
+    ) -> None:
+        self._url = webhook_url
+        self._timeout = timeout
+        self._min = min_severity
+
+    def emit(self, risk: FailureRisk) -> None:
+        if self._min is not None and _order(risk.severity) < _order(self._min):
+            return
+        text = (
+            f"[{risk.severity.upper()}] SNAGLINE failure detected\n"
+            f"Trigger: {risk.trigger}\n"
+            f"Episode: {risk.episode_id} (step {risk.step_id})\n"
+            f"Score: {risk.score:.2f}\n"
+            f"{risk.detail}"
+        )
+        payload: dict[str, Any] = {"text": text}
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            self._url,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                resp.read()
+        except Exception:
+            logger.exception(
+                "snagline Slack sink POST to %s failed; ignoring (fail-open)",
+                self._url,
+            )

--- a/tests/test_slack_sink.py
+++ b/tests/test_slack_sink.py
@@ -1,0 +1,48 @@
+"""Tests for the Slack escalation sink (P1 alerting)."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+from snagline.risk import SEVERITY_CRITICAL, SEVERITY_INFO, FailureRisk
+from snagline.sinks.slack import SlackSink
+
+
+def _risk(severity: str = SEVERITY_INFO, **kw) -> FailureRisk:
+    return FailureRisk(
+        episode_id="ep",
+        step_id="s1",
+        score=0.9,
+        trigger="loop",
+        detail="repeating loop detected",
+        timestamp=1.0,
+        severity=severity,
+        **kw,
+    )
+
+
+def test_slack_posts_formatted_text():
+    sink = SlackSink("https://hooks.slack.com/xyz")
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        sink.emit(_risk(SEVERITY_CRITICAL))
+    assert urlopen.called
+    req = urlopen.call_args[0][0]
+    body = json.loads(req.data.decode())
+    assert "loop" in body["text"]
+    assert "CRITICAL" in body["text"]
+    assert dict(req.headers).get("Content-type") == "application/json"
+
+
+def test_slack_min_severity_filters_lower():
+    sink = SlackSink("https://hooks.slack.com/xyz", min_severity=SEVERITY_CRITICAL)
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        sink.emit(_risk(SEVERITY_INFO))  # below threshold -> dropped
+    assert not urlopen.called
+
+
+def test_slack_swallows_post_errors():
+    sink = SlackSink("https://hooks.slack.com/xyz")
+    with mock.patch("urllib.request.urlopen", side_effect=OSError("down")):
+        # Must not raise; fail-open.
+        sink.emit(_risk(SEVERITY_CRITICAL))


### PR DESCRIPTION
## Summary
P1 alerting maturity: a Slack escalation sink so risks can page a channel.

- `snagline.sinks.slack.SlackSink` POSTs a formatted message to a Slack incoming webhook using only stdlib `urllib` (zero dependency). The `slack` pyproject extra was redundant and removed.
- Optional `min_severity` filter routes only warnings/criticals.
- Fail-open: POST errors are caught and logged, never raised.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (165 passed, 1 skipped, 89% coverage) all green.