### PR TITLE
fix(error_cascade): re-arm dedupe flag when a cascade clears

### DIFF
--- a/src/snagline/detectors/error_cascade.py
+++ b/src/snagline/detectors/error_cascade.py
@@ -55,8 +55,8 @@ class ErrorCascadeDetector:
         )
         self._windows: dict[str, deque] = {}
         self._consecutive: dict[str, int] = {}
-        # Dedupe: emit at most once per cascade episode, then stay quiet until
-        # the alarm condition clears and re-arms (issue #4).
+        # Dedupe: emit at most once per cascade, then stay quiet until the alarm
+        # condition clears and re-arms (issue #4).
         self._fired: dict[str, bool] = {}
 
     def _is_error(self, event: StepEvent) -> bool:
@@ -87,6 +87,14 @@ class ErrorCascadeDetector:
         )
 
         if not (consecutive_alarm or density_alarm):
+            # The cascade cleared: re-arm so a later, independent cascade in the
+            # same episode escalates again (mirrors ``LoopDetector``). Without
+            # this the flag latches for the life of the episode, and a long-lived
+            # episode -- a user session, or a sidecar episode that never calls
+            # ``end_episode`` -- alerts exactly once, ever. A *sustained* cascade
+            # still emits only once (issue #4): the flag clears only when neither
+            # rule holds any more.
+            self._fired[event.episode_id] = False
             return None
         # Already escalated this cascade -- suppress until it clears.
         if self._fired.get(event.episode_id, False):

--- a/tests/detectors/test_error_cascade.py
+++ b/tests/detectors/test_error_cascade.py
@@ -61,3 +61,40 @@ def test_reset_clears_state():
     d.observe(_event(1, True))
     d.reset("ep")
     assert d.observe(_event(2, True)) is None
+
+
+def test_second_cascade_after_recovery_escalates_again():
+    # The dedupe flag must re-arm once the alarm clears, so a second,
+    # independent cascade in the same episode still alerts. A long-lived
+    # episode (a user session, or a sidecar episode that never calls
+    # end_episode) would otherwise be muted after its first cascade.
+    d = ErrorCascadeDetector(window_size=10, error_threshold=3, consecutive_threshold=3)
+    step = 0
+
+    def run(errors: list[bool]) -> list:
+        nonlocal step
+        out = []
+        for err in errors:
+            r = d.observe(_event(step, err))
+            step += 1
+            if r is not None:
+                out.append(r)
+        return out
+
+    first = run([True] * 3)
+    assert len(first) == 1, "first cascade must escalate exactly once"
+
+    # Full recovery: enough clean steps to flush every error out of the window.
+    assert run([False] * 15) == [], "healthy recovery must stay silent"
+
+    second = run([True] * 3)
+    assert len(second) == 1, "second cascade after recovery must escalate again"
+    assert second[0].trigger == "error_cascade"
+
+
+def test_sustained_cascade_still_escalates_only_once():
+    # Guard the issue #4 property the dedupe flag exists for: while the alarm
+    # condition holds, the detector must not re-fire on every step.
+    d = ErrorCascadeDetector(window_size=10, error_threshold=3, consecutive_threshold=3)
+    risks = [d.observe(_event(i, True)) for i in range(30)]
+    assert len([r for r in risks if r is not None]) == 1


### PR DESCRIPTION
Fixes #57

## Summary of Changes

`ErrorCascadeDetector`'s `_fired` dedupe flag was set on escalation but never cleared, so it latched for the life of an episode: only the **first** cascade ever alerted, and every later independent cascade was silently dropped — even after the agent had fully recovered in between.

The fix clears the flag on the already-existing "alarm cleared" branch of `observe()`, mirroring the equivalent re-arm in `LoopDetector.observe()`:

```python
 if not (consecutive_alarm or density_alarm):
+    self._fired[event.episode_id] = False
     return None
```

**Root cause.** The flag was introduced for issue #4 (alert spam: one risk per step during a sustained cascade). It was set to `True` on escalation and cleared only by `reset(episode_id)`. The `not (consecutive_alarm or density_alarm)` early return — the one branch that means *"the cascade is over"* — did not re-arm it. `LoopDetector` does re-arm on its corresponding branch (`if count < self.repeat_threshold: self._fired[...] = False`), which is the asymmetry that identified this as unintended. The flag's own comment already promised the missing behaviour: *"stay quiet until the alarm condition clears and re-arms"*.

Because the defect is an **absent statement** rather than an untaken branch, `error_cascade.py` reported 100% line *and* branch coverage while carrying it.

## Justification

The affected paths are the long-lived ones, which is where the detector matters most:

- `README.md` defines an episode as *"a single agent run, **a user session**"*. Any session-scoped episode spanning several task attempts alerted only on its first cascade.
- The sidecar (`snagline serve`, `POST /events`) never calls `end_episode` — `grep -rn "end_episode" src/` shows callers only in the framework adapters, `raw.watch`, and the `replay` / `watch` CLI commands. For an external agent posting a session-scoped `episode_id`, the mute lasted for the life of the server process.
- `snagline watch --follow` tears down one episode id derived from `--episode-id`/filename, which need not match the episode ids carried in the ingested JSON lines.

