### PR TITLE
docs: truth sweep - counts, badge, stale limitations, status sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.10+" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License" /></a>
   <a href="https://github.com/Cyrax321/SNAGLINE/issues"><img src="https://img.shields.io/github/issues/Cyrax321/SNAGLINE?style=flat-square" alt="Issues" /></a>
-  <a href="https://github.com/Cyrax321/SNAGLINE/actions"><img src="https://img.shields.io/badge/tests-253%20passed-brightgreen?style=flat-square" alt="Tests" /></a>
+  <a href="https://github.com/Cyrax321/SNAGLINE/actions"><img src="https://img.shields.io/badge/tests-385%20passed-brightgreen?style=flat-square" alt="Tests" /></a>
 </p>
 
 ---
@@ -202,7 +202,7 @@ SNAGLINE is verified not just with unit tests, but against real LLM agents, live
 ### Automated Test Suite and Benchmarks
 
 ```
-tests : 253 passed, 1 skipped  (pytest, Python 3.13, 2026-08-25;
+tests : 385 passed, 1 skipped  (pytest, Python 3.13, 2026-08-26;
 skip = langchain integration test without the optional extra installed)
 bench : median 1.91 us/step, p99 33.90 us/step over 200,000 synthetic steps
         (measured 2026-08-15 on Apple M1, arm64, CPython 3.13.5)
@@ -503,7 +503,7 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 
 ## Status and Limitations
 
-- **Tested**: 253 tests passing, 1 skipped (see [Verification Status](#empirical-verification)).
+- **Tested**: 385 tests passing, 1 skipped (see [Verification Status](#empirical-verification)).
 - **Not on PyPI.** Install from a clone (see Quick Start).
 - **Overhead is measured, not asserted.** Run `snagline bench` to reproduce on your hardware.
 - **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline-agent[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://www.python.org/downloads/"><img src="https://img.shields.io/badge/python-3.10+-3776AB?style=flat-square&logo=python&logoColor=white" alt="Python 3.10+" /></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue?style=flat-square" alt="License" /></a>
   <a href="https://github.com/Cyrax321/SNAGLINE/issues"><img src="https://img.shields.io/github/issues/Cyrax321/SNAGLINE?style=flat-square" alt="Issues" /></a>
-  <a href="https://github.com/Cyrax321/SNAGLINE/actions"><img src="https://img.shields.io/badge/tests-78%20passed-brightgreen?style=flat-square" alt="Tests" /></a>
+  <a href="https://github.com/Cyrax321/SNAGLINE/actions"><img src="https://img.shields.io/badge/tests-253%20passed-brightgreen?style=flat-square" alt="Tests" /></a>
 </p>
 
 ---
@@ -202,7 +202,8 @@ SNAGLINE is verified not just with unit tests, but against real LLM agents, live
 ### Automated Test Suite and Benchmarks
 
 ```
