### PR TITLE
fix(state): release a finished episode's lock in end_episode

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -157,9 +157,13 @@ class Monitor:
         """Signal that ``episode_id`` has finished; clear its per-episode state.
 
         Calls ``reset(episode_id)`` on every detector so loop windows, CUSUM
-        baselines, and cascade counters for that episode are dropped. This is
-        the teardown hook adapters call when an agent run completes; without it,
+        baselines, and cascade counters for that episode are dropped, then asks
+        the state backend to release whatever it holds for that id. This is the
+        teardown hook adapters call when an agent run completes; without it,
         per-episode state would accumulate for the life of the Monitor.
+
+        Backends are only asked to release if they implement it -- a backend
+        written against the narrower ``StateBackend`` protocol is unaffected.
 
         Fail-open: a detector's ``reset`` exception is logged, never propagated.
         """
@@ -171,6 +175,19 @@ class Monitor:
                     self._log_fault_once(
                         f"detector {getattr(detector, 'name', repr(detector))} "
                         "reset raised; ignoring (fail-open)"
+                    )
+                    if not self._fail_open:
+                        raise
+            # Inside the lock: no other thread can be in this episode's
+            # critical section, so dropping the entry cannot strand a holder.
+            release = getattr(self._state, "release", None)
+            if callable(release):
+                try:
+                    release(episode_id)
+                except Exception:
+                    self._log_fault_once(
+                        f"state backend {type(self._state).__name__} release "
+                        "raised; ignoring (fail-open)"
                     )
                     if not self._fail_open:
                         raise

--- a/src/snagline/state.py
+++ b/src/snagline/state.py
@@ -33,6 +33,19 @@ class StateBackend(Protocol):
         ...
 
 
+class ReleasableStateBackend(StateBackend, Protocol):
+    """A ``StateBackend`` that can drop what it holds for a finished episode.
+
+    Optional capability: ``Monitor.end_episode`` probes for ``release`` and
+    skips backends that do not expose it, so a backend written against the
+    narrower ``StateBackend`` above keeps working unchanged.
+    """
+
+    def release(self, episode_id: str) -> None:
+        """Discard any per-episode state held for ``episode_id``."""
+        ...
+
+
 class MemoryStateBackend:
     """Process-local backend: one re-entrant lock per episode id."""
 
@@ -49,6 +62,22 @@ class MemoryStateBackend:
                 self._locks[episode_id] = lock
         with lock:
             yield
+
+    def release(self, episode_id: str) -> None:
+        """Drop the lock allocated for a finished episode.
+
+        Without this the dict grows by one entry per episode id and never
+        shrinks, so a long-lived Monitor watching many short runs retains a
+        lock for every episode it has ever seen.
+
+        ``Monitor.end_episode`` calls this while holding the episode lock, so
+        no other thread can be inside the critical section when the entry is
+        dropped. A thread that ingests for the same id *after* the release
+        simply allocates a fresh lock -- correct, because an episode that has
+        ended has no detector state left to serialize.
+        """
+        with self._meta:
+            self._locks.pop(episode_id, None)
 
 
 class RedisStateBackend:  # pragma: no cover - optional, requires redis
@@ -69,6 +98,13 @@ class RedisStateBackend:  # pragma: no cover - optional, requires redis
         finally:
             if acquired:
                 lock.release()
+
+    def release(self, episode_id: str) -> None:
+        """No-op: Redis locks are per-acquisition and expire on their own.
+
+        Nothing is retained between ``episode_lock`` calls, so a finished
+        episode leaves nothing behind to discard.
+        """
 
 
 def default_state_backend() -> StateBackend:

--- a/tests/test_state_backend.py
+++ b/tests/test_state_backend.py
@@ -3,7 +3,11 @@
 from __future__ import annotations
 
 import threading
+from contextlib import contextmanager
 
