### PR TITLE
feat(adapter): explicit OpenAI/Anthropic wrappers (project.md §6.5)

### DIFF
--- a/src/snagline/adapters/anthropic.py
+++ b/src/snagline/adapters/anthropic.py
@@ -1,0 +1,175 @@
+"""Anthropic adapter (project.md §6.5) -- explicit wrappers for raw SDK users.
+
+Mirrors ``adapters/openai.py`` for ``anthropic.Anthropic``.
+
+Usage::
+
+    from snagline.adapters.anthropic import wrap_anthropic_client
+
+    client = wrap_anthropic_client(monitor, anthropic_client, episode_id="ep-1")
+    resp = client.messages.create(model="claude-3-5-sonnet-20241022", messages=[...])
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import itertools
+import time
+from typing import Any
+
+from snagline.events import StepEvent, make_signature
+
+try:
+    from anthropic import Anthropic, AsyncAnthropic  # type: ignore
+except Exception:  # pragma: no cover
+    Anthropic = None  # type: ignore
+    AsyncAnthropic = None  # type: ignore
+
+
+def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
+    try:
+        usage = getattr(result, "usage", None)
+        if usage is None and isinstance(result, dict):
+            usage = result.get("usage")
+        if usage is None:
+            return None, None
+        if isinstance(usage, dict):
+            # Anthropic: input_tokens / output_tokens
+            return usage.get("input_tokens"), usage.get("output_tokens")
+        return getattr(usage, "input_tokens", None), getattr(usage, "output_tokens", None)
+    except Exception:
+        return None, None
+
+
+def observe_anthropic_call(
+    monitor: Any,
+    *,
+    episode_id: str,
+    model: str | None,
+    messages: Any | None = None,
+    latency_ms: float | None = None,
+    error: bool = False,
+    error_type: str | None = None,
+    result: Any | None = None,
+    step_id: str | None = None,
+) -> StepEvent:
+    sig_text = str(messages or "")
+    sig = make_signature("tool_call", model or "anthropic", sig_text)
+    tokens_in, tokens_out = (None, None)
+    if result is not None:
+        tokens_in, tokens_out = _extract_tokens(result)
+    event = StepEvent(
+        step_id=step_id or "anthropic",
+        episode_id=episode_id,
+        timestamp=time.time(),
+        action_type="tool_call",
+        action_signature=sig,
+        tool_name=model or "anthropic",
+        latency_ms=latency_ms,
+        error=error,
+        error_type=error_type,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        metadata={"adapter": "anthropic"},
+    )
+    with contextlib.suppress(Exception):
+        monitor.ingest(event)
+    return event
+
+
+def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any:
+    is_async = inspect.iscoroutinefunction(original)
+
+    def _sync(*args: Any, **kwargs: Any) -> Any:
+        model = kwargs.get("model", "unknown")
+        sig_text = str(kwargs.get("messages") or args)
+        start = time.time()
+        error = False
+        error_type = None
+        result = None
+        try:
+            result = original(*args, **kwargs)
+        except Exception as e:
+            error = True
+            error_type = type(e).__name__
+            raise
+        finally:
+            latency = (time.time() - start) * 1000.0
+            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            sig = make_signature("tool_call", str(model), sig_text)
+            event = StepEvent(
+                step_id=str(next(counter)),
+                episode_id=episode_id,
+                timestamp=time.time(),
+                action_type="tool_call",
+                action_signature=sig,
+                tool_name=str(model),
+                latency_ms=latency,
+                error=error,
+                error_type=error_type,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                metadata={"adapter": "anthropic"},
+            )
+            with contextlib.suppress(Exception):
+                monitor.ingest(event)
+        return result
+
+    async def _async(*args: Any, **kwargs: Any) -> Any:
+        model = kwargs.get("model", "unknown")
+        sig_text = str(kwargs.get("messages") or args)
+        start = time.time()
+        error = False
+        error_type = None
+        result = None
+        try:
+            result = await original(*args, **kwargs)
+        except Exception as e:
+            error = True
+            error_type = type(e).__name__
+            raise
+        finally:
+            latency = (time.time() - start) * 1000.0
+            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            sig = make_signature("tool_call", str(model), sig_text)
+            event = StepEvent(
+                step_id=str(next(counter)),
+                episode_id=episode_id,
+                timestamp=time.time(),
+                action_type="tool_call",
+                action_signature=sig,
+                tool_name=str(model),
+                latency_ms=latency,
+                error=error,
+                error_type=error_type,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                metadata={"adapter": "anthropic"},
+            )
+            with contextlib.suppress(Exception):
+                monitor.ingest(event)
+        return result
+
+    return _async if is_async else _sync
+
+
+def wrap_anthropic_client(monitor: Any, client: Any, episode_id: str = "anthropic") -> Any:
+    """Wrap an ``Anthropic``/``AsyncAnthropic`` client instance explicitly.
+
+    Patches ``client.messages.create`` in place on this instance only.
+    Returns the same client for chaining.
+    """
+    counter = itertools.count()
+    cur = getattr(client, "messages", None)
+    if cur is None:
+        return client
+    method = getattr(cur, "create", None)
+    if method is None or not callable(method):
+        return client
+    cur.create = _wrap_one(monitor, method, episode_id, counter)
+    return client
+
+
+def instrument_anthropic_explicit(monitor: Any, client: Any, episode_id: str = "anthropic") -> Any:
+    return wrap_anthropic_client(monitor, client, episode_id=episode_id)

--- a/src/snagline/adapters/anthropic.py
+++ b/src/snagline/adapters/anthropic.py
@@ -37,7 +37,9 @@ def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
         if isinstance(usage, dict):
             # Anthropic: input_tokens / output_tokens
             return usage.get("input_tokens"), usage.get("output_tokens")
-        return getattr(usage, "input_tokens", None), getattr(usage, "output_tokens", None)
+        return getattr(usage, "input_tokens", None), getattr(
+            usage, "output_tokens", None
+        )
     except Exception:
         return None, None
 
@@ -96,7 +98,9 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
             raise
         finally:
             latency = (time.time() - start) * 1000.0
-            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            tokens_in, tokens_out = (
+                _extract_tokens(result) if not error else (None, None)
+            )
             sig = make_signature("tool_call", str(model), sig_text)
             event = StepEvent(
                 step_id=str(next(counter)),
@@ -131,7 +135,9 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
             raise
         finally:
             latency = (time.time() - start) * 1000.0
-            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            tokens_in, tokens_out = (
+                _extract_tokens(result) if not error else (None, None)
+            )
             sig = make_signature("tool_call", str(model), sig_text)
             event = StepEvent(
                 step_id=str(next(counter)),
@@ -154,7 +160,9 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
     return _async if is_async else _sync
 
 
-def wrap_anthropic_client(monitor: Any, client: Any, episode_id: str = "anthropic") -> Any:
+def wrap_anthropic_client(
+    monitor: Any, client: Any, episode_id: str = "anthropic"
+) -> Any:
     """Wrap an ``Anthropic``/``AsyncAnthropic`` client instance explicitly.
 
     Patches ``client.messages.create`` in place on this instance only.
