### PR TITLE
fix(config): apply env overrides by key presence, not value comparison

### DIFF
--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -90,15 +90,21 @@ class Config:
 
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
-    def from_env(
+    def from_env_overrides(
         cls, environ: Mapping[str, str] | None = None, prefix: str = "SNAGLINE_"
-    ) -> Config:
-        """Build a ``Config`` from environment variables (12-factor).
+    ) -> dict[str, Any]:
+        """Return only the fields that ``environ`` actually sets, coerced.
 
-        Reads ``<prefix><FIELD>`` (case-insensitive) and overrides the matching
-        scalar field. Unknown prefixes, unknown keys, and values that fail to
-        coerce are ignored (logged at warning) rather than fatal, so a host can
-        pass through unrelated environment without breaking startup.
+        ``resolve`` needs the *set of keys present in the environment*, not just
+        their values: once folded into a ``Config``, an environment variable
+        whose value equals the built-in default is indistinguishable from an
+        unset one, and comparing against a default instance would silently drop
+        it (issue #66).
+
+        Reads ``<prefix><FIELD>`` (case-insensitive). Unknown prefixes, unknown
+        keys, and values that fail to coerce are ignored (logged at warning)
+        rather than fatal, so a host can pass through unrelated environment
+        without breaking startup.
         """
         environ = os.environ if environ is None else environ
         hints = get_type_hints(cls)
@@ -115,7 +121,20 @@ class Config:
                     overrides[name] = _coerce(hint, value)
                 except ValueError:
                     logger.warning("snagline: ignoring bad env %s=%r", key, value)
-        return cls(**overrides)
+        return overrides
+
+    @classmethod
+    def from_env(
+        cls, environ: Mapping[str, str] | None = None, prefix: str = "SNAGLINE_"
+    ) -> Config:
+        """Build a ``Config`` from environment variables (12-factor).
+
+        Reads ``<prefix><FIELD>`` (case-insensitive) and overrides the matching
+        scalar field; every other field keeps its built-in default. See
+        ``from_env_overrides`` for the same information as a dict of just the
+        keys the environment set.
+        """
+        return cls(**cls.from_env_overrides(environ=environ, prefix=prefix))
 
     @classmethod
     def load_file(cls, path: str) -> Config:
@@ -131,7 +150,7 @@ class Config:
             data: dict[str, Any] = _load_toml(text)
         else:
             data = json.loads(text)
-        valid = {f.name for f in fields(cls)}  # noqa: F821
+        valid = {f.name for f in fields(cls)}
         return cls(**{k: v for k, v in data.items() if k in valid})
 
     @classmethod
@@ -152,12 +171,14 @@ class Config:
         so behavior is consistent across ``snagline serve``, ``watch``,
         ``replay``, and embedded use.
         """
-        cfg = cls()
-        if path:
-            cfg = cls.load_file(path)
-        env = cls.from_env(environ=environ, prefix=prefix)
-        defaults = cls()
-        for fld in fields(cls):
-            if getattr(env, fld.name) != getattr(defaults, fld.name):
-                setattr(cfg, fld.name, getattr(env, fld.name))
+        cfg = cls.load_file(path) if path else cls()
+        # Apply exactly the keys the environment set. Comparing an env-derived
+        # Config against a default instance instead would treat "set to the
+        # default value" as "unset" and let the file win (issue #66) -- which is
+        # precisely the case an operator hits when resetting a shared config
+        # file back to stock behaviour from the environment.
+        for name, value in cls.from_env_overrides(
+            environ=environ, prefix=prefix
+        ).items():
+            setattr(cfg, name, value)
         return cfg

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -81,3 +81,44 @@ def test_resolve_env_only():
     cfg = Config.resolve(environ=env)
     assert cfg.fail_open is False
     assert cfg.cusum_k == 0.5  # default unchanged
+
+
+def test_resolve_env_equal_to_default_still_beats_the_file(tmp_path):
+    # Issue #66: resolve() inferred "this env var was set" by comparing an
+    # env-derived Config against a default instance, so a variable whose value
+    # happened to equal the built-in default looked unset and the file won --
+    # inverting the documented env > file > defaults precedence.
+    defaults = Config()
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps({"cascade_error_threshold": 99, "fail_open": False}))
+    env = {
+        # Deliberately the built-in default value: an operator resetting a
+        # shared config file back to stock behaviour from the environment.
+        "SNAGLINE_CASCADE_ERROR_THRESHOLD": str(defaults.cascade_error_threshold),
+        "SNAGLINE_FAIL_OPEN": "true",
+    }
+    cfg = Config.resolve(path=str(path), environ=env)
+    assert cfg.cascade_error_threshold == defaults.cascade_error_threshold
+    # fail_open is the sharpest case: an operator restoring the fail-open
+    # guarantee via environment must not stay in strict mode.
+    assert cfg.fail_open is True
+
+
+def test_from_env_overrides_reports_only_keys_that_were_set():
+    # The set of present keys is what resolve() needs; a value equal to the
+    # default must still appear, and unrelated environment must not.
+    overrides = Config.from_env_overrides(
+        environ={
+            "SNAGLINE_CUSUM_K": str(Config().cusum_k),  # == default
+            "SNAGLINE_UNKNOWN_FIELD": "x",
+            "PATH": "/usr/bin",
+        }
+    )
+    assert overrides == {"cusum_k": Config().cusum_k}
+
+
+def test_from_env_still_returns_a_full_config():
+    # from_env's public behaviour is unchanged by the refactor.
+    cfg = Config.from_env(environ={"SNAGLINE_LOOP_WINDOW_SIZE": "42"})
+    assert cfg.loop_window_size == 42
+    assert cfg.cusum_k == Config().cusum_k


### PR DESCRIPTION
## Summary of Changes

`Config.resolve` documents strict 12-factor precedence — "built-in defaults ->
optional config file (`path`) -> environment variables (`prefix`). Environment
overrides win over the file, which wins over defaults." The implementation
inferred "this env var was set" by folding the environment into a `Config` and
comparing each field against a default instance:

```python
env = cls.from_env(environ=environ, prefix=prefix)
defaults = cls()
for fld in fields(cls):
    if getattr(env, fld.name) != getattr(defaults, fld.name):
        setattr(cfg, fld.name, getattr(env, fld.name))
```

After that fold, an environment variable whose value happens to equal the
built-in default is indistinguishable from an unset one — so it was skipped and
the config file's value survived. Environment lost to the file.

`from_env` already computed exactly the set `resolve` needed: an
`overrides: dict[str, Any]` of the keys it actually found in the environment. It
then discarded that dict by returning a fully populated `Config`. This PR splits
it out as a `from_env_overrides` classmethod, rebuilds `from_env` on top of it so
its public behaviour is unchanged, and has `resolve` apply exactly those keys.

Also drops a dead `# noqa: F821` in `load_file` — `fields` is imported at module
scope, so F821 (undefined name) could never apply there and the suppression hid
nothing.

Fixes #66

## Justification

`Config.resolve` is documented as "the single entrypoint the CLI and host
integrations should use so behavior is consistent across `snagline serve`,
`watch`, `replay`, and embedded use". Every detector threshold flows through it.

The failure mode is not an obscure value collision — it is precisely the case an
operator hits when they want to reset a field back to stock behaviour from the
environment without editing a shared config file, which is a large part of why
12-factor env override exists.

It is also value-dependent, which makes it hard to spot in the field: in the
reproduction below, `SNAGLINE_LOOP_REPEAT_THRESHOLD=5` is honoured correctly (5
differs from the default 3) in the *same* `resolve` call that silently drops
`SNAGLINE_CASCADE_ERROR_THRESHOLD=3`. Checking a neighbouring field suggests
everything works.

`fail_open` is the sharpest instance: `SNAGLINE_FAIL_OPEN=true` (the default)
could not override a config file that set `fail_open: false`, so an operator
trying to restore the fail-open guarantee via environment silently stayed in
strict mode, where a detector exception propagates into the host agent.

## Kind of Contribution

Bug Fix, Cleanup, Tests

## Unit Tests

`tests/test_config_loader.py`. The existing `test_resolve_layers_file_then_env`
passes both before and after, because it uses `SNAGLINE_LOOP_REPEAT_THRESHOLD=15`
against a default of `3` — a value that differs, so the old comparison happened
to work. New cases:

- `test_resolve_env_equal_to_default_still_beats_the_file` — the regression
  guard. A config file sets `cascade_error_threshold: 99` and `fail_open: false`;
  the environment sets both to their built-in default values. Both must come back
  as the environment specified.
- `test_from_env_overrides_reports_only_keys_that_were_set` — a value equal to
  the default still appears in the dict; unknown `SNAGLINE_*` keys and unrelated
  environment (`PATH`) do not.
- `test_from_env_still_returns_a_full_config` — pins that the refactor did not
  change `from_env`'s public behaviour.

## Execution Tests

Reproduction from #66, before and after.

Before:

```
env SNAGLINE_CASCADE_ERROR_THRESHOLD=3 (== default)
  -> resolved cascade_error_threshold = 99 (expected 3)
env SNAGLINE_LOOP_REPEAT_THRESHOLD=5 (!= default)
  -> resolved loop_repeat_threshold   = 5 (expected 5)
```

After:

```
env SNAGLINE_CASCADE_ERROR_THRESHOLD=3 (== default)
  -> resolved cascade_error_threshold = 3 (expected 3)
env SNAGLINE_LOOP_REPEAT_THRESHOLD=5 (!= default)
  -> resolved loop_repeat_threshold   = 5 (expected 5)
```

Full suite, lint, and types:

```
$ python -m pytest -q
1 failed, 190 passed, 1 skipped in 18.27s
Required test coverage of 80% reached. Total coverage: 88.16%

$ python -m ruff check src tests
All checks passed!
$ python -m ruff format --check src tests
71 files already formatted
$ python -m mypy src/snagline
Success: no issues found in 37 source files
```

The one failure is pre-existing and unrelated:
`tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` uses
`send_signal(SIGINT)`, unsupported on Windows. Filed separately as #69; it
passes on the ubuntu CI matrix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Environment settings now correctly override configuration-file values, even when they match the application defaults.
  - Boolean and numeric environment settings are handled consistently.

- **Improvements**
  - Added a way to identify only explicitly defined, recognized environment overrides.
  - Existing full environment-based configuration behavior remains supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->