### PR TITLE
ci(welcome): fix first-interaction v3 input names

### DIFF
--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
       - uses: actions/first-interaction@v3
         with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: |
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          issue_message: |
             Thanks for opening your first issue in SNAGLINE.
 
             Taking the time to write up a problem you found is a real
@@ -24,7 +24,7 @@ jobs:
             If you can add reproduction steps and your Python version, that
             helps a maintainer dig in faster. Someone will take a look soon,
             so keep an eye on this thread.
-          pr-message: |
+          pr_message: |
             Thanks for your first pull request to SNAGLINE.
 
             Getting a change from idea to open PR is the hard part, and you


### PR DESCRIPTION
Dependabot bumped actions/first-interaction v1 -> v3, which renamed inputs from kebab-case (repo-token, issue-message, pr-message) to snake_case (repo_token, issue_message, pr_message). The welcome workflow still passed the old names, so every new PR/issue failed the Welcome check with: `Input required and not supplied: issue_message`.

Renames the inputs to match v3.