@@ -171,5 +179,7 @@ def wrap_anthropic_client(monitor: Any, client: Any, episode_id: str = "anthropi
     return client
 
 
-def instrument_anthropic_explicit(monitor: Any, client: Any, episode_id: str = "anthropic") -> Any:
+def instrument_anthropic_explicit(
+    monitor: Any, client: Any, episode_id: str = "anthropic"
+) -> Any:
     return wrap_anthropic_client(monitor, client, episode_id=episode_id)

--- a/src/snagline/adapters/openai.py
+++ b/src/snagline/adapters/openai.py
@@ -49,7 +49,9 @@ def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
             return None, None
         if isinstance(usage, dict):
             return usage.get("prompt_tokens"), usage.get("completion_tokens")
-        return getattr(usage, "prompt_tokens", None), getattr(usage, "completion_tokens", None)
+        return getattr(usage, "prompt_tokens", None), getattr(
+            usage, "completion_tokens", None
+        )
     except Exception:
         return None, None
 
@@ -116,7 +118,9 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
             raise
         finally:
             latency = (time.time() - start) * 1000.0
-            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            tokens_in, tokens_out = (
+                _extract_tokens(result) if not error else (None, None)
+            )
             sig = make_signature("tool_call", str(model), sig_text)
             event = StepEvent(
                 step_id=str(next(counter)),
@@ -151,7 +155,9 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
             raise
         finally:
             latency = (time.time() - start) * 1000.0
-            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            tokens_in, tokens_out = (
+                _extract_tokens(result) if not error else (None, None)
+            )
             sig = make_signature("tool_call", str(model), sig_text)
             event = StepEvent(
                 step_id=str(next(counter)),
@@ -201,6 +207,8 @@ def wrap_openai_client(monitor: Any, client: Any, episode_id: str = "openai") ->
     return client
 
 
-def instrument_openai_explicit(monitor: Any, client: Any, episode_id: str = "openai") -> Any:
+def instrument_openai_explicit(
+    monitor: Any, client: Any, episode_id: str = "openai"
+) -> Any:
     """Alias for ``wrap_openai_client`` covering the explicit-wrapper naming."""
     return wrap_openai_client(monitor, client, episode_id=episode_id)

--- a/src/snagline/adapters/openai.py
+++ b/src/snagline/adapters/openai.py
@@ -1,0 +1,206 @@
+"""OpenAI adapter (project.md §6.5) -- explicit wrappers for raw SDK users.
+
+This is the "raw loop" concrete form: a user with ``openai.OpenAI`` and no
+orchestration framework. Unlike ``snagline.auto.openai`` which monkeypatches
+the SDK globally, this module provides explicit, per-client wrappers that are
+obvious at the call site and never hide control flow.
+
+Usage::
+
+    from snagline.adapters.openai import wrap_openai_client
+
+    client = wrap_openai_client(monitor, openai_client, episode_id="ep-1")
+    resp = client.chat.completions.create(model="gpt-4o", messages=[...])
+
+or low-level observation without wrapping::
+
+    from snagline.adapters.openai import observe_openai_call
+    observe_openai_call(monitor, episode_id="ep", model="gpt-4o", error=False, latency_ms=120)
+
+The adapter is duck-typed and import-safe: it works without ``openai``
+installed and never hard-couples to a specific SDK release. All
+``StepEvent`` construction is fail-open and never raises into the host.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import itertools
+import time
+from typing import Any
+
+from snagline.events import StepEvent, make_signature
+
+try:
+    from openai import AsyncOpenAI, OpenAI  # type: ignore
+except Exception:  # pragma: no cover
+    OpenAI = None  # type: ignore
+    AsyncOpenAI = None  # type: ignore
+
+
+def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
+    # OpenAI response: result.usage.{prompt_tokens, completion_tokens, total_tokens}
+    try:
+        usage = getattr(result, "usage", None)
+        if usage is None and isinstance(result, dict):
+            usage = result.get("usage")
+        if usage is None:
+            return None, None
+        if isinstance(usage, dict):
+            return usage.get("prompt_tokens"), usage.get("completion_tokens")
+        return getattr(usage, "prompt_tokens", None), getattr(usage, "completion_tokens", None)
+    except Exception:
+        return None, None
+
+
+def observe_openai_call(
+    monitor: Any,
+    *,
+    episode_id: str,
+    model: str | None,
+    messages: Any | None = None,
+    prompt: Any | None = None,
+    latency_ms: float | None = None,
+    error: bool = False,
+    error_type: str | None = None,
+    result: Any | None = None,
+    step_id: str | None = None,
+) -> StepEvent:
+    """Observe a single OpenAI call as a ``StepEvent`` and ingest it.
+
+    ``messages``/``prompt`` are hashed into the signature, not stored.
+    If ``result`` is given, tokens are extracted from ``result.usage``.
+    Returns the ingested event.
+    """
+    sig_text = str(messages or prompt or "")
+    # Include model + message shape hash; exclude volatile content already hashed.
+    sig = make_signature("tool_call", model or "openai", sig_text)
+    tokens_in, tokens_out = (None, None)
+    if result is not None:
+        tokens_in, tokens_out = _extract_tokens(result)
+    event = StepEvent(
+        step_id=step_id or "openai",
+        episode_id=episode_id,
+        timestamp=time.time(),
+        action_type="tool_call",
+        action_signature=sig,
+        tool_name=model or "openai",
+        latency_ms=latency_ms,
+        error=error,
+        error_type=error_type,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        metadata={"adapter": "openai"},
+    )
+    with contextlib.suppress(Exception):
+        monitor.ingest(event)
+    return event
+
+
+def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any:
+    is_async = inspect.iscoroutinefunction(original)
+
+    def _sync(*args: Any, **kwargs: Any) -> Any:
+        model = kwargs.get("model", "unknown")
+        sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
+        start = time.time()
+        error = False
+        error_type: str | None = None
+        result: Any = None
+        try:
+            result = original(*args, **kwargs)
+        except Exception as e:
+            error = True
+            error_type = type(e).__name__
+            raise
+        finally:
+            latency = (time.time() - start) * 1000.0
+            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            sig = make_signature("tool_call", str(model), sig_text)
+            event = StepEvent(
+                step_id=str(next(counter)),
+                episode_id=episode_id,
+                timestamp=time.time(),
+                action_type="tool_call",
+                action_signature=sig,
+                tool_name=str(model),
+                latency_ms=latency,
+                error=error,
+                error_type=error_type,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                metadata={"adapter": "openai"},
+            )
+            with contextlib.suppress(Exception):
+                monitor.ingest(event)
+        return result
+
+    async def _async(*args: Any, **kwargs: Any) -> Any:
+        model = kwargs.get("model", "unknown")
+        sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
+        start = time.time()
+        error = False
+        error_type = None
+        result = None
+        try:
+            result = await original(*args, **kwargs)
+        except Exception as e:
+            error = True
+            error_type = type(e).__name__
+            raise
+        finally:
+            latency = (time.time() - start) * 1000.0
+            tokens_in, tokens_out = _extract_tokens(result) if not error else (None, None)
+            sig = make_signature("tool_call", str(model), sig_text)
+            event = StepEvent(
+                step_id=str(next(counter)),
+                episode_id=episode_id,
+                timestamp=time.time(),
+                action_type="tool_call",
+                action_signature=sig,
+                tool_name=str(model),
+                latency_ms=latency,
+                error=error,
+                error_type=error_type,
+                tokens_in=tokens_in,
+                tokens_out=tokens_out,
+                metadata={"adapter": "openai"},
+            )
+            with contextlib.suppress(Exception):
+                monitor.ingest(event)
+        return result
+
+    return _async if is_async else _sync
+
+
+def wrap_openai_client(monitor: Any, client: Any, episode_id: str = "openai") -> Any:
+    """Wrap an ``OpenAI``/``AsyncOpenAI`` client instance explicitly.
+
+    Patches ``client.chat.completions.create`` and ``client.completions.create``
+    in place on *this* instance only (no global monkeypatch). Returns the same
+    client for chaining. Safe to call even if the SDK is not installed or the
+    client shape is mocked.
+    """
+    counter = itertools.count()
+    for path in ("chat.completions.create", "completions.create"):
+        cur: Any = client
+        ok = True
+        parts = path.split(".")
+        for part in parts[:-1]:
+            cur = getattr(cur, part, None)
+            if cur is None:
+                ok = False
+                break
+        if not ok:
+            continue
+        method = getattr(cur, parts[-1], None)
+        if method is None or not callable(method):
+            continue
+        setattr(cur, parts[-1], _wrap_one(monitor, method, episode_id, counter))
+    return client
+
+
+def instrument_openai_explicit(monitor: Any, client: Any, episode_id: str = "openai") -> Any:
+    """Alias for ``wrap_openai_client`` covering the explicit-wrapper naming."""
+    return wrap_openai_client(monitor, client, episode_id=episode_id)


### PR DESCRIPTION
Fixes #78

Implements the missing §6.5 explicit wrappers for raw SDK users — the most common “raw loop” concrete form. Unlike `snagline.auto.*` which patches the SDK globally, these are **explicit per-client wrappers** that are obvious at the call site.

`adapters/openai.py`:
- `wrap_openai_client(monitor, client, episode_id="openai")` wraps `chat.completions.create` + `completions.create` on this instance only
- `observe_openai_call` low-level helper
- Sync+async, token extraction from `usage`, latency, error, fail-open via `contextlib.suppress`
- Duck-typed, import-safe without `openai` installed

`adapters/anthropic.py` mirrors for `messages.create` (input/output tokens).

Web research: paper 2608.02464 validates on bespoke/LangGraph/AutoGen but not raw SDK; this closes the lowest-friction adoption path while keeping core zero-dep. No deterministic verification or ESN yet — those are tracked in #80/#81/#82.

Checks:
- `python -m ruff check` passes
- `python -m mypy src/snagline` 2 pre-existing langchain errors only
- Manual mock-client verification: sync + error paths ingest correctly, metrics ok
- Full suite: 220 passed, 1 pre-existing unrelated failure

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added monitoring integrations for OpenAI and Anthropic clients.
  * Supports synchronous and asynchronous requests.
  * Captures model usage, token counts, latency, errors, and tool-call activity.
  * Provides explicit per-client instrumentation without affecting unrelated clients.

* **Reliability**
  * Monitoring failures are handled without interrupting application requests.
  * Original exceptions continue to be raised as expected.
  * Integrations remain available even when provider SDKs are not installed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->