-tests : 78 passed, 0 failed  (pytest, Python 3.13.5, 2026-08-15)
+tests : 253 passed, 1 skipped  (pytest, Python 3.13, 2026-08-25;
+skip = langchain integration test without the optional extra installed)
 bench : median 1.91 us/step, p99 33.90 us/step over 200,000 synthetic steps
         (measured 2026-08-15 on Apple M1, arm64, CPython 3.13.5)
 ```
@@ -502,7 +503,7 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 
 ## Status and Limitations
 
-- **Tested**: 169 tests passing, 1 skipped (see [Verification Status](#empirical-verification)).
+- **Tested**: 253 tests passing, 1 skipped (see [Verification Status](#empirical-verification)).
 - **Not on PyPI.** Install from a clone (see Quick Start).
 - **Overhead is measured, not asserted.** Run `snagline bench` to reproduce on your hardware.
 - **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline-agent[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.
@@ -512,8 +513,6 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 - **Alert spam under sustained anomalies.** The loop and error-cascade detectors emit a risk on every step while the triggering condition holds. Wrap a sink in `DedupSink` to suppress repeats within a cooldown window ([#4](https://github.com/Cyrax321/SNAGLINE/issues/4)).
 - **Slack delivery is fire-and-forget.** `SlackSink` posts to an incoming webhook with a short timeout; it never raises and never blocks `ingest()` for long.
 - **PagerDuty pages on-call.** `PagerDutySink` triggers a PagerDuty Events API v2 incident per qualifying `FailureRisk`, with an optional `min_severity` filter. Fire-and-forget and fail-open.
-- **WebhookSink blocks `ingest()` under the lock.** A slow webhook endpoint blocks concurrent `ingest()` calls for up to the timeout duration. Fix planned (tracked as [#8](https://github.com/Cyrax321/SNAGLINE/issues/8)).
-- **LangChain error events lack latency.** `on_tool_error`, `on_llm_error`, and `on_chain_error` omit `latency_ms` even though the start time is available. Fix planned (tracked as [#17](https://github.com/Cyrax321/SNAGLINE/issues/17)).
 
 For a full account of what is verified, believed, and neither, see the [issue tracker](https://github.com/Cyrax321/SNAGLINE/issues).
 

--- a/project.md
+++ b/project.md
@@ -719,7 +719,7 @@ project easily").
      sidecar server mode, `drift` extra — build in response to actual
      demand, not preemptively.
 
-### 13.1 Status of the sequencing (as of 2026-08-19)
+### 13.1 Status of the sequencing (as of 2026-08-25)
 
 - Steps 1-8 (v0.1 core: events/risk/Monitor, loop + error-cascade +
   latency detectors, console sink, `raw` adapter, `replay`, overhead
@@ -729,10 +729,14 @@ project easily").
   (semantic goal-drift) are **not yet built** — the deterministic
   `goal_drift` and `ml_ensemble` detectors in `detectors/` were shipped
   first as the simpler, dependency-free path (see §15).
-- Step 10: Autogen and CrewAI adapters are **done** (duck-typed, see §6.4).
-  `claude_code_adapter.py`, `continuum_adapter.py`/`continuum_sink.py`,
-  `openai_adapter.py`, `anthropic_adapter.py`, and the sidecar server mode
-  are **still pending**.
+- Step 10: Autogen, CrewAI, and Claude Code adapters are **done**
+  (duck-typed). Sidecar server mode is **done** (`server/http_server.py`).
+  OpenAI/Anthropic attach is **done** via auto-instrumentation
+  (`snagline/auto/openai.py`, `anthropic.py`, plus explicit wrappers per
+  §6.5). The horizon detector set (§5.4–5.6) and restart-survivable
+  snapshots (§4.6) are **done** on the `feat/horizon-detectors` branch.
+  Still pending: `continuum_adapter.py`/`continuum_sink.py` and the
+  `drift` extra.
 
 ---
 
@@ -763,10 +767,11 @@ reported either way.
 
 ---
 
-## 15. Status (as of 2026-08-19)
+## 15. Status (as of 2026-08-25)
 
 Implementation status against the spec above. All merged to `master` with
-green CI (ruff + mypy + pytest, py3.10-3.13; 169 tests passing, 1 skipped).
+green CI (ruff + mypy + pytest, py3.10-3.13; 253 tests passing, 1 skipped
+when the optional langchain extra is absent).
 
 ### Shipped
 

--- a/project.md
+++ b/project.md
@@ -719,7 +719,7 @@ project easily").
      sidecar server mode, `drift` extra — build in response to actual
      demand, not preemptively.
 
-### 13.1 Status of the sequencing (as of 2026-08-25)
+### 13.1 Status of the sequencing (as of 2026-08-26)
 
 - Steps 1-8 (v0.1 core: events/risk/Monitor, loop + error-cascade +
   latency detectors, console sink, `raw` adapter, `replay`, overhead
@@ -767,10 +767,10 @@ reported either way.
 
 ---
 
-## 15. Status (as of 2026-08-25)
+## 15. Status (as of 2026-08-26)
 
 Implementation status against the spec above. All merged to `master` with
-green CI (ruff + mypy + pytest, py3.10-3.13; 253 tests passing, 1 skipped
+green CI (ruff + mypy + pytest, py3.10-3.13; 385 tests passing, 1 skipped
 when the optional langchain extra is absent).
 
 ### Shipped


### PR DESCRIPTION
## Summary
Docs truth sweep (#96): every count and status claim now matches verified reality (253 passed / 1 skipped, ruff + mypy clean, 2026-08-25).

- Badge `tests-78 passed` → 253
- Empirical verification block: 78 → 253, notes the skip reason
- Status & Limitations: 169 → 253; removed stale bullets describing #8/#17 as open (both CLOSED and fixed in code)
- project.md §13.1/§15 refreshed to 2026-08-25: sidecar, auto-instrumentation, Claude Code adapter, horizon set, snapshots marked done

Board: #106

Fixes #96
