### PR TITLE
fix(tests): cross-platform SIGINT-free teardown reaps the hook bridge watch child

### DIFF
--- a/tests/test_hook_bridge.py
+++ b/tests/test_hook_bridge.py
@@ -3,17 +3,27 @@
 * sidecar ``POST /hooks/claude-code`` (Claude Code native ``http`` hooks)
 * ``snagline hook`` (command-hook bridge: stdin payload -> file/HTTP/local)
 * ``snagline watch --file`` (file bridge)
+
+Teardown contract (issue #69): every spawned child stops through
+``_graceful_stop``, a cross-platform ladder (graceful signal on POSIX,
+terminate() on Windows, then wait -> terminate -> kill escalation), so no
+platform orphans the watch subprocess and no ProcessLookupError escapes.
 """
 
 from __future__ import annotations
 
 import json
+import os
 import signal
+import socket
 import subprocess
 import sys
 import threading
 import time
 import urllib.request
+from contextlib import suppress
+
+import pytest
 
 from snagline.monitor import Monitor
 from snagline.risk import FailureRisk
@@ -47,6 +57,118 @@ def _post(url: str, obj: dict) -> dict:
     )
     with urllib.request.urlopen(req, timeout=5) as resp:
         return json.loads(resp.read())
+
+
+_STOP_TIMEOUT_S = 10.0
+
+
+class _HookTargetServer:
+    """Minimal localhost POST target for webhook-sink teardown tests.
+
+    Raw stdlib socket accept loop on an ephemeral 127.0.0.1 port. With
+    ``respond_ok`` it answers 200 like a healthy sink endpoint; in drop mode
+    it accepts and immediately closes, forcing the WebhookSink failure path
+    while still giving the test a deterministic readiness signal (the first
+    accepted connection). No sleeps needed anywhere.
+    """
+
+    def __init__(self, respond_ok: bool) -> None:
+        self.respond_ok = respond_ok
+        self.bodies: list[bytes] = []
+        self.accepts = 0
+        self._connected = threading.Event()
+        self._sock = socket.socket()
+        self._sock.bind(("127.0.0.1", 0))
+        self._sock.listen(8)
+        self.port: int = self._sock.getsockname()[1]
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+
+    def start(self) -> None:
+        self._thread.start()
+
+    def close(self) -> None:
+        with suppress(OSError):
+            self._sock.close()
+        self._thread.join(timeout=5)
+
+    def wait_for_connection(self, timeout: float) -> bool:
+        return self._connected.wait(timeout)
+
+    def _serve(self) -> None:
+        while True:
+            try:
+                conn, _ = self._sock.accept()
+            except OSError:
+                return  # listening socket closed by close()
+            self.accepts += 1
+            self._connected.set()
+            try:
+                data = conn.recv(65536)
+                if self.respond_ok and data:
+                    self.bodies.append(data)
+                    conn.sendall(b"HTTP/1.0 200 OK\r\nContent-Length: 0\r\n\r\n")
+                # Drop mode: closing with no response IS the failure the
+                # sink must survive.
+            except OSError:
+                pass
+            finally:
+                with suppress(OSError):
+                    conn.close()
+
+
+def _await_exit(proc: subprocess.Popen, timeout: float) -> None:
+    """Wait for exit, escalating terminate() -> kill() until reaped."""
+    try:
+        proc.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    # Rung 1: terminate() (SIGTERM on POSIX, TerminateProcess on Windows).
+    with suppress(Exception):
+        proc.terminate()
+    try:
+        proc.wait(timeout=timeout)
+        return
+    except subprocess.TimeoutExpired:
+        pass
+    # Rung 2: hard kill, then reap unconditionally.
+    with suppress(Exception):
+        proc.kill()
+    with suppress(Exception):
+        proc.wait(timeout=timeout)
+
+
+def _graceful_stop(proc: subprocess.Popen, timeout: float = _STOP_TIMEOUT_S) -> None:
+    """Cross-platform child teardown for issue #69.
+
+    ``Popen.send_signal(SIGINT)`` raises ValueError on Windows (only SIGTERM
+    and the CTRL_* events are supported there), which used to abort the
+    finally block in the follow-mode test and orphan the watch subprocess.
+    This ladder always ends with the child reaped, on every platform:
+
+    - graceful step: SIGINT on POSIX (identical to Ctrl-C on the CLI, so its
+      KeyboardInterrupt-suppressed summary still prints); terminate() first
+      on Windows where SIGINT does not exist;
+    - then wait(timeout) -> terminate() -> wait(timeout) -> kill().
+    """
+    if proc.poll() is None:
+        if os.name == "nt":
+            proc.terminate()
+        else:
+            proc.send_signal(signal.SIGINT)
+    _await_exit(proc, timeout)
+
+
+@pytest.fixture()
+def children():
+    """Track every Popen a test spawns; teardown asserts zero survivors."""
+    handles: list[subprocess.Popen] = []
+    yield handles
+    for proc in handles:
+        if proc.poll() is None:
+            _graceful_stop(proc, timeout=_STOP_TIMEOUT_S)
+    for proc in handles:
+        assert proc.poll() is not None, f"lingering child not reaped: {proc.args}"
 
 
 def test_sidecar_accepts_native_claude_code_payloads_and_fires_loop():
@@ -133,7 +255,7 @@ def test_hook_cli_never_fails_the_host():
     assert r3.returncode == 0  # unmapped events are silently dropped
 
 
-def test_watch_file_follow_sees_appended_lines(tmp_path):
+def test_watch_file_follow_sees_appended_lines(tmp_path, children):
     path = tmp_path / "live.jsonl"
     path.write_text(json.dumps(_base_event(0)) + "\n")
     proc = subprocess.Popen(
@@ -152,6 +274,7 @@ def test_watch_file_follow_sees_appended_lines(tmp_path):
         stderr=subprocess.PIPE,
         text=True,
     )
+    children.append(proc)
     try:
         time.sleep(1.0)  # let it consume the first line
         with open(path, "a") as fh:
@@ -161,8 +284,15 @@ def test_watch_file_follow_sees_appended_lines(tmp_path):
                 time.sleep(0.3)
         time.sleep(0.8)
     finally:
-        proc.send_signal(signal.SIGINT)  # graceful: same as Ctrl-C on the CLI
-        out, err = proc.communicate(timeout=10)
+        _graceful_stop(proc, timeout=_STOP_TIMEOUT_S)
+        out, err = proc.communicate(timeout=15)
+    assert proc.poll() is not None
+    if os.name == "nt":
+        # Windows teardown is terminate()-based: SIGINT does not exist for
+        # arbitrary children (issue #69), so the CLI never reaches its
+        # KeyboardInterrupt-path summary there. Reaping is the contract and
+        # the regression tests below assert it on every platform.
+        return
     assert "ingested 4 step(s)" in err
     assert '"trigger": "loop"' in err
 
@@ -178,3 +308,191 @@ def _base_event(i: int) -> dict:
         "action_signature": make_signature("tool_call", "Bash", "npm test"),
         "tool_name": "Bash",
     }
+
+
+_MALFORMED_MARKER = "malformed line"
+
+
+class _StderrCatcher:
+    """Drain a child's stderr on a thread without racing communicate().
+
+    Exposes the joined text plus a one-shot event that fires once a line
+    containing ``marker`` appears: a deterministic readiness signal with no
+    sleeps, so tests stop the child only after it provably finished the
+    work under test.
+    """
+
+    def __init__(self, proc: subprocess.Popen, marker: str) -> None:
+        self.lines: list[str] = []
+        self.marker_seen = threading.Event()
+        self._marker = marker
+        assert proc.stderr is not None
+        self._stream = proc.stderr
+        self._thread = threading.Thread(target=self._drain, daemon=True)
+        self._thread.start()
+
+    def _drain(self) -> None:
+        for line in self._stream:
+            self.lines.append(line)
+            if self._marker in line:
+                self.marker_seen.set()
+
+    @property
+    def text(self) -> str:
+        return "".join(self.lines)
+
+    def join(self, timeout: float) -> None:
+        self._thread.join(timeout=timeout)
+
+
+def _spawn_follow_watcher(
+    path, webhook_url: str, children: list[subprocess.Popen]
+) -> subprocess.Popen:
+    """Spawn ``snagline watch --follow`` against a webhook sink endpoint."""
+    proc = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "snagline.cli",
+            "watch",
+            "--file",
+            str(path),
+            "--follow",
+            "--episode-id",
+            "ep-follow",
+            "--sink",
+            "webhook",
+            "--webhook-url",
+            webhook_url,
+        ],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    children.append(proc)
+    return proc
+
+
+def test_watch_follow_teardown_reaps_the_child_on_a_healthy_run(tmp_path, children):
+    """Issue #69 regression, healthy path, runs on every platform.
+
+    The follow-mode watcher dispatches its loop risk to a live localhost
+    sink endpoint (first accepted connection = deterministic readiness,
+    no sleeps). A malformed sentinel line then proves the child finished
+    counting all four events before ``_graceful_stop`` ever runs. The child
+    must end fully reaped: poll() non-None, no ProcessLookupError, and the
+    module-level children fixture leaves zero lingering processes.
+    """
+    path = tmp_path / "healthy.jsonl"
+    path.write_text("\n".join(json.dumps(_base_event(i)) for i in range(4)) + "\n")
+    server = _HookTargetServer(respond_ok=True)
+    server.start()
+    try:
+        proc = _spawn_follow_watcher(
+            path, f"http://127.0.0.1:{server.port}/sink", children
+        )
+        catcher = _StderrCatcher(proc, _MALFORMED_MARKER)
+        assert server.wait_for_connection(30), (
+            "watcher never dispatched a risk to the local sink endpoint"
+        )
+        # Sentinel: once the CLI logs this line it has already counted every
+        # seeded event and is back in the follow poll loop, so stopping it
+        # now cannot truncate the run into an exit-code race.
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("{not json at all\n")
+        assert catcher.marker_seen.wait(30), "watcher never reached the sentinel line"
+        _graceful_stop(proc, timeout=_STOP_TIMEOUT_S)
+        catcher.join(10)
+    finally:
+        server.close()
+    assert proc.poll() is not None
+    assert any(b'"trigger": "loop"' in body for body in server.bodies), server.bodies
+    if os.name != "nt":
+        # SIGINT path: clean CLI shutdown with the full summary.
+        assert proc.returncode == 0
+        assert "ingested 4 step(s)" in catcher.text
+
+
+def test_watch_follow_cleanup_reaps_the_child_when_the_sink_endpoint_is_dead(
+    tmp_path, children
+):
+    """Issue #69 regression, failure path, runs on every platform.
+
+    The endpoint accepts connections and drops them without responding, so
+    the watcher's webhook POST fails mid-run. Even then the cleanup ladder
+    must reap the child cleanly after it finishes the whole seeded file.
+    """
+    path = tmp_path / "dead-endpoint.jsonl"
+    path.write_text("\n".join(json.dumps(_base_event(i)) for i in range(4)) + "\n")
+    server = _HookTargetServer(respond_ok=False)
+    server.start()
+    try:
+        proc = _spawn_follow_watcher(
+            path, f"http://127.0.0.1:{server.port}/sink", children
+        )
+        catcher = _StderrCatcher(proc, _MALFORMED_MARKER)
+        assert server.wait_for_connection(30), (
+            "watcher never attempted a webhook POST against the dead endpoint"
+        )
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write("{not json at all\n")
+        assert catcher.marker_seen.wait(30), "watcher never reached the sentinel line"
+        _graceful_stop(proc, timeout=_STOP_TIMEOUT_S)
+        catcher.join(10)
+    finally:
+        server.close()
+    assert proc.poll() is not None
+    assert server.accepts >= 1  # the failing POST genuinely happened
+    if os.name != "nt":
+        # Fail-open: the sink failure never crashes the watch loop...
+        assert proc.returncode == 0
+        assert "ingested 4 step(s)" in catcher.text
+        # ...it is logged and swallowed instead (guaranteed to be in the
+        # captured stream by now: logging precedes the sentinel line).
+        assert "webhook sink POST" in catcher.text
+
+
+def test_graceful_stop_tolerates_an_already_exited_child():
+    """No ProcessLookupError escapes when the child died before the stop."""
+    proc = subprocess.Popen([sys.executable, "-c", "pass"])
+    assert proc.wait(timeout=30) == 0
+    _graceful_stop(proc, timeout=_STOP_TIMEOUT_S)
+    assert proc.poll() is not None
+    assert proc.returncode == 0
+
+
+_IGNORES_SIGNALS_CHILD = (
+    "import signal, time\n"
+    "signal.signal(signal.SIGINT, signal.SIG_IGN)\n"
+    "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+    "print('ready', flush=True)\n"
+    "time.sleep(120)\n"
+)
+
+
+def test_graceful_stop_escalates_to_kill_when_the_child_ignores_signals(children):
+    """A child ignoring SIGINT and SIGTERM is still torn down by kill()."""
+    proc = subprocess.Popen(
+        [sys.executable, "-c", _IGNORES_SIGNALS_CHILD],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    children.append(proc)
+    ready = threading.Event()
+
+    def _wait_ready() -> None:
+        assert proc.stdout is not None
+        if proc.stdout.readline():
+            ready.set()
+
+    pump = threading.Thread(target=_wait_ready, daemon=True)
+    pump.start()
+    assert ready.wait(30), "stubborn child never signalled readiness"
+    _graceful_stop(proc, timeout=5.0)
+    assert proc.poll() is not None
+    pump.join(timeout=5)
+    with suppress(Exception):
+        proc.stdout.close()
+    if os.name != "nt":
+        # POSIX proof of escalation: only SIGKILL gets through the ignores.
+        assert proc.returncode == -signal.SIGKILL


### PR DESCRIPTION
## Summary

`tests/test_hook_bridge.py::test_watch_file_follow_sees_appended_lines` could not run on Windows: `Popen.send_signal(signal.SIGINT)` raises `ValueError: Unsupported signal: 2` there, the raise happened inside the `finally:` block, and the `snagline watch --follow` child was orphaned (issue #69).

Changes, all in `tests/test_hook_bridge.py` (no runtime code touched, POSIX behavior of the CLI is unchanged):

- `_graceful_stop()`: cross-platform stop ladder. Graceful step is SIGINT on POSIX (identical to Ctrl-C on the CLI, so its KeyboardInterrupt-suppressed summary still prints) and `terminate()` first on Windows where SIGINT does not exist. Then a shared escalation ladder: `wait(timeout)` -> `terminate()` -> `wait(timeout)` -> `kill()`, with every signal/wait guarded so no `ProcessLookupError` can escape even if the child already exited.
- A `children` fixture tracks every spawned `Popen` handle in a list (psutil-free) and asserts at teardown that every handle is reaped (`poll() is not None`), so zero lingering children can survive any test in this file.
- Cross-platform regression tests (no skip marks anywhere):
  - healthy path: follow-mode watcher dispatches its loop risk to a live 127.0.0.1 sink endpoint, then must be reaped (`poll()` non-None);
  - failure path: same watcher pointed at an endpoint that accepts connections and drops them, proving the cleanup ladder still reaps the child after failing webhook POSTs and that fail-open kept it alive (exit 0, full "ingested 4 step(s)" summary, logged-and-swallowed sink error);
  - already-exited child: stop must be a no-op, never raising ProcessLookupError;
  - a child that ignores SIGINT and SIGTERM proves the ladder escalates to SIGKILL on POSIX (`returncode == -SIGKILL`).
- Readiness synchronization uses deterministic signals only (server-side accept counting on ephemeral localhost ports plus a malformed-sentinel line observed via a stderr pump thread), no new sleeps.
- The original follow-mode test now stops through `_graceful_stop`. Its summary assertions stay POSIX-only: on Windows the teardown is terminate()-based by design (issue spec), so the CLI's SIGINT-path summary genuinely cannot exist there; reaping is asserted on every platform instead.

## Verification

Full gate, run against a clean worktree of this branch (origin/master + one commit):

```
$ python -m pytest tests/ -q -o addopts=""
239 passed, 1 skipped in 27.46s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
All checks passed!

$ mypy src
Success: no issues found in 39 source files

$ python -m pytest tests/test_hook_bridge.py -q -o addopts=""
.........                                                                [100%]
9 passed in 15.11s
```

Em dash scan of the diff (character U+2014, matched via printf escape rather than typed here): `git diff master...HEAD | grep -c "$(printf \\u2014)"` returns 0.

## Test honesty: mutation check performed

I deliberately broke the implementation and confirmed my own tests go red before reverting:

- Mutation: disabled the final `proc.kill()` rung in `_await_exit()`.
- Result: `test_graceful_stop_escalates_to_kill_when_the_child_ignores_signals` FAILED (child survived the ladder, `poll()` stayed None) and the `children` fixture raised "lingering child not reaped" during teardown: `1 failed, 8 passed, 1 error`.
- Reverted the mutation; suite green again.

Expectations are computed from documented behavior, never from the code under test: exactly one webhook POST per repetition episode comes from the shipped edge-triggered LoopDetector (issue #4 alert-spam fix), and the four ingested steps come from the four seeded fixture lines.

## Notes

- Scope: only `tests/test_hook_bridge.py`; no changes needed in `cli.py` or `adapters/claude_code.py`, so runtime behavior is identical everywhere including POSIX.
- Pre-existing note: two ruff errors visible in some runs of the shared working tree come from another agent's uncommitted files (`sinks/logging_sink.py`); they are not part of this branch. The clean-tree gate above is the authoritative result.

Board: #106

Fixes #69

