### PR TITLE
docs(server): sidecar TLS story: nginx and Caddy termination guide (Refs #103)

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ Detectors reason only about **hashes, timings, counts, and booleans** -- never r
 - **FailureRisk** deliberately carries no `metadata` field. An alerting channel (webhook, Slack) cannot become an accidental data-exfiltration path.
 - **The `metadata` dict** on `StepEvent` is the one place raw content could leak if an adapter author puts it there. Detectors never read `metadata`, and sinks should not forward it by default.
 - **The webhook sink** transmits only `FailureRisk` fields (ids, score, trigger, detail, timestamp) -- never `StepEvent.content` or `StepEvent.metadata`.
-- **The HTTP sidecar** accepts arbitrary `StepEvent` JSON from any caller. For production use, front it with a reverse proxy that enforces authentication.
+- **The HTTP sidecar** serves plain HTTP and accepts arbitrary `StepEvent` JSON from any caller. For production use, front it with a reverse proxy that enforces authentication and terminates TLS; copy-paste nginx and Caddy configs are in [docs/ATTACH_ANY_SYSTEM.md](docs/ATTACH_ANY_SYSTEM.md#sidecar-tls-reverse-proxy-termination-issue-103). In-process TLS is the documented future option ([#103](https://github.com/Cyrax321/SNAGLINE/issues/103)).
 
 ## What SNAGLINE Is Not
 

--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -135,6 +135,165 @@ P0 items 1 to 3 are what turn this from "a library you wire in" into
 next highest-leverage move is P1 item 4 (pluggable state backend) and P1
 item 5 (alerting dedup/cooldown + Slack/PagerDuty sinks).
 
+## Sidecar TLS: reverse-proxy termination (issue #103)
+
+The sidecar (`snagline serve`) speaks plain HTTP and listens on
+`127.0.0.1:8787` by default. Loopback-only binding is safe on a shared host,
+but the moment telemetry crosses a network segment you do not fully trust
+(pod to pod, host to host, office to datacenter), the connection needs TLS.
+The supported production pattern is TLS termination at a reverse proxy:
+public traffic arrives at the proxy over HTTPS, the proxy strips TLS and
+forwards plaintext to the sidecar over loopback. Both configs below are
+copy-paste ready and introduce zero new Python dependencies.
+
+Assumptions used throughout: the sidecar runs on the same host as the proxy,
+on port 8787, with a bearer token set via `$SNAGLINE_SERVE_AUTH_TOKEN` (or
+`--auth-token`). Adjust the hostname and cert paths to yours.
+
+### nginx (stable, copy-paste)
+
+```nginx
+# /etc/nginx/sites-available/snagline
+
+# Standard WebSocket upgrade mapping (from the nginx proxy module docs).
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    http2 on;                          # nginx >= 1.25.1; older: "listen 443 ssl http2;"
+    server_name snagline.example.com;
+
+    ssl_certificate     /etc/letsencrypt/live/snagline.example.com/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/snagline.example.com/privkey.pem;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+
+    # Mirror the sidecar's --max-body-bytes (default 1000000). Unitless means
+    # bytes. Change both together: the edge should reject what the sidecar
+    # would reject so oversized batches die with 413 before reaching Python.
+    client_max_body_size 1000000;
+
+    location / {
+        proxy_pass http://127.0.0.1:8787;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Preserve the shared secret. nginx forwards Authorization unchanged
+        # by default; pinning it here makes that guarantee explicit and
+        # survives later refactors that add other proxy_set_header lines.
+        # The alternate X-Snagline-Token header also passes through untouched.
+        proxy_set_header Authorization $http_authorization;
+
+        # The sidecar exposes no WebSocket endpoints today; these two lines
+        # plus the map above keep the block correct if streaming endpoints
+        # are added later. Harmless for plain request/response POSTs.
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+
+        # Let a large batched POST drain slowly instead of being cut off at
+        # the 60s default.
+        proxy_read_timeout 300s;
+    }
+}
+```
+
+Enable it, then verify from outside the host:
+
+```bash
+sudo ln -s /etc/nginx/sites-available/snagline /etc/nginx/sites-enabled/
+sudo nginx -t && sudo systemctl reload nginx
+
+curl -fsS https://snagline.example.com/health
+curl -fsS -X POST https://snagline.example.com/events \
+  -H "Authorization: Bearer $SNAGLINE_SERVE_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"step_id":"1","episode_id":"run","timestamp":1735689600.0,"action_type":"tool_call","action_signature":"deadbeefdeadbeef"}'
+```
+
+The health probe returns `{"status": "ok"}` and the POST returns 202 with an
+`ingested` status. A missing or wrong token gets 401 exactly as it would
+against the sidecar directly; termination does not weaken auth because the
+proxy never inspects or strips the credential.
+
+### Caddy v2 (copy-paste)
+
+Caddy obtains and renews certificates automatically (ACME against Let's
+Encrypt or ZeroSSL), so TLS needs no configuration at all; the whole site
+block below is six lines:
+
+```caddy
+# /etc/caddy/Caddyfile
+snagline.example.com {
+	request_body {
+		max_size 1000000
+	}
+	reverse_proxy 127.0.0.1:8787
+}
+```
+
+- `reverse_proxy` forwards all request headers, `Authorization` included,
+  untouched, and proxies WebSockets and streaming responses (SSE) with no
+  extra configuration.
+- `request_body`'s `max_size` takes a byte count (unit suffixes like `MB`
+  also work); it mirrors the sidecar's `--max-body-bytes` default.
+- For a host that is not reachable from the public internet, swap automatic
+  ACME certificates for Caddy's own internal CA by adding `tls internal`
+  inside the site block.
+
+Reload with `caddy reload --config /etc/caddy/Caddyfile`, then run the same
+two `curl` checks as under nginx.
+
+### Threat model
+
+TLS termination solves wire confidentiality and integrity on every segment
+between the sending agent and the proxy host: passive observers cannot read
+event payloads or capture the bearer token, and the certificate proves the
+caller reached the intended endpoint. What it does not solve is the final
+hop: proxy to sidecar remains plaintext. On one trusted host across
+loopback, that residual exposure is usually acceptable. It is not acceptable
+when the proxy runs on a different machine than the sidecar, or when the
+shared host runs processes you do not control; in those cases wrap TLS in
+the sidecar process itself. That is the documented future option (issue
+#103): wrap `serve()`'s listening socket with a stdlib `ssl.SSLContext`
+exposed via `--certfile/--keyfile` flags. It would close the last plaintext
+hop and additionally allow mutual TLS, letting the sidecar authenticate
+clients by certificate without any external component. Both directions cost
+zero new dependencies: `ssl` is standard library, and a reverse proxy adds
+nothing to the Python environment, so the choice between them is purely
+operational.
+
+### Hardening checklist
+
+- **Rotate the bearer token on a schedule.** The token is read once at
+  startup, so rotation means a sidecar restart; plan for it. Pass the token
+  via `$SNAGLINE_SERVE_AUTH_TOKEN` rather than `--auth-token` so the secret
+  stays out of process listings and shell history.
+- **Keep the loopback bind.** The default `host="127.0.0.1"` exists so only
+  the proxy can reach the sidecar. Do not expose port 8787 off-host; if the
+  proxy must run on another machine, tunnel that segment (VPN/WireGuard)
+  until in-process TLS lands (issue #103).
+- **Keep the body-size caps in sync.** The sidecar rejects requests above
+  `--max-body-bytes` (default 1000000) with 413; mirror that number in
+  `client_max_body_size` (nginx) or `request_body max_size` (Caddy) so
+  oversized payloads are dropped at the edge instead of consuming sidecar
+  memory and CPU. The cap exists to bound per-request memory while still
+  admitting batched `StepEvent` arrays.
+- **Remember nothing sensitive is retained.** Events carry hashes, timings,
+  counts, and booleans, never prompt or response content. `GET /risks`
+  retains the most recent 1000 `FailureRisk` records (ids, scores, trigger
+  names); proxies' access logs record paths and status codes, not bodies.
+  Do not add `Authorization` (or any header logging) to your proxy log
+  format, and the deployment leaks nothing the library does not already
+  refuse to store.
+- **`GET /health` is intentionally unauthenticated** so liveness probes work
+  without secrets; it reveals reachability only.
+
 ## Progress log
 
 - **sidecar auth + hardening + 12-factor config + auto-instrumentation + PyPI

--- a/docs/INTEGRATION_MATRIX.md
+++ b/docs/INTEGRATION_MATRIX.md
@@ -13,6 +13,19 @@ dependency-free unless noted; the core is always zero-required-dependency.
 | Python auto-instrumentation | `snagline.auto` (OpenAI/Anthropic/LangChain) | Python | one import |
 | Framework adapters | `adapters.raw`, `langchain`, `langgraph`, `autogen`, `crewai`, `claude_code` | Python | wrap your loop |
 
+## Transport security
+
+| Path | Plaintext segment | TLS story |
+|------|-------------------|-----------|
+| In-process adapters / auto-instrumentation | none (no network) | not applicable |
+| HTTP sidecar, direct | client to loopback only | keep the default `127.0.0.1` bind; never expose 8787 off-host |
+| HTTP sidecar behind nginx or Caddy | proxy to sidecar over loopback | public TLS terminates at the proxy; copy-paste configs in [ATTACH_ANY_SYSTEM.md](ATTACH_ANY_SYSTEM.md#sidecar-tls-reverse-proxy-termination-issue-103) |
+| Webhook / Slack / PagerDuty sinks | none outbound | stdlib `urllib` speaks HTTPS to remote endpoints |
+
+In-process TLS for the sidecar itself is the documented future option
+(issue #103); it would remove even the loopback plaintext hop and enable
+mutual TLS, with zero new dependencies either way.
+
 ## Python auto-instrumentation (`snagline.auto`)
 
 Import-safe: a wrapper is a clean no-op when the SDK is absent, and handles


### PR DESCRIPTION
## Summary

Docs-only delivery of the preferred half of #103: a production TLS story for the sidecar via reverse-proxy termination. No `.py` file is touched; another agent owns `http_server.py` in parallel.

- `docs/ATTACH_ANY_SYSTEM.md`: new section "Sidecar TLS: reverse-proxy termination (issue #103)".
  - Copy-paste nginx stable server block: `listen 443 ssl` + `http2 on` (1.25.1+ syntax), `proxy_pass http://127.0.0.1:8787`, explicit `proxy_set_header Authorization $http_authorization` so the bearer secret survives termination, `client_max_body_size 1000000` matching the sidecar's `--max-body-bytes` default byte-for-byte, WebSocket upgrade map plus streaming note, `proxy_read_timeout 300s`. Includes enable steps and two curl verification commands (health + authorized POST).
  - Caddy v2 equivalent: automatic-HTTPS site block with `request_body max_size 1000000`, header-passthrough and auto WebSocket/SSE notes, `tls internal` variant for non-public hosts.
  - Threat-model paragraph: what TLS termination solves (wire confidentiality/integrity up to the proxy, endpoint identity, bearer-token protection), what it does not (the loopback plaintext hop), and why in-process wrapping of the `serve()` listening socket with a stdlib `ssl.SSLContext` (`--certfile/--keyfile`) is the documented future option per #103: it closes the last hop and enables mutual TLS. Zero new dependencies either way.
  - Hardening checklist: bearer rotation via `$SNAGLINE_SERVE_AUTH_TOKEN` (token read at startup, so rotation means restart; env over argv to keep secrets out of process listings), keep the default `127.0.0.1` bind, keep body caps in sync with rationale, no-content-retention reminder tied to the `GET /risks` deque of 1000 `FailureRisk` records.
- `docs/INTEGRATION_MATRIX.md`: new "Transport security" rows mapping each attach path to its plaintext segment and its TLS answer, linking the guide.
- `README.md`: the sidecar security bullet now states the plain-HTTP limitation explicitly and links the guide and #103.

Accuracy rule honored: every published directive was checked against current nginx stable and Caddy v2 behavior (`http2 on` since nginx 1.25.1 with fallback comment; unitless `client_max_body_size` is bytes; `request_body max_size` accepts byte counts; both proxies forward `Authorization` untouched by default). Facts cross-checked against source: port 8787 / host 127.0.0.1 defaults, 413 above `max_body_bytes=1000000`, Bearer + `X-Snagline-Token` auth with open `/health` in `server/http_server.py`; `$SNAGLINE_SERVE_AUTH_TOKEN` in `cli.py`.

## Verification

Writing-ban gate on this branch's full diff, counting codepoints U+2014 and U+2013 explicitly so the check itself stays within the ban:

```
$ python3 -c "import subprocess; d=subprocess.run(['git','diff','origin/master..origin/docs/sidecar-tls-story-103'],capture_output=True,text=True).stdout; print('em dashes:', d.count(chr(0x2014))); print('en dashes:', d.count(chr(0x2013)))"
em dashes: 0
en dashes: 0
```

Full test suite at this branch:

```
$ python -m pytest tests/ -q -o addopts=""
235 passed, 1 skipped in 20.65s
```

Scope check: all three commits touch only markdown files (`git show --stat`): README.md 1 line, INTEGRATION_MATRIX.md +13, ATTACH_ANY_SYSTEM.md +159. Note for reviewers running lint locally: `ruff` currently flags `src/snagline/sinks/logging_sink.py`, an untracked work-in-progress file from a concurrent branch present in the shared checkout; it is not part of this PR.

Mutation check statement: this PR contains no code, so there are no comparisons or thresholds to flip; instead of a code mutation I verified every config claim against the implementation constants listed above and re-ran the codepoint count over the pushed diff after the final edit (clean).

Board: #106

Fixes #103
