### PR TITLE
fix(server): require the auth token on GET, and expose it from the CLI

### DIFF
--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import sys
 import time
 from collections.abc import Iterator
@@ -243,6 +244,27 @@ def _build_parser() -> argparse.ArgumentParser:
         "--host", default="127.0.0.1", help="Bind address [default: 127.0.0.1]."
     )
     p_serve.add_argument("--port", type=int, default=8787, help="Port [default: 8787].")
+    p_serve.add_argument(
+        "--auth-token",
+        default=None,
+        help="Shared secret required on every request except GET /health "
+        "(Authorization: Bearer <token> or X-Snagline-Token). Falls back to "
+        "$SNAGLINE_SERVE_AUTH_TOKEN, which keeps the secret out of argv. "
+        "Unset means all endpoints are open.",
+    )
+    p_serve.add_argument(
+        "--max-body-bytes",
+        type=int,
+        default=1_000_000,
+        help="Reject POST bodies larger than this with 413 [default: 1000000].",
+    )
+    p_serve.add_argument(
+        "--max-risks",
+        type=int,
+        default=1000,
+        help="How many risks received on POST /risks to retain for GET /risks "
+        "[default: 1000].",
+    )
     p_serve.add_argument(
         "--sink",
         choices=["console", "webhook", "slack", "pagerduty"],
@@ -541,15 +563,27 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         sinks = _build_sinks(args)
     except SystemExit as exc:
         return int(exc.code or 2)
+    # Prefer the flag, fall back to the environment so the secret need not
+    # appear in argv (visible to every other process via ps).
+    auth_token = args.auth_token or os.environ.get("SNAGLINE_SERVE_AUTH_TOKEN") or None
     print(
         f"snagline serve: listening on http://{args.host}:{args.port} (POST /events, GET /health)",
         file=sys.stderr,
     )
+    if not auth_token:
+        print(
+            "snagline serve: no --auth-token / $SNAGLINE_SERVE_AUTH_TOKEN set; "
+            "every endpoint is open to anyone who can reach this port",
+            file=sys.stderr,
+        )
     with suppress(KeyboardInterrupt):
         serve(
             Monitor.default(config=_build_config(args), sinks=sinks),
             host=args.host,
             port=args.port,
+            auth_token=auth_token,
+            max_body_bytes=args.max_body_bytes,
+            max_risks=args.max_risks,
         )
     return 0
 

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -13,11 +13,15 @@ POST bodies are capped at ``max_body_bytes`` (default 1 MB); larger payloads
 get 413. This keeps the sidecar safe to expose and able to absorb buffered
 telemetry from any host.
 
-Optionally protect the POST endpoints with a shared secret by passing
-``auth_token=`` to ``make_server``/``serve``. When set, POSTs must carry the
+Optionally protect the endpoints with a shared secret by passing
+``auth_token=`` to ``make_server``/``serve``. When set, requests must carry the
 token via ``Authorization: Bearer <token>`` or ``X-Snagline-Token: <token>``;
 missing or wrong tokens get 401. ``GET /health`` stays open for liveness
-probes.
+probes -- everything else, GET and POST alike, is behind the token.
+
+``POST /risks`` retains the most recent ``max_risks`` risks (default 1000) for
+``GET /risks``; older ones are discarded so an unbounded sender cannot grow the
+sidecar's memory without limit.
 
 No framework, no third-party dependency -- this keeps the zero-dependency
 principle intact even for server mode. For high-throughput production use,
@@ -34,6 +38,7 @@ from __future__ import annotations
 import json
 import logging
 import sys
+from collections import deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 
@@ -48,6 +53,7 @@ def make_handler(
     monitor: Monitor,
     auth_token: str | None = None,
     max_body_bytes: int = 1_000_000,
+    max_risks: int = 1000,
 ) -> type[BaseHTTPRequestHandler]:
     """Build a request-handler class bound to ``monitor``."""
     tracker = HookTracker()
@@ -74,12 +80,21 @@ def make_handler(
             return self.headers.get("X-Snagline-Token") == token
 
         def do_GET(self) -> None:  # noqa: N802 - http.server naming
+            # /health is deliberately open: a liveness probe (k8s, ELB, docker
+            # healthcheck) generally cannot be taught to carry a shared secret,
+            # and it reveals nothing but reachability.
             if self.path == "/health":
                 self._respond(200, {"status": "ok"})
-            elif self.path == "/metrics":
+                return
+            # Everything else is behind the token, including the 404 fallthrough
+            # so an unauthenticated caller cannot probe which paths exist.
+            if not self._authorized():
+                self._respond(401, {"error": "unauthorized"})
+                return
+            if self.path == "/metrics":
                 self._respond(200, self.snagline_monitor.metrics())
             elif self.path == "/risks":
-                self._respond(200, {"risks": self.snagline_risks})
+                self._respond(200, {"risks": list(self.snagline_risks)})
             else:
                 self._respond(404, {"error": "not found"})
 
@@ -207,7 +222,9 @@ def make_handler(
 
     _Handler.snagline_monitor = monitor
     _Handler.snagline_tracker = tracker
-    _Handler.snagline_risks = []
+    # Bounded: POST /risks is an open-ended ingest point, so retain only the
+    # most recent max_risks entries rather than growing without limit.
+    _Handler.snagline_risks = deque(maxlen=max(1, max_risks))
     _Handler.snagline_auth = auth_token
     _Handler.snagline_max_body = max_body_bytes
     return _Handler
@@ -219,10 +236,11 @@ def make_server(
     port: int = 8787,
     auth_token: str | None = None,
     max_body_bytes: int = 1_000_000,
+    max_risks: int = 1000,
 ) -> ThreadingHTTPServer:
     """Construct a ready-to-``serve_forever()`` sidecar server."""
     return ThreadingHTTPServer(
-        (host, port), make_handler(monitor, auth_token, max_body_bytes)
+        (host, port), make_handler(monitor, auth_token, max_body_bytes, max_risks)
     )
 
 
@@ -232,13 +250,15 @@ def serve(
     port: int = 8787,
     auth_token: str | None = None,
     max_body_bytes: int = 1_000_000,
+    max_risks: int = 1000,
 ) -> None:
     """Run the sidecar server in the foreground until interrupted."""
-    server = make_server(monitor, host, port, auth_token, max_body_bytes)
+    server = make_server(monitor, host, port, auth_token, max_body_bytes, max_risks)
     logger.info(
-        "snagline sidecar listening on http://%s:%d (POST /events, GET /health)",
+        "snagline sidecar listening on http://%s:%d (POST /events, GET /health)%s",
         host,
         port,
+        "" if auth_token else " -- no auth token set, all endpoints are open",
     )
     try:
         server.serve_forever()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -189,12 +189,74 @@ def test_main_hook_forwards_to_out(tmp_path, monkeypatch):
 def test_main_serve_starts_server(monkeypatch):
     started: dict = {}
 
-    def _fake_serve(monitor, host="127.0.0.1", port=8787):
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
         started["ok"] = (host, port)
+        started["kwargs"] = kwargs
 
+    monkeypatch.delenv("SNAGLINE_SERVE_AUTH_TOKEN", raising=False)
     monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
     assert main(["serve"]) == 0
     assert started.get("ok") == ("127.0.0.1", 8787)
+    # Defaults: no token, 1 MB body cap, 1000 retained risks.
+    assert started["kwargs"] == {
+        "auth_token": None,
+        "max_body_bytes": 1_000_000,
+        "max_risks": 1000,
+    }
+
+
+def test_main_serve_passes_auth_token_and_limits(monkeypatch):
+    """Regression: serve() accepted auth_token/max_body_bytes but the CLI had no
+    flags for them, so a token could not be set from the command line at all."""
+    started: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        started.update(kwargs)
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert (
+        main(
+            [
+                "serve",
+                "--auth-token",
+                "s3cret",
+                "--max-body-bytes",
+                "4096",
+                "--max-risks",
+                "7",
+            ]
+        )
+        == 0
+    )
+    assert started["auth_token"] == "s3cret"
+    assert started["max_body_bytes"] == 4096
+    assert started["max_risks"] == 7
+
+
+def test_main_serve_reads_auth_token_from_the_environment(monkeypatch):
+    """The token must be settable without putting it in argv, where every other
+    process on the box can read it out of ps."""
+    started: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        started.update(kwargs)
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    monkeypatch.setenv("SNAGLINE_SERVE_AUTH_TOKEN", "from-env")
+    assert main(["serve"]) == 0
+    assert started["auth_token"] == "from-env"
+
+
+def test_main_serve_flag_beats_the_environment(monkeypatch):
+    started: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        started.update(kwargs)
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    monkeypatch.setenv("SNAGLINE_SERVE_AUTH_TOKEN", "from-env")
+    assert main(["serve", "--auth-token", "from-flag"]) == 0
+    assert started["auth_token"] == "from-flag"
 
 
 def test_maybe_dedup_wraps_sinks_only_when_cooldown_set():

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -24,10 +24,13 @@ def _start_server(
     sink: _RecordingSink,
     auth_token: str | None = None,
     max_body_bytes: int | None = None,
+    max_risks: int | None = None,
 ):
     kwargs = {}
     if max_body_bytes is not None:
         kwargs["max_body_bytes"] = max_body_bytes
+    if max_risks is not None:
+        kwargs["max_risks"] = max_risks
     server = make_server(
         Monitor.default(sinks=[sink]),
         host="127.0.0.1",
@@ -38,6 +41,16 @@ def _start_server(
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     return server, f"http://127.0.0.1:{server.server_address[1]}"
+
+
+def _get(base: str, path: str, headers: dict | None = None) -> int:
+    """GET ``path`` and return the status code, HTTPError codes included."""
+    req = urllib.request.Request(base + path, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return int(resp.status)
+    except urllib.error.HTTPError as exc:
+        return int(exc.code)
 
 
 def test_health_endpoint():
@@ -315,6 +328,108 @@ def test_risks_endpoint_records_received_risk():
         with urllib.request.urlopen(base + "/risks", timeout=5) as resp:
             assert resp.status == 200
             assert json.loads(resp.read())["risks"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_get_metrics_requires_token_when_configured():
+    """Regression: do_GET never consulted _authorized(), so /metrics leaked."""
+    server, base = _start_server(_RecordingSink(), auth_token="secret")
+    try:
+        assert _get(base, "/metrics") == 401
+        assert _get(base, "/metrics", {"Authorization": "Bearer wrong"}) == 401
+        assert _get(base, "/metrics", {"Authorization": "Bearer secret"}) == 200
+        assert _get(base, "/metrics", {"X-Snagline-Token": "secret"}) == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_get_risks_requires_token_when_configured():
+    """Regression: /risks returned every risk the sidecar had ever received --
+    episode ids, triggers, and detail strings -- to an unauthenticated caller."""
+    sink = _RecordingSink()
+    server, base = _start_server(sink, auth_token="secret")
+    try:
+        risk = {
+            "episode_id": "ep-secret",
+            "step_id": "s1",
+            "score": 0.9,
+            "trigger": "loop",
+            "detail": "repeated",
+            "timestamp": 1.0,
+        }
+        req = urllib.request.Request(
+            base + "/risks",
+            data=json.dumps(risk).encode(),
+            headers={"Authorization": "Bearer secret"},
+            method="POST",
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            assert resp.status == 202
+
+        assert _get(base, "/risks") == 401
+        req = urllib.request.Request(
+            base + "/risks", headers={"Authorization": "Bearer secret"}, method="GET"
+        )
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            assert resp.status == 200
+            assert json.loads(resp.read())["risks"][0]["episode_id"] == "ep-secret"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_unknown_get_path_is_401_not_404_when_token_configured():
+    """An unauthenticated caller must not be able to enumerate which paths
+    exist, so the 404 fallthrough sits behind the token too."""
+    server, base = _start_server(_RecordingSink(), auth_token="secret")
+    try:
+        assert _get(base, "/nope") == 401
+        assert _get(base, "/nope", {"Authorization": "Bearer secret"}) == 404
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_get_endpoints_stay_open_when_no_token_is_configured():
+    """Without auth_token the sidecar is unchanged: GETs are open."""
+    server, base = _start_server(_RecordingSink())
+    try:
+        assert _get(base, "/health") == 200
+        assert _get(base, "/metrics") == 200
+        assert _get(base, "/risks") == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_received_risks_are_bounded():
+    """POST /risks is an open-ended ingest point; retention must be capped."""
+    server, base = _start_server(_RecordingSink(), max_risks=3)
+    try:
+        for i in range(5):
+            req = urllib.request.Request(
+                base + "/risks",
+                data=json.dumps(
+                    {
+                        "episode_id": "ep",
+                        "step_id": str(i),
+                        "score": 0.9,
+                        "trigger": "loop",
+                        "detail": "d",
+                        "timestamp": float(i),
+                    }
+                ).encode(),
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=5) as resp:
+                assert resp.status == 202
+        with urllib.request.urlopen(base + "/risks", timeout=5) as resp:
+            risks = json.loads(resp.read())["risks"]
+        # Oldest dropped, newest kept, and still JSON-serializable.
+        assert [r["step_id"] for r in risks] == ["2", "3", "4"]
     finally:
         server.shutdown()
         server.server_close()


### PR DESCRIPTION
## Summary of Changes

Three related defects in the sidecar, all on the "is this port safe to expose"
question.

**`do_GET` never called `_authorized()`.** `do_POST` did, so with `auth_token` set
`POST /events` was correctly refused with 401 -- while `GET /metrics` and
`GET /risks` answered anyone who could reach the port. `GET /risks` returns every
risk the sidecar has received, with episode ids, triggers, and detail strings.
Auth now runs before the path dispatch, so the 404 fallthrough is behind the token
too and an unauthenticated caller cannot enumerate which paths exist.
`GET /health` stays open -- the module docstring already promised that, and a
liveness probe (k8s, ELB, docker healthcheck) generally cannot be taught to carry
a shared secret.

**No CLI flag reached `auth_token`.** `serve()` and `make_server()` have accepted
`auth_token` and `max_body_bytes` since the endpoint landed, but `_cmd_serve`
called `serve(monitor, host=..., port=...)` and nothing else, so `snagline serve`
could not be secured from the command line at all. Adds `--auth-token`,
`--max-body-bytes`, and `--max-risks`. The token also reads from
`$SNAGLINE_SERVE_AUTH_TOKEN`, so it need not appear in argv where any other
process on the box can read it out of `ps`; the flag wins when both are set. When
no token is configured, `serve` now says so on stderr rather than starting an open
port silently.

**`POST /risks` appended to an unbounded list.** `_Handler.snagline_risks = []`,
appended once per received risk, never trimmed. It is now a
`collections.deque(maxlen=max_risks)` (default 1000), and `GET /risks` wraps it in
`list(...)` so the response stays JSON-serializable.

Fixes #68

## Justification

The sidecar exists to be reachable: it is the integration path for non-Python
agents, and the docstring's own framing is that the body cap and the token
"keep the sidecar safe to expose." The two auth defects meet in the worst place --
the endpoints that were open are the ones that read data out, and the flag that
would have closed them did not exist, so an operator who set out to secure
`snagline serve` had no way to do it and no signal that anything was wrong.

`/metrics` also discloses `detector_errors` and `sink_errors`, which is exactly the
information that tells an observer whether the monitoring is degraded.

The retention leak is smaller but the same shape: `POST /risks` is documented as
lenient and fail-open so remote senders never retry, which means the one thing it
must not do is trust the sender to stop.

## Kind of Contribution

Bug Fix, Tests

## Unit Tests

`tests/test_http_server.py` and `tests/test_cli.py`. Eight new or updated cases
fail on `origin/master`:

- `test_get_metrics_requires_token_when_configured` -- 401 with no token, 401 with
  a wrong token, 200 with `Authorization: Bearer`, 200 with `X-Snagline-Token`.
  Mirrors the existing `test_post_requires_token_when_configured`, which is the
  test that made the GET gap visible by contrast.
- `test_get_risks_requires_token_when_configured` -- posts a risk with the token,
  then asserts an unauthenticated `GET /risks` is 401 and an authenticated one
  actually returns the episode id.
- `test_unknown_get_path_is_401_not_404_when_token_configured` -- pins the
  ordering: unauthenticated probes get 401, not a 404 that confirms the path is
  unused.
- `test_received_risks_are_bounded` -- `max_risks=3`, 5 posts, asserts the
  retained step ids are exactly `["2", "3", "4"]`: oldest dropped, newest kept,
  and still serializable through `GET /risks`.
- `test_main_serve_starts_server` -- updated. It previously declared
  `_fake_serve(monitor, host, port)`, which is why the missing flags went
  unnoticed: any extra kwarg would have been a `TypeError`. It now captures
  `**kwargs` and asserts the defaults.
- `test_main_serve_passes_auth_token_and_limits`,
  `test_main_serve_reads_auth_token_from_the_environment`, and
  `test_main_serve_flag_beats_the_environment` -- the flag/env plumbing.

`test_get_endpoints_stay_open_when_no_token_is_configured` passes both before and
after; it is there to pin that this does not change the default no-token
deployment.

## Execution Tests

Reproduction from #68 against a live `make_server(..., auth_token="s3cret")`.

On `origin/master`:

```
token is set on the server: 's3cret'

GET  /health   no token -> 200 (expected 200)  ok
GET  /metrics  no token -> 200 (expected 401)  LEAK
     body: {"events_ingested": 0, "risks_emitted": 0, "detector_errors": 0, "sink_errors": 0}
GET  /risks    no token -> 200 (expected 401)  LEAK
     body: {"risks": []}
POST /risks    no token -> 401 (expected 401)  ok

posted 1500 risks -> GET /risks returns 1500 (bounded default is 1000)
```

On this branch:

```
token is set on the server: 's3cret'

GET  /health   no token -> 200 (expected 200)  ok
GET  /metrics  no token -> 401 (expected 401)  ok
GET  /risks    no token -> 401 (expected 401)  ok
POST /risks    no token -> 401 (expected 401)  ok

with token:
GET  /metrics  token    -> 200 (expected 200)
GET  /risks    token    -> 200 (expected 200)

posted 1500 risks -> GET /risks returns 1000 (bounded default is 1000)
```

Full suite, lint, and types:

```
$ python -m pytest -q
1 failed, 195 passed, 1 skipped in 23.24s
Required test coverage of 80% reached. Total coverage: 88.27%

$ python -m ruff check src tests
All checks passed!
$ python -m ruff format --check src tests
71 files already formatted
$ python -m mypy src/snagline
Success: no issues found in 37 source files
```

The one failure is pre-existing and unrelated:
`tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` uses
`send_signal(SIGINT)`, unsupported on Windows. Filed separately as #69; it passes
on the ubuntu CI matrix.

## Benchmark

Not applicable -- no change to the `ingest()` path. `do_GET` gains one header
comparison per request, and only when a token is configured.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional authentication for HTTP server endpoints, with support for CLI flags and environment configuration.
  * Added configurable request-body size and risk-retention limits.
  * Kept the health check publicly accessible while protecting other endpoints.
  * Limited risk history to the newest configured entries.
  * Added clearer startup warnings when authentication is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->