### PR TITLE
docs: integration matrix

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -102,11 +102,16 @@ enterprise-grade alerting. Concretely:
 
 4. **Pluggable state backend** (in-memory default, Redis/DB optional) so
    detector state and baselines survive restarts and span workers; shard the
-   lock by `episode_id` to remove the global ingest bottleneck.
+   lock by `episode_id` to remove the global ingest bottleneck. **Done:**
+   `StateBackend` (memory + optional Redis) + per-episode lock sharding (#44).
 5. **Alerting maturity:** dedup/cooldown (issue #4), severity, Slack and
-   PagerDuty sinks, batched and rate-limited async dispatch.
+   PagerDuty sinks, batched and rate-limited async dispatch. **Done:**
+   `DedupSink` + severity (#39, #40), `SlackSink`/`PagerDutySink` + CLI
+   exposure (#41-#43), `BatchingSink` (#48).
 6. **Baseline lifecycle:** auto-capture cadence, versioned store, per-tenant
-   baselines, scheduled retrain.
+   baselines, scheduled retrain. **Done (storage + collector + CLI):** versioned
+   per-tenant `BaselineStore`, `BaselineCollector`, and `snagline baseline
+   --store-dir` (#45, #46). Scheduled retrain remains a host-owned cadence.
 
 ### P2 (detection quality, the differentiator)
 
@@ -118,8 +123,10 @@ enterprise-grade alerting. Concretely:
 ### P3 (trust and observability)
 
 10. Monitor self-metrics (Prometheus), health endpoint, structured logs.
+    **Done (partial):** `Monitor.metrics()` counters + `GET /metrics` sidecar
+    endpoint (#47). Prometheus export and structured logging remain.
 11. Integration matrix document plus a prominent "10-line custom adapter"
-    path.
+    path. **Done:** `docs/INTEGRATION_MATRIX.md` (#49).
 
 ## Suggested starting point
 
@@ -149,11 +156,16 @@ item 5 (alerting dedup/cooldown + Slack/PagerDuty sinks).
   - #43 `feat/cli-sinks` - `--sink` exposes slack/pagerduty on watch/serve.
   - #44 `feat/state-backend-lock-sharding` - `StateBackend` (memory + optional
     Redis) and per-episode ingest lock sharding (removes the global lock).
-- **Remaining for true "attach anywhere":**
-  - P1 item 6: baseline lifecycle (auto-capture cadence, versioned store,
-    per-tenant baselines).
-  - P1 item 5 tail: batched/rate-limited async sink dispatch.
+  - #45 `feat/baseline-store` - versioned, per-tenant `BaselineStore`.
+  - #46 `feat/baseline-cli-store` - `BaselineCollector` + store-backed
+    `snagline baseline` CLI.
+  - #47 `feat/monitor-metrics` - `Monitor.metrics()` + `GET /metrics`.
+  - #48 `feat/batching-sink` - `BatchingSink` async/rate-limited dispatch.
+  - #49 `docs/integration-matrix` - `docs/INTEGRATION_MATRIX.md` (P3 item 11).
+- **Status: P0, P1, and most of P3 are complete.** Remaining:
+  - P1 item 6 tail: scheduled/automated retrain cadence (host-owned today).
+  - P3 item 10 tail: Prometheus export + structured logging for the monitor.
   - Actual PyPI upload (needs a token); in-process TLS (or documented
     reverse-proxy).
-  - Then P2 (ml/drift extras, calibration, eval harness) and P3 (self-metrics,
-    health endpoint, integration matrix).
+  - Then P2 (ml/drift extras, calibration, eval harness) - the research
+    differentiators that approach the paper's accuracy.

--- a/docs/INTEGRATION_MATRIX.md
+++ b/docs/INTEGRATION_MATRIX.md
@@ -1,0 +1,105 @@
+# SNAGLINE integration matrix
+
+How to attach SNAGLINE to any agent system. Everything below is
+dependency-free unless noted; the core is always zero-required-dependency.
+
+## Languages and runtimes
+
+| Path | Mechanism | Languages | Code change |
+|------|-----------|-----------|-------------|
+| HTTP sidecar | `snagline serve` + `POST /events` (or batched array) | any | none in host; send JSON |
+| Claude Code hooks | `snagline hook` as a `PostToolUse`/`PreToolUse` hook | any CLI agent | one hook line |
+| File / command bridge | `snagline watch --file` or `hook --out` | any | forward one JSON line |
+| Python auto-instrumentation | `snagline.auto` (OpenAI/Anthropic/LangChain) | Python | one import |
+| Framework adapters | `adapters.raw`, `langchain`, `langgraph`, `autogen`, `crewai`, `claude_code` | Python | wrap your loop |
+
+## Python auto-instrumentation (`snagline.auto`)
+
+Import-safe: a wrapper is a clean no-op when the SDK is absent, and handles
+sync + async clients.
+
+```python
+from snagline.auto import instrument_openai, instrument_anthropic, instrument_langchain
+from snagline.monitor import Monitor
+
+monitor = Monitor.default()          # or Monitor.default(config=Config.from_env())
+instrument_openai(monitor)           # patches openai.OpenAI / AsyncOpenAI globally
+instrument_anthropic(monitor)        # patches anthropic.Anthropic / AsyncAnthropic
+instrument_langchain(monitor)        # patches langchain BaseLLM / Chain entrypoints
+```
+
+## Framework adapters
+
+```python
+from snagline.adapters.raw import watch          # generic StepEvent stream
+from snagline.adapters.langchain import LLMChainObserver
+from snagline.adapters.langgraph import GraphObserver
+from snagline.adapters.autogen import SnaglineAutogenHandler
+from snagline.adapters.crewai import snagline_step_callback
+```
+
+Each adapter maps the framework's native callback/hook into a `StepEvent` and
+hands it to a `Monitor`. They are duck-typed so they work without the
+framework installed at import time.
+
+## Sinks (escalation)
+
+| Sink | Purpose | Deps |
+|------|---------|------|
+| `ConsoleSink` | local stderr | stdlib |
+| `WebhookSink` | POST `FailureRisk` JSON | stdlib |
+| `SlackSink` | Slack incoming webhook | stdlib |
+| `PagerDutySink` | PagerDuty Events API v2 | stdlib |
+| `DedupSink` | cooldown/dedup wrapper (issue #4) | stdlib |
+| `BatchingSink` | async, rate-limited dispatch | stdlib |
+
+CLI: `snagline watch --sink {console,webhook,slack,pagerduty}` (plus
+`--cooldown-seconds`, `--min-severity`). Wrap any sink in `DedupSink` and/or
+`BatchingSink` for storm protection and non-blocking delivery.
+
+## Configuration (12-factor)
+
+`Config.from_env()` / `Config.load_file()` / `Config.resolve()` layer
+built-in defaults -> config file -> `SNAGLINE_*` env vars. The CLI reads
+`--config <json|toml>` and `SNAGLINE_*` automatically.
+
+## State
+
+`Monitor` locks per `episode_id` via a `StateBackend`. `MemoryStateBackend`
+is the default; `RedisStateBackend` (optional, behind the `redis` extra)
+coordinates across workers.
+
+## Baselines
+
+`snagline baseline <traj>` fits a healthy-run profile. With `--store-dir`
+the profile is stored versioned and per-tenant via `BaselineStore`, and
+`BaselineCollector` captures one live during a healthy run. The goal-drift
+detector compares live traffic against it.
+
+## Write your own adapter in ~10 lines
+
+If your agent is not covered above, map each step to a `StepEvent` and feed
+it to a `Monitor`. Minimal example:
+
+```python
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+
+monitor = Monitor.default()  # fail-open by construction
+
+def observe(step_id, tool, latency_ms, error=False, episode_id="run"):
+    monitor.ingest(StepEvent(
+        step_id=step_id,
+        episode_id=episode_id,
+        timestamp=__import__("time").time(),
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", tool, step_id),
+        tool_name=tool,
+        latency_ms=latency_ms,
+        error=error,
+    ))
+```
+
+Call `observe(...)` once per tool/LLM call in your loop (or wrap the call).
+Detection and escalation happen automatically; a fault in detection never
+breaks your agent.


### PR DESCRIPTION
## Summary
Closes P3 item 11: a single document that makes "attach to any system" concrete.

- Adds `docs/INTEGRATION_MATRIX.md` covering every integration path (Python auto-instrumentation, framework adapters, HTTP sidecar, Claude Code hooks, file/command bridge), sinks, config, state, baselines, and a ~10-line custom-adapter recipe.
- Updates `docs/ATTACH_ANY_SYSTEM.md` to mark P1 (items 4-6) and P3 (items 10/11) as done with their PR numbers, and to record the remaining P2 research work.

Docs only; no code changes.