### PR TITLE
feat: monitor self-metrics + /metrics

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -28,6 +28,29 @@ from snagline.state import StateBackend, default_state_backend
 logger = logging.getLogger("snagline")
 
 
+class MonitorMetrics:
+    """Self-observability counters for a Monitor (P3, item 10).
+
+    Lets an operator see, without touching the host, how much traffic the
+    monitor is handling and whether its detectors/sinks are faulting. Counts
+    are incremented under a dedicated lock so concurrent ingest stays safe.
+    """
+
+    def __init__(self) -> None:
+        self.events_ingested = 0
+        self.risks_emitted = 0
+        self.detector_errors = 0
+        self.sink_errors = 0
+
+    def as_dict(self) -> dict:
+        return {
+            "events_ingested": self.events_ingested,
+            "risks_emitted": self.risks_emitted,
+            "detector_errors": self.detector_errors,
+            "sink_errors": self.sink_errors,
+        }
+
+
 class Monitor:
     """Runs every registered detector against each ingested event and
     dispatches any resulting ``FailureRisk`` to every registered sink.
@@ -56,6 +79,8 @@ class Monitor:
         # (issue #14) -- log each distinct fault exactly once.
         self._fault_lock = threading.Lock()
         self._fault_logged: set[str] = set()
+        self._metrics = MonitorMetrics()
+        self._metrics_lock = threading.Lock()
 
     def ingest(self, event: StepEvent) -> None:
         """Run all detectors against ``event`` and dispatch any risks.
@@ -74,6 +99,7 @@ class Monitor:
                 try:
                     risk = detector.observe(event)
                 except Exception:
+                    self._incr("detector_errors")
                     self._log_fault_once(
                         f"detector {getattr(detector, 'name', repr(detector))} "
                         "raised; ignoring (fail-open)"
@@ -83,6 +109,9 @@ class Monitor:
                     continue
                 if risk is not None:
                     risks.append(risk)
+        with self._metrics_lock:
+            self._metrics.events_ingested += 1
+            self._metrics.risks_emitted += len(risks)
         for risk in risks:
             self._dispatch(risk)
 
@@ -91,11 +120,21 @@ class Monitor:
             try:
                 sink.emit(risk)
             except Exception:
+                self._incr("sink_errors")
                 self._log_fault_once(
                     f"sink {type(sink).__name__} raised; ignoring (fail-open)"
                 )
                 if not self._fail_open:
                     raise
+
+    def _incr(self, name: str) -> None:
+        with self._metrics_lock:
+            setattr(self._metrics, name, getattr(self._metrics, name) + 1)
+
+    def metrics(self) -> dict:
+        """Return a snapshot of self-observability counters (P3, item 10)."""
+        with self._metrics_lock:
+            return self._metrics.as_dict()
 
     def _log_fault_once(self, key: str) -> None:
         """Log a fail-open fault, but only the first time we see this exact

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -7,6 +7,7 @@ shell script, a Claude Code hook) can POST ``StepEvent`` JSON to:
                                or a JSON array of StepEvent objects     (batched)
     POST /hooks/claude-code  body: a native Claude Code hook payload -> mapped + ingested
     GET  /health                                                     -> 200 OK
+    GET  /metrics                                                    -> self-observability counters
 
 POST bodies are capped at ``max_body_bytes`` (default 1 MB); larger payloads
 get 413. This keeps the sidecar safe to expose and able to absorb buffered
@@ -75,6 +76,8 @@ def make_handler(
         def do_GET(self) -> None:  # noqa: N802 - http.server naming
             if self.path == "/health":
                 self._respond(200, {"status": "ok"})
+            elif self.path == "/metrics":
+                self._respond(200, self.snagline_monitor.metrics())
             elif self.path == "/risks":
                 self._respond(200, {"risks": self.snagline_risks})
             else:

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -220,6 +220,36 @@ def test_health_open_without_token():
         server.server_close()
 
 
+def test_metrics_endpoint_reports_ingested_counts():
+    server, base = _start_server(_RecordingSink())
+    try:
+        event = {
+            "step_id": "0",
+            "episode_id": "ep-metrics",
+            "timestamp": 1718300000.0,
+            "action_type": "tool_call",
+            "action_signature": "aaaa1111bbbb2222",
+            "tool_name": "search",
+        }
+        req = urllib.request.Request(
+            base + "/events",
+            data=json.dumps(event).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            assert resp.status == 202
+        with urllib.request.urlopen(base + "/metrics", timeout=5) as resp:
+            assert resp.status == 200
+            body = json.loads(resp.read())
+        assert body["events_ingested"] >= 1
+        assert "risks_emitted" in body
+        assert "detector_errors" in body
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
 def test_unknown_paths_are_404():
     server, base = _start_server(_RecordingSink())
     try:


### PR DESCRIPTION
## Summary
P3 item 10 (partial): the monitor should observe itself, so operators can see ingest/risk volume and detector/sink fault counts without instrumenting the host.

- `Monitor` now tracks `events_ingested`, `risks_emitted`, `detector_errors`, and `sink_errors` under a dedicated lock; `Monitor.metrics()` returns a snapshot dict.
- The sidecar exposes `GET /metrics` (open, like `/health`) returning those counters as JSON.

## Verification
Local gate: `ruff check`, `ruff format --check`, `mypy src`, full `pytest` (185 passed, 1 skipped, 89% coverage) all green.