### PR TITLE
feat: pluggable state backend + lock sharding

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -23,6 +23,7 @@ from snagline.detectors.base import Detector
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 from snagline.sinks.base import AlertSink
+from snagline.state import StateBackend, default_state_backend
 
 logger = logging.getLogger("snagline")
 
@@ -33,6 +34,11 @@ class Monitor:
 
     Fail-open: detector/sink exceptions are caught and logged, never
     propagated into the host agent, unless ``fail_open=False``.
+
+    Concurrency is sharded by ``episode_id`` via a ``StateBackend``: two
+    distinct episodes can be observed concurrently, while a single episode's
+    events serialize. This removes the single global ingest lock that would
+    bottleneck a high-throughput service (P1, item 4).
     """
 
     def __init__(
@@ -40,11 +46,12 @@ class Monitor:
         detectors: list[Detector],
         sinks: list[AlertSink],
         fail_open: bool = True,
+        state_backend: StateBackend | None = None,
     ) -> None:
         self._detectors = list(detectors)
         self._sinks = list(sinks)
         self._fail_open = fail_open
-        self._lock = threading.Lock()
+        self._state = state_backend or default_state_backend()
         # A faulty detector or sink must not spam the logs on every single step
         # (issue #14) -- log each distinct fault exactly once.
         self._fault_lock = threading.Lock()
@@ -62,7 +69,7 @@ class Monitor:
         that re-enters ``ingest`` must not deadlock.
         """
         risks: list[FailureRisk] = []
-        with self._lock:
+        with self._state.episode_lock(event.episode_id):
             for detector in self._detectors:
                 try:
                     risk = detector.observe(event)
@@ -117,7 +124,7 @@ class Monitor:
 
         Fail-open: a detector's ``reset`` exception is logged, never propagated.
         """
-        with self._lock:
+        with self._state.episode_lock(episode_id):
             for detector in self._detectors:
                 try:
                     detector.reset(episode_id)
@@ -134,6 +141,7 @@ class Monitor:
         cls,
         config: Config | None = None,
         sinks: list[AlertSink] | None = None,
+        state_backend: StateBackend | None = None,
     ) -> Monitor:
         """Construct a zero-configuration Monitor with sensible defaults.
 
@@ -164,4 +172,8 @@ class Monitor:
         else:
             detectors = list(base)
         chosen_sinks: list[AlertSink] = sinks if sinks is not None else [ConsoleSink()]
-        return cls(detectors, chosen_sinks, fail_open=cfg.fail_open)
+        monitor = cls(detectors, chosen_sinks, fail_open=cfg.fail_open)
+        # Set after construction so subclasses with a fixed __init__ signature
+        # (e.g. test doubles) still work; base Monitor.__init__ also sets it.
+        monitor._state = state_backend or default_state_backend()
+        return monitor

--- a/src/snagline/state.py
+++ b/src/snagline/state.py
@@ -1,0 +1,87 @@
+"""Pluggable state backend (ATTACH_ANY_SYSTEM P1, item 4).
+
+The Monitor's per-episode detector state (loop windows, cascade counters,
+CUSUM baselines) is naturally keyed by ``episode_id``. This module provides a
+``StateBackend`` that owns the concurrency primitive, so the ingest path can
+shard its lock by episode instead of serializing all episodes behind one
+global lock (the verified bottleneck in monitor.py).
+
+The default ``MemoryStateBackend`` is process-local. ``RedisStateBackend``
+(optional, behind the ``redis`` extra) provides a shared lock across workers
+so a horizontally-scaled deployment does not double-count; it is imported
+lazily so the core stays zero-dependency.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import threading
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Protocol
+
+logger = logging.getLogger("snagline")
+
+
+class StateBackend(Protocol):
+    """Owns the lock used to serialize a single episode's ingest path."""
+
+    @contextmanager
+    def episode_lock(self, episode_id: str) -> Iterator[None]:
+        """Yield while holding the lock for ``episode_id`` (re-entrant safe)."""
+        ...
+
+
+class MemoryStateBackend:
+    """Process-local backend: one re-entrant lock per episode id."""
+
+    def __init__(self) -> None:
+        self._meta = threading.Lock()
+        self._locks: dict[str, threading.RLock] = {}
+
+    @contextmanager
+    def episode_lock(self, episode_id: str) -> Iterator[None]:
+        with self._meta:
+            lock = self._locks.get(episode_id)
+            if lock is None:
+                lock = threading.RLock()
+                self._locks[episode_id] = lock
+        with lock:
+            yield
+
+
+class RedisStateBackend:  # pragma: no cover - optional, requires redis
+    """Shared backend: a Redis lock so workers coordinate across processes."""
+
+    def __init__(self, url: str, prefix: str = "snagline:") -> None:
+        import redis
+
+        self._r = redis.Redis.from_url(url)
+        self._prefix = prefix
+
+    @contextmanager
+    def episode_lock(self, episode_id: str) -> Iterator[None]:
+        lock = self._r.lock(self._prefix + "lock:" + episode_id, timeout=30)
+        acquired = lock.acquire(blocking=True, blocking_timeout=30)
+        try:
+            yield
+        finally:
+            if acquired:
+                lock.release()
+
+
+def default_state_backend() -> StateBackend:
+    """Pick a backend from ``SNAGLINE_STATE_BACKEND`` env (memory|redis)."""
+    kind = os.environ.get("SNAGLINE_STATE_BACKEND", "memory").lower()
+    if kind == "redis":
+        url = os.environ.get("SNAGLINE_STATE_REDIS_URL")
+        if url:
+            try:
+                return RedisStateBackend(url)
+            except ImportError:
+                logger.warning(
+                    "snagline: redis backend requested but redis not installed; "
+                    "falling back to in-memory state"
+                )
+    return MemoryStateBackend()

