### PR TITLE
fix: expose snagline.__version__ from distribution metadata

### DIFF
--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -26,7 +26,15 @@ from snagline.events import EpisodeMeta, StepEvent, make_signature
 from snagline.monitor import Monitor
 from snagline.risk import FailureRisk, TriggerType
 
+try:
+    from importlib.metadata import version
+
+    __version__ = version("snagline-agent")
+except Exception:
+    __version__ = "0.1.0"
+
 __all__ = [
+    "__version__",
     "Monitor",
     "StepEvent",
     "EpisodeMeta",


### PR DESCRIPTION
Fixes #70

`snagline/__init__.py` did not define `__version__` though the issue template instructs reporters to run `import snagline; print(snagline.__version__)`. This adds it via `importlib.metadata.version('snagline-agent')` with fallback to `0.1.0` when run from a source tree without install, and exposes it in `__all__`.

Tested locally: `python -c "import snagline; print(snagline.__version__)"` -> `0.1.0`, `ruff check` passes, full suite 220 passed (1 pre-existing unrelated failure).

This PR also serves as a live test for the recently fixed Auto Assign and PR Status Labels bots after fork-PR 403 handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accessible package version information through the public `__version__` value.
  * Version detection uses installed package metadata, with a fallback version when metadata is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->