### PR TITLE
feat: baseline collector + store CLI

### DIFF
--- a/src/snagline/baseline_store.py
+++ b/src/snagline/baseline_store.py
@@ -128,3 +128,45 @@ def capture_from_jsonl(
         version=version,
         max_versions=max_versions,
     )
+
+
+class BaselineCollector:
+    """Live auto-capture building block for P1 item 6.
+
+    A host feeds it every ``StepEvent`` during a *known-healthy* run; whenever
+    it decides the run is a good reference (a cadence it owns -- e.g. nightly,
+    or after N steps), it calls ``commit()`` to persist a versioned baseline.
+
+    Fail-open: a ``commit`` with no store configured is a no-op rather than an
+    error, so the collector is safe to drop into any pipeline.
+    """
+
+    def __init__(
+        self,
+        store: BaselineStore | None = None,
+        tenant: str = "default",
+        deployment: str = "default",
+        max_versions: int | None = None,
+    ) -> None:
+        self._store = store
+        self._tenant = tenant
+        self._deployment = deployment
+        self._max_versions = max_versions
+        self._profile = BaselineProfile()
+
+    def observe(self, event) -> None:
+        self._profile.add_event(event)
+
+    def snapshot(self) -> BaselineProfile:
+        return self._profile
+
+    def commit(self, version: str | None = None) -> str | None:
+        if self._store is None:
+            return None
+        return self._store.save(
+            self._profile,
+            tenant=self._tenant,
+            deployment=self._deployment,
+            version=version,
+            max_versions=self._max_versions,
+        )

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -317,6 +317,33 @@ def _build_parser() -> argparse.ArgumentParser:
         default="baseline.json",
         help="Where to write the fitted baseline JSON [default: baseline.json].",
     )
+    sp.add_argument(
+        "--store-dir",
+        default=None,
+        help="If set, store the baseline in a versioned BaselineStore at this "
+        "root (per --tenant/--deployment) instead of a single --output file.",
+    )
+    sp.add_argument(
+        "--tenant",
+        default="default",
+        help="Tenant scope for the BaselineStore [default: default].",
+    )
+    sp.add_argument(
+        "--deployment",
+        default="default",
+        help="Deployment scope for the BaselineStore [default: default].",
+    )
+    sp.add_argument(
+        "--list-versions",
+        action="store_true",
+        help="With --store-dir: list stored versions and exit (ignores fitting).",
+    )
+    sp.add_argument(
+        "--max-versions",
+        type=int,
+        default=None,
+        help="With --store-dir: cap retained versions (oldest pruned).",
+    )
 
     return parser
 
@@ -451,7 +478,44 @@ def _event_to_json(event: StepEvent) -> dict:
 
 
 def _cmd_baseline(args: argparse.Namespace) -> int:
-    """Fit a healthy-run baseline from a trajectory and persist it as JSON."""
+    """Fit a healthy-run baseline from a trajectory and persist it.
+
+    With ``--store-dir`` the baseline is stored versioned and per-tenant in a
+    ``BaselineStore``; ``--list-versions`` just lists what is already stored.
+    Otherwise it writes a single JSON file (``--output``).
+    """
+    if args.store_dir:
+        from snagline.baseline_store import (
+            BaselineStore,
+            capture_from_jsonl,
+        )
+
+        store = BaselineStore(args.store_dir, max_versions=args.max_versions or 10)
+        if args.list_versions:
+            versions = store.list_versions(args.tenant, args.deployment)
+            if not versions:
+                print(
+                    f"snagline baseline: no stored versions for "
+                    f"{args.tenant}/{args.deployment}"
+                )
+                return 0
+            print(f"snagline baseline: versions for {args.tenant}/{args.deployment}:")
+            for v in versions:
+                print(f"  {v}")
+            return 0
+        version = capture_from_jsonl(
+            store,
+            args.trajectory,
+            tenant=args.tenant,
+            deployment=args.deployment,
+            max_versions=args.max_versions,
+        )
+        print(
+            f"snagline baseline: stored version {version} for "
+            f"{args.tenant}/{args.deployment}"
+        )
+        return 0
+
     from snagline.baseline import fit_baseline_from_jsonl, save_baseline
 
     profile = fit_baseline_from_jsonl(args.trajectory)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -70,6 +70,58 @@ def test_main_watch_slack_missing_url_exits_2():
     assert main(["watch", "--sink", "slack"]) == 2
 
 
+def _write_healthy_trajectory(path):
+    import json as _json
+
+    rows = [
+        {
+            "step_id": str(i),
+            "episode_id": "ep",
+            "timestamp": 1.0 + i,
+            "action_type": "tool_call",
+            "action_signature": "SIG",
+            "tool_name": "search",
+            "latency_ms": 100.0 + i,
+        }
+        for i in range(5)
+    ]
+    path.write_text("\n".join(_json.dumps(r) for r in rows) + "\n")
+
+
+def test_main_baseline_store_and_list(tmp_path):
+    traj = tmp_path / "h.jsonl"
+    _write_healthy_trajectory(traj)
+    store_dir = tmp_path / "store"
+    assert (
+        main(
+            [
+                "baseline",
+                str(traj),
+                "--store-dir",
+                str(store_dir),
+                "--tenant",
+                "acme",
+            ]
+        )
+        == 0
+    )
+    # Version was stored and is listed.
+    assert (
+        main(
+            [
+                "baseline",
+                str(traj),
+                "--store-dir",
+                str(store_dir),
+                "--tenant",
+                "acme",
+                "--list-versions",
+            ]
+        )
+        == 0
+    )
+
+
 def test_main_replay_quiet_and_summary(capsys, tmp_path):
     traj = tmp_path / "t.jsonl"
     traj.write_text(


### PR DESCRIPTION
## Summary
P1 item 6 (auto-capture + CLI): makes the versioned `BaselineStore` usable end to end.

- `BaselineCollector` accumulates `StepEvent`s during a healthy run and commits a versioned baseline on demand (the host owns the cadence). Fail-open: `commit()` with no store is a no-op.
- `snagline baseline` gains `--store-dir` / `--tenant` / `--deployment` / `--list-versions` / `--max-versions`; with `--store-dir` it stores versioned, per-tenant baselines via `BaselineStore` instead of a single file.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (184 passed, 1 skipped, 89% coverage) all green.