--- a/tests/test_state_backend.py
+++ b/tests/test_state_backend.py
@@ -1,0 +1,73 @@
+"""Tests for the pluggable StateBackend and Monitor per-episode locking (P1)."""
+
+from __future__ import annotations
+
+import threading
+
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+from snagline.state import (
+    MemoryStateBackend,
+    RedisStateBackend,
+    default_state_backend,
+)
+
+
+def _event(episode_id="ep", i=0):
+    return StepEvent(
+        step_id=str(i),
+        episode_id=episode_id,
+        timestamp=1.0,
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", "tool", str(i)),
+        tool_name="tool",
+        latency_ms=100.0,
+    )
+
+
+def test_memory_backend_isolates_episode_locks():
+    b = MemoryStateBackend()
+    # Same episode id returns the same underlying lock object (re-entrant).
+    with b.episode_lock("a"):
+        with b.episode_lock("a"):
+            pass  # re-entrant: must not deadlock
+    with b.episode_lock("b"):
+        pass
+    # Distinct episodes get distinct locks.
+    assert b._locks["a"] is not b._locks["b"]
+
+
+def test_default_state_backend_memory_without_env(monkeypatch):
+    monkeypatch.delenv("SNAGLINE_STATE_BACKEND", raising=False)
+    assert isinstance(default_state_backend(), MemoryStateBackend)
+
+
+def test_default_state_backend_redis_when_configured(monkeypatch):
+    monkeypatch.setenv("SNAGLINE_STATE_BACKEND", "redis")
+    monkeypatch.setenv("SNAGLINE_STATE_REDIS_URL", "redis://localhost:6379/0")
+    # Import is guarded; without redis installed this returns a Memory backend
+    # as a safe fallback rather than raising (redis extra not installed in CI).
+    backend = default_state_backend()
+    assert isinstance(backend, (RedisStateBackend, MemoryStateBackend))
+
+
+def test_concurrent_ingest_of_distinct_episodes_no_deadlock():
+    monitor = Monitor.default()
+    errors: list[Exception] = []
+
+    def worker(ep):
+        try:
+            for i in range(50):
+                monitor.ingest(_event(episode_id=ep, i=i))
+        except Exception as exc:  # pragma: no cover
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(f"ep{j}",)) for j in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    assert not errors, errors
+    # Each episode's state was torn down cleanly.
+    for j in range(4):
+        monitor.end_episode(f"ep{j}")


### PR DESCRIPTION
## Summary
P1 item 4 (part 1): removes the single global ingest lock that bottlenecked high-throughput use and opens the door to shared state across workers.

- New `snagline.state`: `StateBackend` protocol, `MemoryStateBackend` (default, one re-entrant lock per `episode_id`), optional `RedisStateBackend` (guarded import, behind the `redis` extra), and `default_state_backend()` reading `SNAGLINE_STATE_BACKEND` (memory|redis) + `SNAGLINE_STATE_REDIS_URL`.
- `Monitor.ingest`/`end_episode` now lock per `episode_id` via the backend, so distinct episodes run concurrently while one episode still serializes. Detector per-episode state is already keyed by `episode_id`, so this is safe.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (178 passed, 1 skipped, 89% coverage) all green.