### PR TITLE
fix(crewai): key action_signature on tool_input, not step output

### DIFF
--- a/src/snagline/adapters/crewai.py
+++ b/src/snagline/adapters/crewai.py
@@ -25,6 +25,7 @@ the adapter stays loosely coupled to a specific CrewAI release.
 from __future__ import annotations
 
 import itertools
+import json
 import time
 from collections.abc import Callable
 from typing import Any
@@ -67,6 +68,39 @@ def _extract_text(step: dict[str, Any]) -> str:
     return ""
 
 
+def _extract_tool_input(step: dict[str, Any]) -> str | None:
+    """Canonical form of the tool arguments, or ``None`` when unavailable.
+
+    The arguments -- not the model's prose -- are what make two tool calls "the
+    same attempt" (see ``make_signature`` and docs/ADAPTER_GUIDE.md). CrewAI
+    exposes them on the step itself or nested under ``action``, so mirror the
+    dual lookup :func:`_extract_tool_name` already does. ``sort_keys`` matches
+    the canonicalization the Claude Code adapter uses, so a dict payload hashes
+    the same regardless of key order.
+
+    A payload JSON cannot represent (unorderable key types, a reference cycle,
+    an arbitrary object) yields ``None`` so the caller keeps its previous stable
+    part. Serializing is deliberately strict rather than falling back to
+    ``str``: the default repr of an object embeds its memory address, which
+    would vary per attempt and defeat loop detection all over again.
+    """
+    action = step.get("action") if isinstance(step.get("action"), dict) else None
+    for src in (action, step):
+        if src is None:
+            continue
+        val = src.get("tool_input")
+        if val is None:
+            continue
+        try:
+            return json.dumps(val, sort_keys=True)
+        except Exception:
+            # _map_step runs in the framework's thread, before Monitor.ingest
+            # and therefore outside its fail-open guard, so an exotic payload
+            # must never propagate into the host agent.
+            return None
+    return None
+
+
 def _map_step(
     step: Any,
     *,
@@ -86,7 +120,17 @@ def _map_step(
     action: dict[str, Any] = raw_action if isinstance(raw_action, dict) else {}
     if latency is None:
         latency = action.get("latency_ms")
-    sig = make_signature(action_type, tool_name, text or str(d))
+    # Key the signature on the *attempt* -- tool plus arguments -- never on the
+    # step's output. Model prose is re-worded on every retry, so hashing it made
+    # a stuck loop look like a stream of unique actions, while omitting the
+    # arguments collapsed a legitimate iteration into one signature (issue #61).
+    # Non-tool steps carry no argument payload, so they keep hashing the text.
+    tool_args = _extract_tool_input(d)
+    if action_type == "tool_call" and tool_args is not None:
+        stable = tool_args
+    else:
+        stable = text or str(d)
+    sig = make_signature(action_type, tool_name, stable)
     return StepEvent(
         step_id=step_id,
         episode_id=episode_id,

--- a/tests/test_adapters_autogen_crewai.py
+++ b/tests/test_adapters_autogen_crewai.py
@@ -6,6 +6,8 @@ import asyncio
 
 from snagline.adapters.autogen import SnaglineAutogenHandler, run_and_monitor
 from snagline.adapters.crewai import observe_crewai_step, snagline_step_callback
+from snagline.detectors.loop import LoopDetector
+from snagline.monitor import Monitor
 
 
 class _Collector:
@@ -216,3 +218,75 @@ def test_crewai_callback_close_ends_episode():
     cb.close()
     assert mon.ended == ["ep-7"]
     assert len(mon.events) == 1
+
+
+def _crewai_step(tool_input, text, tool="search"):
+    # Shape of crewai.agents.parser.AgentAction: the raw LLM block lands in
+    # ``text``, the argument payload in ``tool_input``.
+    return {"tool": tool, "tool_input": tool_input, "text": text}
+
+
+def test_crewai_signature_is_stable_across_reworded_prose():
+    # Issue #61: the signature must come from the tool arguments, not the step
+    # output. A stuck agent retries the identical call while the model re-words
+    # its thought each attempt; if that prose feeds the hash, every retry looks
+    # unique and the loop detector never fires.
+    mon = _Collector()
+    args = '{"query": "Q3 revenue"}'
+    first = observe_crewai_step(  # noqa: F821
+        mon, "ep", _crewai_step(args, "Thought: let me search for that")
+    )
+    second = observe_crewai_step(  # noqa: F821
+        mon, "ep", _crewai_step(args, "Thought: the search failed, retrying")
+    )
+    assert first.action_signature == second.action_signature
+    # The nested ``action`` dict shape must resolve to the same signature.
+    nested = observe_crewai_step(  # noqa: F821
+        mon,
+        "ep",
+        {"action": {"tool": "search", "tool_input": args}, "text": "unrelated prose"},
+    )
+    assert nested.action_signature == first.action_signature
+
+
+def test_crewai_different_tool_inputs_have_different_signatures():
+    # Issue #61, other direction: leaving the arguments out entirely collapses a
+    # legitimate iteration over distinct inputs into one signature, which the
+    # loop detector then reports as a loop. Same prose, different arguments.
+    mon = _Collector()
+    text = "Thought: look up the next city"
+    a = observe_crewai_step(mon, "ep", _crewai_step('{"q": "Paris"}', text))  # noqa: F821
+    b = observe_crewai_step(mon, "ep", _crewai_step('{"q": "Berlin"}', text))  # noqa: F821
+    assert a.action_signature != b.action_signature
+
+
+def test_crewai_stuck_tool_loop_escalates_end_to_end():
+    # The user-visible consequence, through a real Monitor and LoopDetector: an
+    # agent that keeps issuing the same call with the same arguments must
+    # escalate exactly once (the dedupe from issue #4 keeps it to one).
+    risks = []
+
+    class _Sink:
+        def emit(self, risk):
+            risks.append(risk)
+
+    monitor = Monitor([LoopDetector()], [_Sink()])
+    cb = snagline_step_callback(monitor, "ep-stuck")  # noqa: F821
+    for i in range(5):
+        cb(_crewai_step('{"query": "Q3 revenue"}', f"Thought: attempt {i}"))
+    assert [r.trigger for r in risks] == ["loop"]
+
+
+def test_crewai_exotic_tool_input_does_not_raise_into_the_host():
+    # Mapping runs in the framework's thread, before Monitor.ingest and so
+    # outside its fail-open guard. A payload JSON cannot canonicalize (unorderable
+    # key types, a reference cycle, an arbitrary object) must fall back to the
+    # previous stable part rather than surface inside the user's agent.
+    mon = _Collector()
+    cb = snagline_step_callback(mon, "ep-odd")  # noqa: F821
+    cycle: dict = {"a": None}
+    cycle["a"] = cycle
+    for payload in ({1: "a", "b": 2}, cycle, {"x", "y"}, object()):
+        cb({"tool": "search", "tool_input": payload, "text": "prose"})
+    assert len(mon.events) == 4
+    assert all(ev.action_signature for ev in mon.events)


### PR DESCRIPTION
## Summary of Changes

`adapters/crewai.py` built `action_signature` from the step's **output** text:

```python
sig = make_signature(action_type, tool_name, text or str(d))   # _map_step, line 89
```

`_extract_text` reads `("text", "thought", "output", "content", "result")`. On CrewAI's `AgentAction`, `text` is the raw LLM block and `thought` is model prose — both re-worded on every attempt — while `tool_input`, the argument payload, was never read by the adapter at all.

This change adds `_extract_tool_input` and uses the arguments as the stable part for tool calls:

```python
tool_args = _extract_tool_input(d)
if action_type == "tool_call" and tool_args is not None:
    stable = tool_args
else:
    stable = text or str(d)
sig = make_signature(action_type, tool_name, stable)
```

`_extract_tool_input` mirrors the dual lookup `_extract_tool_name` already does (top-level `tool_input`, or nested under `action`), and canonicalizes with `json.dumps(..., sort_keys=True)` — the same treatment `adapters/claude_code.py:116` applies. Non-tool `agent_step` events carry no argument payload, so that path is untouched.

Two deliberate details:

- **Strict serialization, not `default=str`.** An arbitrary object's default repr embeds its memory address (`<Foo object at 0x…>`), which varies per instance and would have re-introduced the exact volatility this PR removes.
- **A payload JSON cannot represent returns `None`** and the caller keeps the previous stable part. `_map_step` runs in CrewAI's thread *before* `Monitor.ingest`, so it is outside the fail-open guard — an unorderable key type, a reference cycle, or an exotic object must not surface inside the user's agent. Verified below.

No public API change, no new dependency (`json` is stdlib), and nothing persists `action_signature` (neither `baseline.py` nor `baseline_store.py` stores it), so this is not a stored-format change.

## Justification

Fixes #61. `docs/ADAPTER_GUIDE.md` has a section named "Signature rules (the part people get wrong)" listing two failure modes, and this adapter hit **both**:

> Including them makes every retry look unique and silently defeats loop detection. (Excluding them entirely is equally wrong in the other direction - a constant `args=""` makes *every* LLM call look like a loop …)

1. **False negative** — an agent retrying the identical call with identical `tool_input` got a fresh signature every attempt, because the model re-words its thought. `LoopDetector` never fired. That is precisely the scenario the detector exists to catch.
2. **False positive** — with the arguments excluded, an agent whose prose is templated but whose arguments differ each step collapsed to one signature and was reported as a loop.

Both are silent: nothing raises, nothing logs, and the monitor's metrics look normal, so a CrewAI user has no signal that tier-1 detection is degraded. CrewAI is a documented, advertised integration (`README.md:255`, `docs/ADAPTER_GUIDE.md:64`, the `crewai` extra).

The fix also brings the adapter in line with every sibling, which all hash the input:

| adapter | stable part hashed |
| --- | --- |
| `adapters/raw.py:36` | `str(args)` |
| `adapters/langchain_adapter.py:73` | `str(args)` |
| `adapters/autogen.py:119` | `args` |
| `adapters/claude_code.py:116` | `json.dumps(payload.get("tool_input") or {}, sort_keys=True)` |
| `adapters/crewai.py` | **was** the step output — now `tool_input` |

and makes the module docstring's existing claim that it reads `tool_input` (lines 20–22) true.

## Kind of Contribution

Bug Fix, Tests

## Benchmark

The core ingest path is not touched by this diff — only `adapters/crewai.py` changed — so `benchmarks/overhead_benchmark.py` cannot move here. Three runs on this branch for the noise band, so the claim is checkable rather than asserted:

```
median 2.91 us/step, p99 4.94
median 2.91 us/step, p99 3.76
median 2.99 us/step, p99 5.90
```

The function that *did* change is `_map_step`, so I measured it directly (20k calls x 7 repeats, median of per-call medians, same machine, before = `c2390af`):

| payload | before | after | delta |
| --- | --- | --- | --- |
| `tool_input` as dict | 5.469 us | 7.965 us | +2.50 us |
| `tool_input` as str | 5.417 us | 6.673 us | +1.26 us |

That is one additional `json.dumps` per tool-call step. It fires once per agent step — a step that contains an LLM round-trip of roughly 10^5–10^6 us — so the added cost is about one part in 10^5 of the smallest realistic step, against restoring a detector that was silently inert.

I considered short-circuiting `isinstance(val, str)` past `json.dumps` to recover most of that, and rejected it: `tool_input="{}"` would then produce the same signature as `tool_input={}`, and `make_signature`'s docstring calls out exactly that ambiguity class (issue #15). Not worth trading a correctness guarantee for microseconds on this path. Happy to revisit if you would rather have the cycles.

## Unit Tests

Four tests added to `tests/test_adapters_autogen_crewai.py`. The existing CrewAI tests cover `action_type`, `tool_name`, `error`, and `latency_ms` but make no assertion about `action_signature`, which is why this went unnoticed — every other adapter has that assertion (`tests/adapters/test_raw_adapter.py:42`, `test_langgraph_adapter.py:62-65`, `test_claude_code_adapter.py:69,78`).

- `test_crewai_signature_is_stable_across_reworded_prose` — same tool + same `tool_input`, different prose ⇒ same signature; also asserts the nested `action` dict shape resolves identically.
- `test_crewai_different_tool_inputs_have_different_signatures` — identical prose, different arguments ⇒ different signatures (the false-positive direction).
- `test_crewai_stuck_tool_loop_escalates_end_to_end` — through a real `Monitor` + `LoopDetector`, a stuck agent escalates exactly once (also pins the issue #4 dedupe).
- `test_crewai_exotic_tool_input_does_not_raise_into_the_host` — unorderable keys, a reference cycle, a set, and a bare `object()` all map without raising.

All three of the first tests fail on `c2390af` and pass with the fix:

```
$ python -m pytest tests/test_adapters_autogen_crewai.py -q -k "signature or stuck"   # before
FAILED tests/test_adapters_autogen_crewai.py::test_crewai_signature_is_stable_across_reworded_prose
FAILED tests/test_adapters_autogen_crewai.py::test_crewai_different_tool_inputs_have_different_signatures
FAILED tests/test_adapters_autogen_crewai.py::test_crewai_stuck_tool_loop_escalates_end_to_end
3 failed, 15 deselected

# the end-to-end one before the fix:
>       assert [r.trigger for r in risks] == ["loop"]
E       AssertionError: assert [] == ['loop']
```

Full CI steps, run locally against `c2390af` + this commit:

```
$ ruff check src tests                 -> All checks passed!
$ ruff format --check src tests        -> 71 files already formatted
$ mypy src                             -> Success: no issues found in 37 source files
$ python -m pytest tests/ -q           -> 1 failed, 191 passed, 1 skipped
                                          Total coverage: 88.41% (was 88.19%)
```

The one failure is `tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines`, which is **pre-existing and unrelated**: it fails identically on a clean `c2390af` with `ValueError: Unsupported signal: 2`, because `subprocess.send_signal(SIGINT)` is unsupported on Windows, which is my local platform. CI runs `ubuntu-latest`, where it passes. I am not claiming green CI here — as a first-time contributor these workflows need a maintainer's "Approve and run workflows" click.

`adapters/crewai.py` coverage is 86%; the uncovered lines (39–47) are the pre-existing `_to_dict` fallbacks, not new code. `_extract_tool_input` is fully covered.

## Execution Tests

End to end through the real adapter and a real `Monitor`, modelling the shape of `crewai.agents.parser.AgentAction` (no CrewAI install needed — the adapter is duck-typed). Full script in #61.

| scenario | expected | before | after |
| --- | --- | --- | --- |
| stuck agent, 6x identical `tool_input`, re-worded thought | ≥1 loop risk | **0 risks**, 6/6 distinct signatures | 1 risk, 1/6 distinct |
| control: identical prose too | ≥1 loop risk | 1 risk | 1 risk |
| legitimate iteration, 6 different `tool_input` | 0 risks | **1 risk**, 1/6 distinct | 0 risks, 6/6 distinct |
| two steps differing only in `tool_input` | different signatures | **identical** | different |

The control row is the point: with the prose pinned identical the detector fired normally even before the fix, so the detector and the wiring were always fine — only the choice of stable part in `_map_step` was wrong.

Fail-open check, since this change puts a `json.dumps` on a path outside `Monitor`'s guard — each of these was ingested through `snagline_step_callback` and none raised:

```
  OK  mixed-type dict keys + sort_keys
  OK  circular reference
  OK  object with a raising __str__
  OK  set (not JSON-serializable)
  OK  bytes / None / empty dict / empty string / zero
  OK  nested dict, keys out of order   -> same signature regardless of key order
```

On `c2390af` + my first draft (which used `default=str`) the first three of those raised `TypeError`, `ValueError`, and `ZeroDivisionError` straight into the caller; the strict-with-fallback form above is why the final version does not.