+import pytest
+
+from snagline.config import Config
 from snagline.events import StepEvent, make_signature
 from snagline.monitor import Monitor
 from snagline.state import (
@@ -71,3 +75,77 @@ def test_concurrent_ingest_of_distinct_episodes_no_deadlock():
     # Each episode's state was torn down cleanly.
     for j in range(4):
         monitor.end_episode(f"ep{j}")
+
+
+def test_end_episode_releases_the_episode_lock():
+    """Regression: the lock dict must not grow once per episode forever.
+
+    A long-lived Monitor (sidecar, hook bridge) sees one fresh episode id per
+    agent run, so a lock retained past ``end_episode`` is an unbounded leak.
+    """
+    backend = MemoryStateBackend()
+    monitor = Monitor.default(state_backend=backend)
+    for n in range(500):
+        ep = f"episode-{n}"
+        monitor.ingest(_event(episode_id=ep, i=n))
+        monitor.end_episode(ep)
+    assert backend._locks == {}
+
+
+def test_release_keeps_other_episodes_untouched():
+    backend = MemoryStateBackend()
+    with backend.episode_lock("a"):
+        pass
+    with backend.episode_lock("b"):
+        pass
+    kept = backend._locks["b"]
+    backend.release("a")
+    assert "a" not in backend._locks
+    assert backend._locks["b"] is kept
+
+
+def test_release_of_an_unknown_episode_is_a_no_op():
+    backend = MemoryStateBackend()
+    backend.release("never-seen")  # must not raise
+    assert backend._locks == {}
+
+
+def test_end_episode_tolerates_a_backend_without_release():
+    """``release`` is optional: a backend implementing only the narrower
+    ``StateBackend`` protocol must keep working unchanged."""
+
+    class MinimalBackend:
+        def __init__(self):
+            self.locked: list[str] = []
+
+        @contextmanager
+        def episode_lock(self, episode_id):
+            self.locked.append(episode_id)
+            yield
+
+    backend = MinimalBackend()
+    monitor = Monitor.default(state_backend=backend)
+    monitor.ingest(_event(episode_id="ep", i=0))
+    monitor.end_episode("ep")  # must not raise AttributeError
+    assert backend.locked == ["ep", "ep"]
+
+
+def test_end_episode_is_fail_open_when_release_raises():
+    class BrokenBackend(MemoryStateBackend):
+        def release(self, episode_id):
+            raise RuntimeError("backend down")
+
+    monitor = Monitor.default(state_backend=BrokenBackend())
+    monitor.end_episode("ep")  # fail-open: logged, not raised
+
+
+def test_end_episode_propagates_release_error_when_not_fail_open():
+    class BrokenBackend(MemoryStateBackend):
+        def release(self, episode_id):
+            raise RuntimeError("backend down")
+
+    monitor = Monitor.default(
+        config=Config(fail_open=False), state_backend=BrokenBackend()
+    )
+    with pytest.raises(RuntimeError):
+        monitor.end_episode("ep")


### PR DESCRIPTION
## Summary of Changes

`MemoryStateBackend.episode_lock` allocates one `threading.RLock` per episode id
and stores it in `self._locks`. Nothing ever removed an entry. `end_episode` --
documented as the teardown hook that exists because "without it, per-episode
state would accumulate for the life of the Monitor" -- reset every detector but
left the backend's dict untouched, so the Monitor kept a lock for every episode
id it had ever seen.

This PR adds an optional `release(episode_id)`:

- `MemoryStateBackend.release` pops the entry under `self._meta`.
- `RedisStateBackend.release` is an explicit no-op with a comment saying why: its
  locks are per-acquisition and expire on their own, so a finished episode leaves
  nothing behind to discard.
- `Monitor.end_episode` probes for the method with `getattr` and calls it inside
  the same fail-open guard the detector resets use.

The capability is documented as a `ReleasableStateBackend(StateBackend, Protocol)`
rather than being added to `StateBackend` itself, so a third-party backend written
against the narrower protocol stays valid under mypy and keeps working unchanged.

The release happens *inside* the `with self._state.episode_lock(episode_id):`
block, not after it. Holding the episode lock means no other thread can be in that
episode's critical section at the moment the entry is dropped. A thread that
ingests for the same id after the release simply allocates a fresh lock, which is
correct: an episode that has ended has no detector state left to serialize.

Fixes #67

## Justification

`MemoryStateBackend` is the default backend, so this is the shipped path for every
embedded use, `snagline serve`, and `snagline hook`.

The leak is keyed on *episode id*, and the long-lived deployments are exactly the
ones that see a fresh id per run. The sidecar handles `POST /events` for whatever
episode a caller names; the Claude Code hook bridge is a long-lived process
watching many short sessions. Each finished run adds one permanent dict entry plus
one `RLock`, and `end_episode` -- the one API that could have cleaned it up, called
from adapter `finally` blocks precisely for that purpose -- was the call that did
not.

It is also invisible to the caller: the leak is in a private dict on a backend the
user never touches, and there is no metric or log that reflects it.

## Kind of Contribution

Bug Fix, Tests

## Unit Tests

`tests/test_state_backend.py`. Four of the six new cases fail on `origin/master`
and pass here:

- `test_end_episode_releases_the_episode_lock` -- the regression guard. 500
  ingest/`end_episode` pairs with distinct ids, then `backend._locks == {}`.
- `test_release_keeps_other_episodes_untouched` -- releasing `"a"` leaves `"b"`'s
  lock object identical, not merely present.
- `test_release_of_an_unknown_episode_is_a_no_op`.
- `test_end_episode_propagates_release_error_when_not_fail_open`.

Two cover the compatibility contract:

- `test_end_episode_tolerates_a_backend_without_release` -- a backend implementing
  only `episode_lock` must not hit `AttributeError`. It passes on master too; it is
  there to pin that this PR did not make `release` mandatory.
- `test_end_episode_is_fail_open_when_release_raises` -- a backend whose `release`
  throws is logged, not propagated, matching the detector-reset behaviour beside
  it.

The existing `test_memory_backend_isolates_episode_locks` and
`test_concurrent_ingest_of_distinct_episodes_no_deadlock` pass unchanged.

## Execution Tests

Reproduction from #67: 5000 episodes, each ingested and then ended.

On `origin/master`:

```
episodes started and ended : 5000
locks still held by backend: 5000 (expected 0)
bytes retained (approx)    : 103856
VERDICT: LEAK
```

On this branch:

```
episodes started and ended : 5000
locks still held by backend: 0 (expected 0)
bytes retained (approx)    : 184
VERDICT: clean
```

The byte figure is `sys.getsizeof(backend._locks)` -- the dict's own table only,
excluding the 5000 `RLock` objects and 5000 key strings it keeps alive.

Full suite, lint, and types:

```
$ python -m pytest -q
1 failed, 193 passed, 1 skipped in 18.69s
Required test coverage of 80% reached. Total coverage: 88.24%

$ python -m ruff check src tests
All checks passed!
$ python -m ruff format --check src tests
71 files already formatted
$ python -m mypy src/snagline
Success: no issues found in 37 source files
```

The one failure is pre-existing and unrelated:
`tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` uses
`send_signal(SIGINT)`, unsupported on Windows. Filed separately as #69; it passes
on the ubuntu CI matrix.

## Benchmark

Not applicable -- no change to the `ingest()` path. `end_episode` gains one
`getattr` and one dict `pop` under the existing `_meta` lock, both off the
per-step hot path.
