### PR TITLE
ci(auto-assign): grant issues:write for addAssignees API

### DIFF
--- a/.github/workflows/auto-assign.yml
+++ b/.github/workflows/auto-assign.yml
@@ -8,6 +8,7 @@ jobs:
   assign:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
       - name: Assign PR to owner


### PR DESCRIPTION
The assign job calls `issues.addAssignees` but only declared `pull-requests: write`. Explicitly scoping permissions without `issues: write` makes the issues API return 403 (Resource not accessible by integration) on every new PR. Adds the missing scope.