Net effect: an agent that fails, recovers, then fails again reported only the first failure — a false negative in one of the two headline detectors. The dedupe intent (don't page per step) is preserved; only the permanent latch is removed. `DedupSink` remains the time-based rate limiter for operators who want fewer than one alert per incident.

Nothing else changes: no new dependencies, no public API change, no `StepEvent.metadata` access, still O(1) per step (one dict store on the clean path), fail-open untouched.

## Kind of Contribution

Bug Fix, Tests

## Benchmark (for Performance Improvements)

Not a performance change, but it adds one dict store to the per-step clean path, so I measured it. `python benchmarks/overhead_benchmark.py`, 200,000 steps, two runs each, same machine (Windows 11, Python 3.13.1):

| | median µs/step | p99 µs/step |
|---|---|---|
| before (`f1aabbc`) | 2.97 / 3.02 | 4.01 / 3.40 |
| after | 3.02 / 2.99 | 4.02 / 4.54 |

Median is unchanged within run-to-run variance on this machine; the p99 spread is larger than the effect being measured, so I would not read a regression into it.

I also measured the alert rate over 1000-step synthetic streams to confirm issue #4 does not come back:

| pattern | alerts / 1000 steps |
|---|---|
| all errors (sustained cascade) | 1 |
| all clean (healthy) | 0 |
| 1 error in 10 (isolated) | 0 |
| alternating error/clean | 1 |
| 3 errors then 7 clean, repeating | 1 |
| 3 errors then 20 clean, repeating | 44 |

The 44 is one alert per genuinely distinct incident (43 separate cascades, each with a full recovery between them) — not one per step, which is what issue #4 was about and would have been up to 1000 here.

## Unit Tests:

Two tests added to `tests/detectors/test_error_cascade.py`, following the existing synthetic-sequence shape in that file:

- `test_second_cascade_after_recovery_escalates_again` — cascade → 15 clean steps (window fully flushed) → second cascade. Asserts one risk for each and silence during recovery. **Fails on `master`** with `AssertionError: second cascade after recovery must escalate again / assert 0 == 1`; passes with the fix.
- `test_sustained_cascade_still_escalates_only_once` — 30 consecutive error steps produce exactly 1 risk, pinning the issue #4 property the flag exists for so this fix cannot regress it.

## Execution Tests:

Commands run locally against `f1aabbc` + this commit (Python 3.13.1, `pip install -e . --no-deps`):

```
pytest tests/detectors/test_error_cascade.py -q      ->  6 passed
pytest tests/test_issue_regressions.py tests/detectors/ -q  -> 25 passed
pytest tests/ -q                                    ->  189 passed, 1 skipped, 1 failed
ruff check src tests                                ->  All checks passed!
ruff format --check src tests                       ->  71 files already formatted
mypy src                                            ->  Success: no issues found in 37 source files
coverage                                            ->  88.19% (gate: 80%)
```

The one failure is pre-existing and unrelated — `tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` fails identically on unmodified `master` on Windows, because `Popen.send_signal(signal.SIGINT)` raises `ValueError: Unsupported signal: 2` there. CI runs `ubuntu-latest`, where it passes.

End-to-end behaviour:

- **CLI**: `snagline replay tests/fixtures/trajectories/injected_error_cascade.jsonl` still reports the cascade (`{"trigger": "error_cascade", "detail": "3 consecutive errors", ...}`); `snagline replay .../healthy_run.jsonl` stays silent. The `healthy_run` fixture produces 0 risks from this detector, per the `DETECTOR_GUIDE.md` no-false-positives bar.
- **Monitor + sink**: a single long-lived episode (`session-42`) driven through `Monitor.default()` with the sequence `3 errors → 15 clean → 4 errors → 15 clean → 3 errors` now delivers **3** `error_cascade` risks to the sink (steps 2, 20, 39). On `master` it delivers 1.

Fail-open verification (`Monitor.default()`, `fail_open=True`):

- Malformed / boundary events through `observe()` — empty `action_type` and `action_signature`, empty `episode_id`, `NaN` timestamp, `inf` latency: no exception.
- `reset()` on an unknown episode, and repeated `reset()`: no exception.
- A sink raising on **both** cascades: host unaffected, `monitor.metrics()` reports `sink_errors: 3`, nothing propagates.
- `Monitor(..., fail_open=False)` still propagates as documented, so the strict-mode contract is unchanged.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error-cascade alerts can now trigger again after the system fully recovers and a new cascade begins.
  * Ongoing cascades continue to generate only one alert, reducing duplicate notifications.

* **Tests**
  * Added coverage for re-triggering after recovery and suppressing repeated alerts during sustained cascades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->