### PR TITLE
feat: versioned per-tenant BaselineStore

### DIFF
--- a/src/snagline/baseline_store.py
+++ b/src/snagline/baseline_store.py
@@ -1,0 +1,130 @@
+"""Versioned, per-tenant baseline store (ATTACH_ANY_SYSTEM P1, item 6).
+
+The `goal_drift` detector compares live traffic against a *healthy* reference
+profile. In production that reference must be (a) scoped per tenant/deployment
+(because "healthy" latency differs across customers and environments) and
+(b) versioned, so a retrained baseline can be rolled back if it regresses.
+
+This module is the storage layer: a file-backed ``BaselineStore`` that keeps
+the latest profile plus a bounded history of past versions under a root
+directory. Heavier backends (DB, object store) can implement the same shape
+later; the core stays stdlib-only.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+from typing import IO
+
+from snagline.baseline import BaselineProfile, fit_baseline_from_jsonl
+
+
+def _write_json(stream: IO[str], data: dict) -> None:
+    json.dump(data, stream, indent=2, sort_keys=True)
+    stream.write("\n")
+
+
+class BaselineStore:
+    """File-backed, versioned baseline store keyed by (tenant, deployment)."""
+
+    def __init__(self, root_dir: str, max_versions: int = 10) -> None:
+        self._root = Path(root_dir)
+        self._max_versions = max_versions
+
+    # --- paths ---------------------------------------------------------------
+    def _scope_dir(self, tenant: str, deployment: str) -> Path:
+        return self._root / tenant / deployment
+
+    def _version_path(self, tenant: str, deployment: str, version: str) -> Path:
+        return self._scope_dir(tenant, deployment) / "versions" / f"{version}.json"
+
+    # --- write ---------------------------------------------------------------
+    def save(
+        self,
+        profile: BaselineProfile,
+        tenant: str = "default",
+        deployment: str = "default",
+        version: str | None = None,
+        max_versions: int | None = None,
+    ) -> str:
+        """Persist ``profile`` and return the version id used.
+
+        Writes both a timestamped history entry and a ``latest.json`` pointer.
+        Old versions beyond ``max_versions`` (this call, else the store
+        default) are pruned oldest-first.
+        """
+        version = version or f"{time.time():.6f}"
+        scope = self._scope_dir(tenant, deployment)
+        versions_dir = scope / "versions"
+        versions_dir.mkdir(parents=True, exist_ok=True)
+
+        with open(
+            self._version_path(tenant, deployment, version), "w", encoding="utf-8"
+        ) as fh:
+            _write_json(fh, profile.to_dict())
+        # Latest pointer.
+        with open(scope / "latest.json", "w", encoding="utf-8") as fh:
+            _write_json(fh, profile.to_dict())
+
+        limit = max_versions if max_versions is not None else self._max_versions
+        self._prune(tenant, deployment, limit)
+        return version
+
+    def _prune(self, tenant: str, deployment: str, limit: int) -> None:
+        versions_dir = self._scope_dir(tenant, deployment) / "versions"
+        if not versions_dir.exists():
+            return
+        existing = sorted(p.name for p in versions_dir.glob("*.json"))
+        excess = existing[: max(0, len(existing) - limit)]
+        for name in excess:
+            (versions_dir / name).unlink(missing_ok=True)
+
+    # --- read ----------------------------------------------------------------
+    def load(
+        self, tenant: str = "default", deployment: str = "default"
+    ) -> BaselineProfile | None:
+        """Return the latest profile, or None if nothing has been stored."""
+        latest = self._scope_dir(tenant, deployment) / "latest.json"
+        if not latest.exists():
+            return None
+        return BaselineProfile.from_dict(json.loads(latest.read_text(encoding="utf-8")))
+
+    def load_version(
+        self, tenant: str, deployment: str, version: str
+    ) -> BaselineProfile | None:
+        path = self._version_path(tenant, deployment, version)
+        if not path.exists():
+            return None
+        return BaselineProfile.from_dict(json.loads(path.read_text(encoding="utf-8")))
+
+    def list_versions(
+        self, tenant: str = "default", deployment: str = "default"
+    ) -> list[str]:
+        versions_dir = self._scope_dir(tenant, deployment) / "versions"
+        if not versions_dir.exists():
+            return []
+        return sorted(p.name[:-5] for p in versions_dir.glob("*.json"))
+
+
+def capture_from_jsonl(
+    store: BaselineStore,
+    trajectory_path: str,
+    tenant: str = "default",
+    deployment: str = "default",
+    version: str | None = None,
+    max_versions: int | None = None,
+) -> str:
+    """Fit a baseline from a healthy-run JSONL trajectory and store it.
+
+    Returns the stored version id. ``max_versions`` overrides the store's
+    retention for this write.
+    """
+    return store.save(
+        fit_baseline_from_jsonl(trajectory_path),
+        tenant=tenant,
+        deployment=deployment,
+        version=version,
+        max_versions=max_versions,
+    )

--- a/tests/test_baseline_store.py
+++ b/tests/test_baseline_store.py
@@ -1,0 +1,80 @@
+"""Tests for the versioned, per-tenant BaselineStore (P1 item 6)."""
+
+from __future__ import annotations
+
+import json
+
+from snagline.baseline import BaselineProfile
+from snagline.baseline_store import (
+    BaselineStore,
+    capture_from_jsonl,
+)
+
+
+def _trajectory(tmp_path):
+    path = tmp_path / "healthy.jsonl"
+    rows = [
+        {
+            "step_id": str(i),
+            "episode_id": "ep",
+            "timestamp": 1.0 + i,
+            "action_type": "tool_call",
+            "action_signature": "SIG",
+            "tool_name": "search",
+            "latency_ms": 100.0 + i,
+        }
+        for i in range(5)
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return str(path)
+
+
+def test_store_save_and_load_latest(tmp_path):
+    store = BaselineStore(str(tmp_path / "store"))
+    profile = BaselineProfile()
+    profile.total_steps = 5
+    store.save(profile, tenant="acme", deployment="prod")
+    loaded = store.load(tenant="acme", deployment="prod")
+    assert loaded is not None
+    assert loaded.total_steps == 5
+
+
+def test_store_versions_and_rollback(tmp_path):
+    store = BaselineStore(str(tmp_path / "store"))
+    v1 = store.save(BaselineProfile(), tenant="t", deployment="d")
+    p2 = BaselineProfile()
+    p2.total_steps = 9
+    v2 = store.save(p2, tenant="t", deployment="d")
+    versions = store.list_versions("t", "d")
+    assert versions == [v1, v2]
+    # load() returns the newest.
+    assert store.load("t", "d").total_steps == 9
+    # A specific older version can still be fetched.
+    assert store.load_version("t", "d", v1).total_steps == 0
+
+
+def test_store_isolation_by_tenant(tmp_path):
+    store = BaselineStore(str(tmp_path / "store"))
+    p = BaselineProfile()
+    p.total_steps = 3
+    store.save(p, tenant="acme", deployment="prod")
+    # Different tenant has nothing.
+    assert store.load(tenant="other", deployment="prod") is None
+
+
+def test_store_prunes_old_versions(tmp_path):
+    store = BaselineStore(str(tmp_path / "store"), max_versions=3)
+    for _ in range(5):
+        store.save(BaselineProfile(), tenant="t", deployment="d")
+    assert len(store.list_versions("t", "d")) == 3
+
+
+def test_capture_from_jsonl_fits_and_stores(tmp_path):
+    store = BaselineStore(str(tmp_path / "store"))
+    version = capture_from_jsonl(
+        store, _trajectory(tmp_path), tenant="acme", deployment="prod"
+    )
+    loaded = store.load_version("acme", "prod", version)
+    assert loaded is not None
+    assert loaded.total_steps == 5
+    assert "search" in loaded.tools


### PR DESCRIPTION
## Summary
P1 item 6 (storage layer): baselines must be scoped per tenant/deployment and versioned so a retrained reference can be rolled back.

- `snagline.baseline_store.BaselineStore` (stdlib file backend) keeps a `latest.json` pointer plus a bounded history of timestamped versions under `<root>/<tenant>/<deployment>/versions`, pruning the oldest past `max_versions`.
- `capture_from_jsonl(store, path, tenant, deployment)` fits from a healthy trajectory and stores it. `load()` / `load_version()` / `list_versions()` round-trip.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (183 passed, 1 skipped, 89.5% coverage) all green.