### PR TITLE
feat: PagerDuty escalation sink

### DIFF
--- a/src/snagline/sinks/pagerduty.py
+++ b/src/snagline/sinks/pagerduty.py
@@ -1,0 +1,93 @@
+"""PagerDuty sink -- trigger PagerDuty Events API v2 incidents.
+
+Zero dependency (stdlib ``urllib.request``). Posts a ``trigger`` event with a
+mapped severity so on-call gets paged. Optional ``min_severity`` filter.
+
+Privacy: only ``FailureRisk`` fields are transmitted, never raw content
+(project.md §11).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+from typing import Any
+
+from snagline.risk import (
+    SEVERITY_CRITICAL,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    FailureRisk,
+)
+
+logger = logging.getLogger("snagline")
+
+_EVENTS_API = "https://events.pagerduty.com/v2/enqueue"
+
+_SEVERITY_ORDER = {
+    SEVERITY_INFO: 0,
+    SEVERITY_WARNING: 1,
+    SEVERITY_CRITICAL: 2,
+}
+
+# PagerDuty's severity vocabulary is a subset of ours.
+_PD_SEVERITY = {
+    SEVERITY_CRITICAL: "critical",
+    SEVERITY_WARNING: "warning",
+    SEVERITY_INFO: "info",
+}
+
+
+def _order(severity: str) -> int:
+    return _SEVERITY_ORDER.get(severity, 1)
+
+
+class PagerDutySink:
+    """Trigger a PagerDuty incident for each ``FailureRisk``."""
+
+    def __init__(
+        self,
+        routing_key: str,
+        timeout: float = 2.0,
+        source: str = "snagline",
+        min_severity: str | None = None,
+    ) -> None:
+        self._key = routing_key
+        self._timeout = timeout
+        self._source = source
+        self._min = min_severity
+
+    def emit(self, risk: FailureRisk) -> None:
+        if self._min is not None and _order(risk.severity) < _order(self._min):
+            return
+        pd_sev = _PD_SEVERITY.get(risk.severity, "warning")
+        payload: dict[str, Any] = {
+            "routing_key": self._key,
+            "event_action": "trigger",
+            "payload": {
+                "summary": f"[{risk.severity}] {risk.trigger}: {risk.detail}",
+                "source": self._source,
+                "severity": pd_sev,
+            },
+            "custom_details": {
+                "episode_id": risk.episode_id,
+                "step_id": risk.step_id,
+                "score": risk.score,
+                "trigger": risk.trigger,
+            },
+        }
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            _EVENTS_API,
+            data=data,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=self._timeout) as resp:
+                resp.read()
+        except Exception:
+            logger.exception(
+                "snagline PagerDuty sink POST failed; ignoring (fail-open)"
+            )

--- a/tests/test_pagerduty_sink.py
+++ b/tests/test_pagerduty_sink.py
@@ -1,0 +1,58 @@
+"""Tests for the PagerDuty escalation sink (P1 alerting)."""
+
+from __future__ import annotations
+
+import json
+from unittest import mock
+
+from snagline.risk import SEVERITY_CRITICAL, SEVERITY_INFO, FailureRisk
+from snagline.sinks.pagerduty import _EVENTS_API, PagerDutySink
+
+
+def _risk(severity: str = SEVERITY_INFO, **kw) -> FailureRisk:
+    return FailureRisk(
+        episode_id="ep",
+        step_id="s1",
+        score=0.9,
+        trigger="loop",
+        detail="repeating loop detected",
+        timestamp=1.0,
+        severity=severity,
+        **kw,
+    )
+
+
+def test_pagerduty_posts_trigger_event():
+    sink = PagerDutySink("RKEY")
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        sink.emit(_risk(SEVERITY_CRITICAL))
+    assert urlopen.called
+    req = urlopen.call_args[0][0]
+    assert req.full_url == _EVENTS_API
+    body = json.loads(req.data.decode())
+    assert body["routing_key"] == "RKEY"
+    assert body["event_action"] == "trigger"
+    assert body["payload"]["severity"] == "critical"
+    assert "loop" in body["payload"]["summary"]
+    assert body["custom_details"]["episode_id"] == "ep"
+
+
+def test_pagerduty_maps_info_severity():
+    sink = PagerDutySink("RKEY")
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        sink.emit(_risk(SEVERITY_INFO))
+    body = json.loads(urlopen.call_args[0][0].data.decode())
+    assert body["payload"]["severity"] == "info"
+
+
+def test_pagerduty_min_severity_filters_lower():
+    sink = PagerDutySink("RKEY", min_severity=SEVERITY_CRITICAL)
+    with mock.patch("urllib.request.urlopen") as urlopen:
+        sink.emit(_risk(SEVERITY_INFO))
+    assert not urlopen.called
+
+
+def test_pagerduty_swallows_post_errors():
+    sink = PagerDutySink("RKEY")
+    with mock.patch("urllib.request.urlopen", side_effect=OSError("down")):
+        sink.emit(_risk(SEVERITY_CRITICAL))  # must not raise


### PR DESCRIPTION
## Summary
P1 alerting maturity: a PagerDuty escalation sink so risks can page on-call.

- `snagline.sinks.pagerduty.PagerDutySink` triggers PagerDuty Events API v2 incidents using only stdlib `urllib` (no SDK).
- Maps SNAGLINE severity to PagerDuty's severity vocabulary and supports an optional `min_severity` filter.
- Fail-open: POST errors are caught and logged, never raised.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (169 passed, 1 skipped, 89% coverage) all green.