### PR TITLE
fix(batching): enforce max_batch and drain the queue on close

### DIFF
--- a/src/snagline/sinks/batching.py
+++ b/src/snagline/sinks/batching.py
@@ -8,7 +8,13 @@ or once it reaches ``max_batch``. An optional ``max_per_second`` rate limit
 paces the actual deliveries so a burst of risk does not trip the destination's
 rate limiter.
 
+``max_batch`` is what bounds the queue between interval ticks, so reaching it
+wakes the flusher immediately rather than delivering on the caller's thread --
+``emit`` stays non-blocking even when the wrapped sink is slow.
+
 Fail-open: a delivery error is swallowed (never blocks ingest or the queue).
+``close()`` drains the queue before returning, so a clean shutdown inside one
+``flush_interval`` of a detection still delivers the alert.
 """
 
 from __future__ import annotations
@@ -33,12 +39,15 @@ class BatchingSink:
         max_per_second: float | None = None,
     ) -> None:
         self._sink = sink
-        self._max_batch = max_batch
+        self._max_batch = max(1, max_batch)
         self._flush_interval = flush_interval
         self._min_gap = 1.0 / max_per_second if max_per_second else 0.0
         self._queue: collections.deque[FailureRisk] = collections.deque()
         self._lock = threading.Lock()
         self._stop = threading.Event()
+        # Set when the queue reaches ``max_batch`` (or on close) so the flusher
+        # can wake early instead of sitting out the rest of the interval.
+        self._wake = threading.Event()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
 
@@ -46,9 +55,25 @@ class BatchingSink:
         # Non-blocking enqueue; the background thread does the actual delivery.
         with self._lock:
             self._queue.append(risk)
+            full = len(self._queue) >= self._max_batch
+        if full:
+            # Threshold reached. Wake the flusher rather than delivering here:
+            # ``emit`` runs on the caller's thread (inside ``ingest``) and must
+            # stay non-blocking even when the wrapped sink is slow.
+            self._wake.set()
 
     def _run(self) -> None:
-        while not self._stop.wait(self._flush_interval):
+        try:
+            while not self._stop.is_set():
+                # Whichever comes first: the interval elapsing or a full batch.
+                self._wake.wait(self._flush_interval)
+                self._wake.clear()
+                if self._stop.is_set():
+                    break
+                self._flush()
+        finally:
+            # Drain anything enqueued before the stop so a clean shutdown does
+            # not silently lose alerts.
             self._flush()
 
     def _flush(self) -> None:
@@ -77,5 +102,11 @@ class BatchingSink:
         self._flush()
 
     def close(self) -> None:
+        """Stop the flusher and deliver whatever is still queued."""
         self._stop.set()
+        self._wake.set()  # unblock the interval wait so the drain happens now
         self._thread.join(timeout=self._flush_interval + 1.0)
+        # If the thread did not finish its drain within the join timeout, flush
+        # on the caller's thread. ``_flush`` is a no-op on an empty queue, so
+        # this is safe either way.
+        self._flush()

--- a/tests/test_batching_sink.py
+++ b/tests/test_batching_sink.py
@@ -72,3 +72,63 @@ def test_rate_limit_paces_delivery():
         assert len(inner.emitted) == 3
     finally:
         sink.close()
+
+
+def _wait_for(predicate, timeout: float = 5.0) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+
+
+def test_max_batch_flushes_without_an_interval_tick():
+    # Issue #65: max_batch was stored and never read, so flush_interval was the
+    # only trigger and the queue was unbounded between ticks. Deliberately no
+    # flush_now() here -- an interval tick is an hour away, so the only thing
+    # that can deliver is the max_batch threshold.
+    inner = _RecordingSink()
+    sink = BatchingSink(inner, max_batch=3, flush_interval=3600.0)
+    try:
+        for i in range(6):
+            sink.emit(_risk(i))
+        _wait_for(lambda: len(inner.emitted) == 6)
+        assert len(inner.emitted) == 6
+    finally:
+        sink.close()
+
+
+def test_close_drains_queued_risks():
+    # Issue #65: close() set the stop event and joined, which made _run exit
+    # without a final flush, so every risk enqueued since the last tick was
+    # dropped. No flush_now() -- close() alone must deliver.
+    inner = _RecordingSink()
+    sink = BatchingSink(inner, max_batch=100, flush_interval=3600.0)
+    for i in range(5):
+        sink.emit(_risk(i))
+    sink.close()
+    assert len(inner.emitted) == 5
+
+
+def test_emit_stays_non_blocking_when_the_batch_is_full():
+    # The threshold flush must happen on the background thread: emit runs inside
+    # ingest() on the host's thread and must not inherit the sink's latency.
+    class _SlowSink:
+        def __init__(self):
+            self.emitted: list[FailureRisk] = []
+
+        def emit(self, risk: FailureRisk) -> None:
+            time.sleep(0.2)
+            self.emitted.append(risk)
+
+    inner = _SlowSink()
+    sink = BatchingSink(inner, max_batch=1, flush_interval=3600.0)
+    try:
+        start = time.monotonic()
+        for i in range(3):
+            sink.emit(_risk(i))
+        assert time.monotonic() - start < 0.1, "emit must not wait on the sink"
+        _wait_for(lambda: len(inner.emitted) == 3)
+        assert len(inner.emitted) == 3
+    finally:
+        sink.close()


### PR DESCRIPTION
## Summary of Changes

Two independent defects in `src/snagline/sinks/batching.py`.

**`max_batch` was never enforced.** The constructor stored `self._max_batch` and
nothing read it again — `emit` only appended, `_run` only waited on the interval,
`_flush` drained whatever happened to be there. The documented threshold flush
never fired, so `flush_interval` was the only trigger and the queue was
unbounded between ticks.

Reaching `max_batch` now sets a `threading.Event` that the flusher waits on
alongside the interval. Delivery stays on the background thread — `emit` runs
inside `ingest()` on the host's thread and must not inherit the wrapped sink's
latency, so it signals rather than delivers inline.

**`close()` silently dropped everything still queued.** It set `_stop` and
joined; setting `_stop` made `_run`'s `self._stop.wait(...)` return `True`
immediately, so the loop exited *without* a final flush. `flush_now` existed and
its docstring said it was "used at shutdown", but `close` never called it.
`_run` now drains in a `finally`, and `close` flushes on the caller's thread as a
backstop if the join times out (`_flush` is a no-op on an empty queue, so the
double call is safe).

Fixes #65

## Justification

`BatchingSink` is the recommended wrapper for the network sinks
(webhook/Slack/PagerDuty), precisely so alert delivery is decoupled from
`ingest()`. Both defects landed on the alerting path:

- A process shutting down within one `flush_interval` of a detection never paged
  anyone. At the default `flush_interval=5.0` that is a five second window on
  every clean exit — and for a short-lived agent run, the detected risk may be
  the last thing that happens before shutdown.
- With `max_batch` dead, the configured batch size was a no-op the user had no
  way to observe, and the queue had no bound between interval ticks.

## Kind of Contribution

Bug Fix, Tests

## Unit Tests

`tests/test_batching_sink.py`. Worth stating why the existing suite was green:
every test called `sink.flush_now()` before asserting, which masks both defects.
`test_emit_is_non_blocking_and_background_flushes` looked like it covered the
threshold — it passes `max_batch=2` — but with `flush_interval=0.05` and an
assertion of `len(inner.emitted) >= 1`, the interval tick alone satisfies it.

The three new tests deliberately never call `flush_now()`:

- `test_max_batch_flushes_without_an_interval_tick` — `max_batch=3`,
  `flush_interval=3600`, 6 emits. The only thing that can deliver is the
  threshold.
- `test_close_drains_queued_risks` — `flush_interval=3600`, 5 emits, then
  `close()` alone must deliver all 5.
- `test_emit_stays_non_blocking_when_the_batch_is_full` — `max_batch=1` against a
  sink that sleeps 200 ms per emit; asserts the three `emit` calls return in
  under 100 ms total, then that all three arrive. This pins the reason the fix
  signals the background thread instead of flushing inline.

## Execution Tests

Reproduction from #65, with a bounded wait added for the background delivery
(the threshold flush is asynchronous by design, so the original synchronous
repro cannot observe it either way).

On `origin/master`:

```
max_batch=2, 50 emits -> delivered=0 (expected 50)
queue still holds 50 risks (expected 0)
after close(): delivered=0 (expected 5)
```

On this branch:

```
max_batch=2, 50 emits -> delivered=50 (expected 50)
queue still holds 0 risks (expected 0)
after close(): delivered=5 (expected 5)
```

Full suite, lint, and types:

```
$ python -m pytest -q
1 failed, 190 passed, 1 skipped in 21.21s
Required test coverage of 80% reached. Total coverage: 88.32%

$ python -m ruff check src tests
All checks passed!
$ python -m ruff format --check src tests
71 files already formatted
$ python -m mypy src/snagline
Success: no issues found in 37 source files
```

The one failure is pre-existing and unrelated:
`tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` uses
`send_signal(SIGINT)`, unsupported on Windows. Filed separately as #69; it
passes on the ubuntu CI matrix.

## Benchmark

Not applicable — no change to the `ingest()` path. `emit` gains one integer
comparison and, on the threshold, an `Event.set()`; both are off the detector
hot path and outside the Monitor's lock.
