### PR TITLE
fix(claude-code): preserve tool latency through ingest_payload

### DIFF
--- a/src/snagline/adapters/claude_code.py
+++ b/src/snagline/adapters/claude_code.py
@@ -27,6 +27,7 @@ signature, never ``metadata``.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import time
 import uuid
@@ -60,22 +61,49 @@ class HookTracker:
     and defensive: malformed payloads never raise out of ``note``/``latency``.
     """
 
-    def __init__(self, clock=None) -> None:
+    def __init__(
+        self,
+        clock=None,
+        ttl_seconds: float = 600.0,
+        max_pending: int = 1024,
+    ) -> None:
         self._clock = clock or time.monotonic
         self._starts: dict[str, float] = {}
+        self._ttl = ttl_seconds
+        self._max_pending = max_pending
 
     def note(self, payload: dict) -> None:
+        """Record a ``PreToolUse`` start, or retire a paired start.
+
+        Call this *after* the payload has been mapped: it pops the start, so
+        reading the latency afterwards would always see ``None`` (issue #64).
+        """
         event = payload.get("hook_event_name")
         tool_use_id = payload.get("tool_use_id")
         if not isinstance(tool_use_id, str):
             return
+        now = self._clock()
         if event == "PreToolUse":
-            self._starts[tool_use_id] = self._clock()
+            self._starts[tool_use_id] = now
         else:
             self._starts.pop(tool_use_id, None)
-        # Bound memory: drop stale starts older than 10 minutes.
-        if len(self._starts) > 256:
-            self._starts.clear()
+        if len(self._starts) > self._max_pending:
+            self._evict(now)
+
+    def _evict(self, now: float) -> None:
+        """Bound memory by age, so a tool still running keeps its start.
+
+        A ``PreToolUse`` whose ``PostToolUse`` never arrives (crashed tool,
+        dropped hook) would otherwise leak. Drop those by age first; only if
+        nothing is actually stale do we shed the oldest half, which keeps the
+        newest -- still pairable -- starts.
+        """
+        cutoff = now - self._ttl
+        for key in [k for k, started in self._starts.items() if started < cutoff]:
+            del self._starts[key]
+        if len(self._starts) > self._max_pending:
+            by_age = sorted(self._starts.items(), key=lambda kv: kv[1])
+            self._starts = dict(by_age[len(by_age) // 2 :])
 
     def latency_ms(self, payload: dict) -> float | None:
         tool_use_id = payload.get("tool_use_id")
@@ -94,9 +122,12 @@ def payload_to_event(
 ) -> StepEvent | None:
     """Map one Claude Code hook payload to a ``StepEvent`` (or ``None``).
 
-    ``tracker`` is consulted for latency: call ``tracker.note(payload)`` on
-    every payload (including unmapped ones), then this function fills
-    ``latency_ms`` on ``PostToolUse`` events.
+    ``tracker`` is consulted for latency: map the payload with this function
+    first, then call ``tracker.note(payload)``. ``note`` retires the paired
+    ``PreToolUse`` start, so noting before mapping loses the latency entirely
+    (issue #64). ``latency_ms`` is filled only on the events that *end* a tool
+    call (``PostToolUse`` / ``PostToolUseFailure``); a ``PreToolUse`` has not
+    run yet and therefore has no duration.
     """
     mapped = _EVENT_MAP.get(str(payload.get("hook_event_name")))
     if mapped is None:
@@ -131,8 +162,13 @@ def payload_to_event(
             else (str(err) if err else payload.get("hook_event_name"))
         )
 
+    # Only the event that *ends* a tool call has a duration; PreToolUse fires
+    # before the tool runs, so asking the tracker there would read the start it
+    # just wrote and report a bogus 0.0 ms (issue #64).
     latency_ms = (
-        tracker.latency_ms(payload) if tracker is not None and is_tool else None
+        tracker.latency_ms(payload)
+        if tracker is not None and is_tool and subkind == "end"
+        else None
     )
 
     return StepEvent(
@@ -154,18 +190,25 @@ def payload_to_event(
 def ingest_payload(
     monitor: Any, payload: dict, tracker: HookTracker | None = None
 ) -> StepEvent | None:
-    """Convenience: note the payload on ``tracker`` and ingest the mapped event.
+    """Convenience: map the payload, ingest it, then note it on ``tracker``.
 
     Returns the event that was ingested, or ``None`` for unmapped events.
     Never raises: mapping/ingest failures are the Monitor's fail-open concern,
     and a bridge must not break the host process.
+
+    Order matters. ``tracker.note`` retires the ``PreToolUse`` start that
+    ``payload_to_event`` needs to compute ``latency_ms``, so mapping happens
+    first and the tracker is updated afterwards -- in a ``finally`` so an
+    unmapped or malformed payload still advances the tracker (issue #64).
     """
     try:
-        if tracker is not None:
-            tracker.note(payload)
         event = payload_to_event(payload, tracker=tracker)
         if event is not None:
             monitor.ingest(event)
         return event
     except Exception:
         return None
+    finally:
+        if tracker is not None:
+            with contextlib.suppress(Exception):
+                tracker.note(payload)

--- a/tests/adapters/test_claude_code_adapter.py
+++ b/tests/adapters/test_claude_code_adapter.py
@@ -11,7 +11,9 @@ from snagline.adapters.claude_code import (
     is_claude_code_payload,
     payload_to_event,
 )
+from snagline.config import Config
 from snagline.events import StepEvent
+from snagline.monitor import Monitor
 from snagline.risk import FailureRisk
 
 
@@ -106,6 +108,91 @@ def test_tracker_pairs_pre_and_post_for_latency():
     ev = payload_to_event(_tool_payload("PostToolUse"), tracker=tracker)
     assert ev is not None
     assert ev.latency_ms == 250.0
+
+
+def test_ingest_payload_preserves_latency_on_the_shipped_path():
+    # Issue #64: ingest_payload used to call tracker.note() *before* mapping,
+    # and note() retires the paired PreToolUse start -- so every PostToolUse
+    # came out with latency_ms=None. Assert through ingest_payload (the path
+    # `snagline hook` and POST /hooks/claude-code actually take), not through a
+    # hand-sequenced payload_to_event call.
+    clock = {"now": 0.0}
+    tracker = HookTracker(clock=lambda: clock["now"])
+    m = _RecordingMonitor()
+    ingest_payload(m, _tool_payload("PreToolUse"), tracker)
+    clock["now"] = 0.25
+    ingest_payload(m, _tool_payload("PostToolUse"), tracker)
+    assert [e.latency_ms for e in m.events] == [None, 250.0]
+
+
+def test_pretooluse_carries_no_latency():
+    # Issue #64: PreToolUse fires before the tool runs. Reporting 0.0 ms poisons
+    # the CUSUM baseline with synthetic zeros; it must be None.
+    clock = {"now": 0.0}
+    tracker = HookTracker(clock=lambda: clock["now"])
+    m = _RecordingMonitor()
+    ingest_payload(m, _tool_payload("PreToolUse"), tracker)
+    assert m.events[0].latency_ms is None
+
+
+def test_post_tool_use_failure_also_carries_latency():
+    # A tool that fails still took time; the CUSUM detector must see it.
+    clock = {"now": 0.0}
+    tracker = HookTracker(clock=lambda: clock["now"])
+    m = _RecordingMonitor()
+    ingest_payload(m, _tool_payload("PreToolUse"), tracker)
+    clock["now"] = 1.5
+    ingest_payload(m, _tool_payload("PostToolUseFailure", error="exit 1"), tracker)
+    assert m.events[-1].latency_ms == 1500.0
+    assert m.events[-1].error is True
+
+
+def test_hook_latency_reaches_the_cusum_detector():
+    # Issue #64, end to end: a healthy 100ms baseline followed by a 30s call
+    # must raise a latency_anomaly risk through the real Monitor.
+    risks: list[FailureRisk] = []
+
+    class _Sink:
+        def emit(self, risk: FailureRisk) -> None:
+            risks.append(risk)
+
+    monitor = Monitor.default(config=Config(), sinks=[_Sink()])
+    clock = {"now": 0.0}
+    tracker = HookTracker(clock=lambda: clock["now"])
+
+    def call(i: int, duration_s: float) -> None:
+        p = _tool_payload("PreToolUse", tool_use_id=f"toolu_{i}")
+        p["tool_input"] = {"command": f"step-{i}"}
+        ingest_payload(monitor, p, tracker)
+        clock["now"] += duration_s
+        ingest_payload(monitor, {**p, "hook_event_name": "PostToolUse"}, tracker)
+
+    for i in range(10):
+        call(i, 0.100)
+    call(99, 30.0)
+    assert [r.trigger for r in risks if r.trigger == "latency_anomaly"], (
+        "a 30s tool call after a 100ms baseline must trip the CUSUM detector"
+    )
+
+
+def test_tracker_evicts_stale_starts_by_age_not_wholesale():
+    # Issue #64: the old eviction cleared the whole dict once it passed 256
+    # entries, dropping fresh in-flight starts along with stale ones despite a
+    # comment promising an age-based policy.
+    clock = {"now": 0.0}
+    tracker = HookTracker(clock=lambda: clock["now"], ttl_seconds=600.0, max_pending=8)
+    for i in range(9):  # 9 unpaired PreToolUse starts, all abandoned
+        tracker.note(_tool_payload("PreToolUse", tool_use_id=f"stale_{i}"))
+    clock["now"] = 601.0  # every start above is now past the TTL
+    fresh = _tool_payload("PreToolUse", tool_use_id="fresh")
+    for i in range(9, 18):
+        tracker.note(_tool_payload("PreToolUse", tool_use_id=f"more_{i}"))
+    tracker.note(fresh)
+    clock["now"] = 601.5
+    ev = payload_to_event(_tool_payload("PostToolUse", tool_use_id="fresh"), tracker)
+    assert ev is not None
+    assert ev.latency_ms == 500.0, "a fresh in-flight start must survive eviction"
+    assert not any(k.startswith("stale_") for k in tracker._starts)
 
 
 def test_user_prompt_submit_maps_and_repeats_are_detectable():


### PR DESCRIPTION
## Summary of Changes

`ingest_payload` called `tracker.note(payload)` **before** mapping the payload.
`HookTracker.note` retires the paired `PreToolUse` start, so by the time
`payload_to_event` asked the tracker for a duration the start was already gone
and `latency_ms` came back `None`. The tracker lookup was gated on `is_tool`,
which is `True` for `PreToolUse` too, so that half reported a synthetic `0.0` ms
(the start had just been written with the same clock reading).

This PR:

- **Maps first, then notes**, with the `note` call in a `finally` so an unmapped
  or malformed payload still advances the tracker.
- **Restricts the latency lookup to the `"end"` subkind** that `_EVENT_MAP`
  already distinguishes, so `PreToolUse` reports `latency_ms=None` instead of
  `0.0`.
- **Replaces `_starts.clear()` with the age-based eviction the comment already
  promised.** The old policy dropped the whole dict once it passed 256 entries,
  discarding fresh in-flight starts along with abandoned ones. Now stale entries
  go by TTL first, and only if nothing is actually stale does it shed the oldest
  half.

Fixes #64

## Justification

`LatencyAnomalyDetector` is one of the three tier-1 detectors `Monitor.default`
wires up. Because every `PostToolUse` arrived with `latency_ms=None` and every
`PreToolUse` with `0.0`, the detector's entire Welford baseline was synthetic
zeros and it never observed a real tool duration. A tool degrading from 100 ms
to 30 s produced no risk at all.

This was silent and it hit the flagship documented integration on both bridges:

- `snagline hook` (command hook) -> `_cmd_hook` -> `ingest_payload`
- `POST /hooks/claude-code` (http hook) -> `_post_claude_hook` -> `ingest_payload`

## Kind of Contribution

Bug Fix, Tests

## Unit Tests

`tests/adapters/test_claude_code_adapter.py` gained five cases. The important
point about the existing coverage: `test_tracker_pairs_pre_and_post_for_latency`
asserted `250.0` ms, but reached it by calling `payload_to_event` directly after
a single `ingest_payload` for the `PreToolUse` half. That note-then-read-on-a-
different-payload ordering is not the ordering the shipped `ingest_payload`
used, so the test was green against code that never produced a latency in
production. It is kept (it still exercises `payload_to_event`), and the new
tests assert the shipped path:

- `test_ingest_payload_preserves_latency_on_the_shipped_path` — asserts
  `[None, 250.0]` through two `ingest_payload` calls.
- `test_pretooluse_carries_no_latency` — pins `None`, not `0.0`.
- `test_post_tool_use_failure_also_carries_latency` — a failing tool still took
  time; `PostToolUseFailure` is an `"end"` event too.
- `test_hook_latency_reaches_the_cusum_detector` — end to end through a real
  `Monitor.default`: 10 healthy 100 ms calls then one 30 s call must raise a
  `latency_anomaly`. This is the regression guard that would have caught the
  original bug.
- `test_tracker_evicts_stale_starts_by_age_not_wholesale` — a fresh in-flight
  start survives an eviction that clears abandoned ones.

## Execution Tests

Reproduction from #64, before and after.

Before:

```
via ingest_payload (documented CLI hook + sidecar path):
  tool_call tool=Bash latency_ms=0.0
  tool_call tool=Bash latency_ms=None
if latency is read before note() pops the start:
  post latency_ms=250.0

latency risks emitted: 0
all risks: []
```

After:

```
via ingest_payload (documented CLI hook + sidecar path):
  tool_call tool=Bash latency_ms=None
  tool_call tool=Bash latency_ms=250.0
if latency is read before note() pops the start:
  post latency_ms=250.0

latency risks emitted: 1
all risks: ['latency_anomaly']
```

Full suite, lint, and types:

```
$ python -m pytest -q
1 failed, 192 passed, 1 skipped in 22.67s
Required test coverage of 80% reached. Total coverage: 88.35%

$ python -m ruff check src tests
All checks passed!
$ python -m ruff format --check src tests
71 files already formatted
$ python -m mypy src/snagline
Success: no issues found in 37 source files
```

The one failure is pre-existing and unrelated:
`tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` uses
`send_signal(SIGINT)`, which is unsupported on Windows. Filed separately as #69;
it passes on the ubuntu CI matrix.
