### PR TITLE
feat(server): serve Prometheus text exposition on GET /metrics

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -123,8 +123,15 @@ enterprise-grade alerting. Concretely:
 ### P3 (trust and observability)
 
 10. Monitor self-metrics (Prometheus), health endpoint, structured logs.
-    **Done (partial):** `Monitor.metrics()` counters + `GET /metrics` sidecar
-    endpoint (#47). Prometheus export and structured logging remain.
+    **Done (mostly):** `Monitor.metrics()` counters (#47) and the `GET
+    /metrics` sidecar endpoint now speak Prometheus text exposition 0.0.4 by
+    default (#98): `snagline_events_total`,
+    `snagline_risks_total{trigger,severity}`, `snagline_episodes_active`, and
+    the `snagline_ingest_seconds` count/sum pair. The legacy JSON body stays
+    available via `?format=classic`, an `Accept: application/json` header,
+    or `SNAGLINE_METRICS_FORMAT=classic`. Scrape config: point Prometheus at
+    the sidecar with `metrics_path: /metrics` (same port and auth token as
+    the event endpoints). Structured logging remains.
 11. Integration matrix document plus a prominent "10-line custom adapter"
     path. **Done:** `docs/INTEGRATION_MATRIX.md` (#49).
 

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -97,6 +97,13 @@ class Config:
     # Structure only: the emitted object never carries prompt/response content.
     log_format: str = "text"
 
+    # --- Sidecar /metrics exposition (issue #98) -----------------------------
+    # Format served by GET /metrics on the sidecar: "prometheus" serves text
+    # exposition version 0.0.4 (the default), "classic" serves the legacy JSON
+    # counters body. Per-request override via ?format=classic or
+    # ?format=prometheus; environment override SNAGLINE_METRICS_FORMAT.
+    metrics_format: str = "prometheus"
+
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
     def from_env_overrides(

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -7,7 +7,7 @@ shell script, a Claude Code hook) can POST ``StepEvent`` JSON to:
                                or a JSON array of StepEvent objects     (batched)
     POST /hooks/claude-code  body: a native Claude Code hook payload -> mapped + ingested
     GET  /health                                                     -> 200 OK
-    GET  /metrics                                                    -> self-observability counters
+    GET  /metrics                                                    -> Prometheus text exposition (v0.0.4)
 
 POST bodies are capped at ``max_body_bytes`` (default 1 MB); larger payloads
 get 413. This keeps the sidecar safe to expose and able to absorb buffered
@@ -23,6 +23,16 @@ probes -- everything else, GET and POST alike, is behind the token.
 ``GET /risks``; older ones are discarded so an unbounded sender cannot grow the
 sidecar's memory without limit.
 
+``GET /metrics`` speaks Prometheus text exposition version 0.0.4 by default
+(issue #98), rendered with plain string formatting and no client library:
+``snagline_events_total``, ``snagline_risks_total{trigger,severity}``,
+``snagline_episodes_active``, the ``snagline_ingest_seconds`` count/sum pair,
+and the raw ``Monitor.metrics()`` counters under ``snagline_monitor_*_total``.
+The legacy JSON counters body is still served with ``?format=classic``, for
+clients sending ``Accept: application/json``, or when the sidecar is started
+with ``SNAGLINE_METRICS_FORMAT=classic`` (config key ``metrics_format``);
+``?format=prometheus`` forces the new format back on per request.
+
 No framework, no third-party dependency -- this keeps the zero-dependency
 principle intact even for server mode. For high-throughput production use,
 front it with a real ASGI server / reverse proxy; that is the user's infra
@@ -37,16 +47,242 @@ from __future__ import annotations
 
 import json
 import logging
+import math
 import sys
-from collections import deque
+import threading
+import time
+from collections import OrderedDict, deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
+from urllib.parse import parse_qs, urlsplit
 
 from snagline.adapters.claude_code import HookTracker, ingest_payload
+from snagline.config import Config
 from snagline.events import StepEvent
 from snagline.monitor import Monitor
 
 logger = logging.getLogger("snagline")
+
+# Content type required for Prometheus text exposition format 0.0.4.
+PROMETHEUS_CONTENT_TYPE = "text/plain; version=0.0.4; charset=utf-8"
+# Supported values of the metrics_format config/env/request toggle.
+METRICS_FORMATS = ("prometheus", "classic")
+# Bound on distinct episode ids tracked for the episodes-active gauge. Episode
+# ids are identifiers, never content; the cap keeps memory bounded even if a
+# host streams unlimited unique ids through one long-lived sidecar process.
+_MAX_TRACKED_EPISODES = 10_000
+
+
+def _escape_label(value: str) -> str:
+    """Escape a Prometheus label value (backslash, quote, newline)."""
+    return value.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+
+
+def _format_sample_value(value: float | int) -> str:
+    """Render a sample value the way the exposition format expects."""
+    number = float(value)
+    if math.isnan(number):
+        return "NaN"
+    if math.isinf(number):
+        return "+Inf" if number > 0 else "-Inf"
+    return repr(float(value))
+
+
+def _resolve_metrics_format(explicit: str | None) -> str:
+    """Pick the startup-time default for GET /metrics.
+
+    Precedence: explicit argument, then SNAGLINE_METRICS_FORMAT via Config,
+    then the built-in Config default ("prometheus"). Unknown values are
+    logged and replaced by "prometheus": configuration must never take the
+    sidecar down (fail-open).
+    """
+    candidate = explicit
+    if candidate is None:
+        try:
+            candidate = Config.from_env_overrides().get("metrics_format")
+        except Exception:
+            logger.debug(
+                "snagline: env lookup for metrics_format failed", exc_info=True
+            )
+            candidate = None
+    if candidate is None:
+        candidate = Config().metrics_format
+    name = str(candidate).strip().lower()
+    if name in METRICS_FORMATS:
+        return name
+    logger.warning("snagline: unknown metrics format %r; serving prometheus", candidate)
+    return "prometheus"
+
+
+def _choose_metrics_format(
+    query: dict[str, list[str]], accept_header: str | None, configured: str
+) -> str:
+    """Resolve the format for one GET /metrics request.
+
+    An explicit ``?format=`` parameter wins. Without it, clients that send
+    ``Accept: application/json`` keep getting the legacy JSON body; everyone
+    else gets the configured default (prometheus since issue #98).
+    """
+    requested = (query.get("format") or [""])[-1].strip().lower()
+    if requested:
+        if requested in METRICS_FORMATS:
+            return requested
+        logger.warning(
+            "snagline: unknown ?format=%r; falling back to negotiation", requested
+        )
+    accept = (accept_header or "").lower()
+    if "application/json" in accept:
+        return "classic"
+    return configured
+
+
+class SidecarMetricsCollector:
+    """Process-lifetime sidecar counters, renderable as Prometheus text.
+
+    Counts risks per ``(trigger, severity)`` by acting as one extra sink on
+    the Monitor, plus HTTP-layer totals: events accepted, time spent inside
+    ``Monitor.ingest``, and distinct episode ids seen (bounded FIFO table,
+    ids only, no content). Every entry point swallows its own exceptions:
+    like any sink, this must never take down ingestion or serving.
+    """
+
+    def __init__(self, max_episodes: int = _MAX_TRACKED_EPISODES) -> None:
+        self._lock = threading.Lock()
+        self._risks: dict[tuple[str, str], int] = {}
+        self._events_total = 0
+        self._ingest_count = 0
+        self._ingest_sum = 0.0
+        # Insertion-ordered id set with FIFO eviction at max_episodes.
+        self._episodes: OrderedDict[str, None] = OrderedDict()
+        self._max_episodes = max(1, int(max_episodes))
+
+    def emit(self, risk: Any) -> None:
+        """AlertSink protocol entry point; counts one risk by label pair."""
+        try:
+            key = (str(risk.trigger), str(risk.severity))
+            with self._lock:
+                self._risks[key] = self._risks.get(key, 0) + 1
+        except Exception:
+            logger.debug("snagline: metrics collector emit failed", exc_info=True)
+
+    def record_ingest(self, episode_id: str | None, elapsed_seconds: float) -> None:
+        """Record one accepted event and its ingest wall time."""
+        try:
+            with self._lock:
+                self._events_total += 1
+                self._ingest_count += 1
+                self._ingest_sum += max(0.0, float(elapsed_seconds))
+                if episode_id is not None:
+                    key = str(episode_id)
+                    self._episodes.pop(key, None)
+                    self._episodes[key] = None
+                    while len(self._episodes) > self._max_episodes:
+                        self._episodes.popitem(last=False)
+        except Exception:
+            logger.debug("snagline: metrics record failed", exc_info=True)
+
+    def snapshot(self) -> dict[str, Any]:
+        """Return a consistent copy of the counters for rendering."""
+        with self._lock:
+            return {
+                "events_total": self._events_total,
+                "risks": sorted(self._risks.items()),
+                "episodes_active": len(self._episodes),
+                "ingest_count": self._ingest_count,
+                "ingest_sum": self._ingest_sum,
+            }
+
+    def render_prometheus(self, monitor_metrics: dict[str, int]) -> str:
+        """Render the full exposition body (version 0.0.4 text format).
+
+        ``monitor_metrics`` is the ``Monitor.metrics()`` snapshot; those four
+        counters are exposed under ``snagline_monitor_*_total`` names so the
+        sidecar view adds process-lifetime detail without renaming anything
+        the JSON endpoint already published.
+        """
+        snap = self.snapshot()
+        lines: list[str] = []
+        lines.append(
+            "# HELP snagline_events_total Steps ingested through this sidecar."
+        )
+        lines.append("# TYPE snagline_events_total counter")
+        lines.append(f"snagline_events_total {snap['events_total']}")
+        lines.append(
+            "# HELP snagline_risks_total Risks emitted by trigger and severity."
+        )
+        lines.append("# TYPE snagline_risks_total counter")
+        for (trigger, severity), count in snap["risks"]:
+            lines.append(
+                f'snagline_risks_total{{trigger="{_escape_label(trigger)}",'
+                f'severity="{_escape_label(severity)}"}} {count}'
+            )
+        lines.append(
+            "# HELP snagline_episodes_active Distinct episode ids seen since start."
+        )
+        lines.append("# TYPE snagline_episodes_active gauge")
+        lines.append(f"snagline_episodes_active {snap['episodes_active']}")
+        lines.append("# HELP snagline_ingest_seconds Wall time spent ingesting steps.")
+        lines.append("# TYPE snagline_ingest_seconds summary")
+        lines.append(f"snagline_ingest_seconds_count {snap['ingest_count']}")
+        lines.append(
+            f"snagline_ingest_seconds_sum {_format_sample_value(snap['ingest_sum'])}"
+        )
+        monitor_families = (
+            (
+                "events_ingested",
+                "snagline_monitor_events_ingested_total",
+                "Events ingested by the Monitor.",
+            ),
+            (
+                "risks_emitted",
+                "snagline_monitor_risks_emitted_total",
+                "Risks emitted by the Monitor.",
+            ),
+            (
+                "detector_errors",
+                "snagline_monitor_detector_errors_total",
+                "Detector exceptions swallowed (fail-open).",
+            ),
+            (
+                "sink_errors",
+                "snagline_monitor_sink_errors_total",
+                "Sink exceptions swallowed (fail-open).",
+            ),
+        )
+        for key, name, help_text in monitor_families:
+            lines.append(f"# HELP {name} {help_text}")
+            lines.append(f"# TYPE {name} counter")
+            lines.append(f"{name} {monitor_metrics.get(key, 0)}")
+        return "\n".join(lines) + "\n"
+
+
+def _attach_metrics_collector(monitor: Any, collector: SidecarMetricsCollector) -> None:
+    """Register ``collector`` as one extra sink so risks are counted per label.
+
+    The base Monitor has no public add-sink API yet, so prefer ``add_sink``
+    when it exists and fall back to appending to its sink list otherwise.
+    Guarded end to end: any failure leaves serving fully functional, only the
+    per-label risk counters stay empty. Monitor dispatch already treats sinks
+    as fail-open, matching project.md §1.2.
+    """
+    try:
+        add_sink = getattr(monitor, "add_sink", None)
+        if callable(add_sink):
+            add_sink(collector)
+            return
+        sinks = getattr(monitor, "_sinks", None)
+        if isinstance(sinks, list):
+            sinks.append(collector)
+        else:
+            logger.warning(
+                "snagline: cannot attach metrics collector to %s",
+                type(monitor).__name__,
+            )
+    except Exception:
+        logger.warning(
+            "snagline: attaching metrics collector failed; risk labels stay empty",
+            exc_info=True,
+        )
 
 
 def make_handler(
@@ -54,8 +290,14 @@ def make_handler(
     auth_token: str | None = None,
     max_body_bytes: int = 1_000_000,
     max_risks: int = 1000,
+    metrics_format: str | None = None,
 ) -> type[BaseHTTPRequestHandler]:
-    """Build a request-handler class bound to ``monitor``."""
+    """Build a request-handler class bound to ``monitor``.
+
+    ``metrics_format`` pins the default GET /metrics body; when omitted the
+    SNAGLINE_METRICS_FORMAT environment variable decides, then the built-in
+    "prometheus" default (see ``_resolve_metrics_format``).
+    """
     tracker = HookTracker()
 
     class _Handler(BaseHTTPRequestHandler):
@@ -65,6 +307,8 @@ def make_handler(
         snagline_risks: Any = None
         snagline_auth: str | None = None
         snagline_max_body: int = 1_000_000
+        snagline_collector: Any = None
+        snagline_metrics_format: str = "prometheus"
 
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             # Route http.server's access log through logging, not stderr raw.
@@ -91,12 +335,35 @@ def make_handler(
             if not self._authorized():
                 self._respond(401, {"error": "unauthorized"})
                 return
-            if self.path == "/metrics":
-                self._respond(200, self.snagline_monitor.metrics())
-            elif self.path == "/risks":
+            split = urlsplit(self.path)
+            if split.path == "/metrics":
+                self._serve_metrics(parse_qs(split.query))
+            elif split.path == "/risks":
                 self._respond(200, {"risks": list(self.snagline_risks)})
             else:
                 self._respond(404, {"error": "not found"})
+
+        def _serve_metrics(self, query: dict[str, list[str]]) -> None:
+            """Serve either exposition format, failing open to an empty body.
+
+            Rendering happens under try/except because a scrape endpoint that
+            raises would break scrapers' confidence far more than an empty
+            (valid) body does.
+            """
+            fmt = _choose_metrics_format(
+                query, self.headers.get("Accept"), self.snagline_metrics_format
+            )
+            if fmt == "classic":
+                self._respond(200, self.snagline_monitor.metrics())
+                return
+            try:
+                body = self.snagline_collector.render_prometheus(
+                    self.snagline_monitor.metrics()
+                )
+            except Exception:
+                logger.exception("snagline: prometheus render failed")
+                body = ""
+            self._respond_text(200, body, PROMETHEUS_CONTENT_TYPE)
 
         def do_POST(self) -> None:  # noqa: N802 - http.server naming
             if not self._authorized():
@@ -162,7 +429,7 @@ def make_handler(
                     except (ValueError, TypeError):
                         self._respond(400, {"error": "invalid StepEvent in batch"})
                         return
-                    self.snagline_monitor.ingest(event)
+                    self._ingest_recorded(event)
                     count += 1
                 self._respond(202, {"status": "ingested", "count": count})
                 return
@@ -178,8 +445,24 @@ def make_handler(
                 return
             # Ingest itself is fail-open inside the Monitor; a bad event shape
             # above is the only client-visible error.
-            self.snagline_monitor.ingest(event)
+            self._ingest_recorded(event)
             self._respond(202, {"status": "ingested", "step_id": event.step_id})
+
+        def _ingest_recorded(self, event: StepEvent) -> None:
+            """Ingest one event while recording sidecar metrics around it.
+
+            The collector swallows its own exceptions, so bookkeeping can
+            never turn into a serving failure; the ingest call itself keeps
+            exactly the Monitor's own fail-open contract.
+            """
+            collector = self.snagline_collector
+            start = time.perf_counter()
+            try:
+                self.snagline_monitor.ingest(event)
+            finally:
+                if collector is not None:
+                    elapsed = time.perf_counter() - start
+                    collector.record_ingest(event.episode_id, elapsed)
 
         def _post_claude_hook(self) -> None:
             """Accept a native Claude Code hook payload (http hook type).
@@ -197,9 +480,14 @@ def make_handler(
             except (ValueError, json.JSONDecodeError):
                 self._respond(400, {"error": "invalid hook JSON"})
                 return
+            collector = self.snagline_collector
+            start = time.perf_counter()
             event = ingest_payload(
                 self.snagline_monitor, payload, self.snagline_tracker
             )
+            if collector is not None and event is not None:
+                elapsed = time.perf_counter() - start
+                collector.record_ingest(event.episode_id, elapsed)
             self._respond(
                 202,
                 {
@@ -220,6 +508,14 @@ def make_handler(
             self.end_headers()
             self.wfile.write(data)
 
+        def _respond_text(self, code: int, text: str, content_type: str) -> None:
+            data = text.encode("utf-8")
+            self.send_response(code)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(data)))
+            self.end_headers()
+            self.wfile.write(data)
+
     _Handler.snagline_monitor = monitor
     _Handler.snagline_tracker = tracker
     # Bounded: POST /risks is an open-ended ingest point, so retain only the
@@ -227,6 +523,9 @@ def make_handler(
     _Handler.snagline_risks = deque(maxlen=max(1, max_risks))
     _Handler.snagline_auth = auth_token
     _Handler.snagline_max_body = max_body_bytes
+    _Handler.snagline_collector = SidecarMetricsCollector()
+    _attach_metrics_collector(monitor, _Handler.snagline_collector)
+    _Handler.snagline_metrics_format = _resolve_metrics_format(metrics_format)
     return _Handler
 
 
@@ -237,10 +536,12 @@ def make_server(
     auth_token: str | None = None,
     max_body_bytes: int = 1_000_000,
     max_risks: int = 1000,
+    metrics_format: str | None = None,
 ) -> ThreadingHTTPServer:
     """Construct a ready-to-``serve_forever()`` sidecar server."""
     return ThreadingHTTPServer(
-        (host, port), make_handler(monitor, auth_token, max_body_bytes, max_risks)
+        (host, port),
+        make_handler(monitor, auth_token, max_body_bytes, max_risks, metrics_format),
     )
 
 
@@ -251,9 +552,12 @@ def serve(
     auth_token: str | None = None,
     max_body_bytes: int = 1_000_000,
     max_risks: int = 1000,
+    metrics_format: str | None = None,
 ) -> None:
     """Run the sidecar server in the foreground until interrupted."""
-    server = make_server(monitor, host, port, auth_token, max_body_bytes, max_risks)
+    server = make_server(
+        monitor, host, port, auth_token, max_body_bytes, max_risks, metrics_format
+    )
     logger.info(
         "snagline sidecar listening on http://%s:%d (POST /events, GET /health)%s",
         host,

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -141,9 +141,10 @@ class SidecarMetricsCollector:
 
     Counts risks per ``(trigger, severity)`` by acting as one extra sink on
     the Monitor, plus HTTP-layer totals: events accepted, time spent inside
-    ``Monitor.ingest``, and distinct episode ids seen (bounded FIFO table,
-    ids only, no content). Every entry point swallows its own exceptions:
-    like any sink, this must never take down ingestion or serving.
+    ``Monitor.ingest``, and distinct episode ids seen (bounded table with
+    least-recently-seen eviction, ids only, no content). Every entry point
+    swallows its own exceptions: like any sink, this must never take down
+    ingestion or serving.
     """
 
     def __init__(self, max_episodes: int = _MAX_TRACKED_EPISODES) -> None:
@@ -152,7 +153,9 @@ class SidecarMetricsCollector:
         self._events_total = 0
         self._ingest_count = 0
         self._ingest_sum = 0.0
-        # Insertion-ordered id set with FIFO eviction at max_episodes.
+        # Episode id table: reseeing an id moves it to the end, so when the
+        # cap bites we forget the episode quiet for the longest time, which
+        # is the right approximation of "active" for a long-lived sidecar.
         self._episodes: OrderedDict[str, None] = OrderedDict()
         self._max_episodes = max(1, int(max_episodes))
 

--- a/tests/server/test_metrics_prometheus.py
+++ b/tests/server/test_metrics_prometheus.py
@@ -251,7 +251,7 @@ def test_escape_label_handles_backslash_quote_newline():
     assert _escape_label("plain") == "plain"
 
 
-def test_episode_table_evicts_oldest_at_cap():
+def test_episode_table_evicts_least_recently_seen_at_cap():
     collector = SidecarMetricsCollector(max_episodes=2)
     collector.record_ingest("ep-a", 0.001)
     collector.record_ingest("ep-b", 0.001)

--- a/tests/server/test_metrics_prometheus.py
+++ b/tests/server/test_metrics_prometheus.py
@@ -66,16 +66,22 @@ def _step(index, sig, episode="ep-metrics", error=False):
 
 
 def _parse_samples(body: str) -> dict:
-    """Parse exposition lines into {(name, labels): value}, asserting shape."""
-    samples: dict = {}
+    """Parse exposition lines into {(name, labels): value}, asserting shape.
+
+    Also rejects duplicate time series (same name and labels twice), which
+    Prometheus itself refuses to ingest.
+    """
+    seen: list = []
     for line in body.splitlines():
         if not line or line.startswith("#"):
             continue
         assert SAMPLE_LINE_RE.match(line), f"bad exposition line: {line!r}"
         head, _, value = line.rpartition(" ")
         name, _, labels = head.partition("{")
-        samples[(name, labels.rstrip("}"))] = float(value)
-    return samples
+        seen.append((name, labels.rstrip("}"), float(value)))
+    keys = [(name, labels) for name, labels, _ in seen]
+    assert len(keys) == len(set(keys)), f"duplicate time series: {keys}"
+    return {(name, labels): value for name, labels, value in seen}
 
 
 def test_empty_monitor_serves_valid_prometheus():

--- a/tests/server/test_metrics_prometheus.py
+++ b/tests/server/test_metrics_prometheus.py
@@ -1,0 +1,302 @@
+"""Prometheus exposition tests for GET /metrics (issue #98).
+
+Every detector-side assertion here has both sides: an injected-failure
+sequence that must fire (exact trigger label) and a healthy sequence that
+must stay silent. Expected counts are derived from the documented detector
+thresholds, never by calling the code under test.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import threading
+import urllib.request
+
+from snagline.monitor import Monitor
+from snagline.server.http_server import (
+    PROMETHEUS_CONTENT_TYPE,
+    SidecarMetricsCollector,
+    _escape_label,
+    make_server,
+)
+
+# Sanity shape every sample line must satisfy (spec of issue #98).
+SAMPLE_LINE_RE = re.compile(r"^[a-zA-Z_:][a-zA-Z0-9_:]*(\{.*\})? [0-9.eE+-]+$")
+
+
+def _start_server(**kwargs):
+    server = make_server(Monitor.default(sinks=[]), host="127.0.0.1", port=0, **kwargs)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}"
+
+
+def _stop(server) -> None:
+    server.shutdown()
+    server.server_close()
+
+
+def _get(base: str, path: str, headers: dict | None = None):
+    req = urllib.request.Request(base + path, headers=headers or {}, method="GET")
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        return resp.status, dict(resp.headers), resp.read().decode("utf-8")
+
+
+def _post(base: str, payload) -> None:
+    req = urllib.request.Request(
+        base + "/events",
+        data=json.dumps(payload).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    with urllib.request.urlopen(req, timeout=5) as resp:
+        assert resp.status == 202
+
+
+def _step(index, sig, episode="ep-metrics", error=False):
+    return {
+        "step_id": str(index),
+        "episode_id": episode,
+        "timestamp": 1718300000.0 + index,
+        "action_type": "tool_call",
+        "action_signature": sig,
+        "tool_name": "search",
+        "error": error,
+    }
+
+
+def _parse_samples(body: str) -> dict:
+    """Parse exposition lines into {(name, labels): value}, asserting shape."""
+    samples: dict = {}
+    for line in body.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        assert SAMPLE_LINE_RE.match(line), f"bad exposition line: {line!r}"
+        head, _, value = line.rpartition(" ")
+        name, _, labels = head.partition("{")
+        samples[(name, labels.rstrip("}"))] = float(value)
+    return samples
+
+
+def test_empty_monitor_serves_valid_prometheus():
+    server, base = _start_server()
+    try:
+        status, headers, body = _get(base, "/metrics")
+        assert status == 200
+        assert headers["Content-Type"] == PROMETHEUS_CONTENT_TYPE
+        # HELP and TYPE lines exist for every family even with zero traffic.
+        for family in (
+            "snagline_events_total",
+            "snagline_risks_total",
+            "snagline_episodes_active",
+            "snagline_ingest_seconds",
+            "snagline_monitor_events_ingested_total",
+            "snagline_monitor_risks_emitted_total",
+            "snagline_monitor_detector_errors_total",
+            "snagline_monitor_sink_errors_total",
+        ):
+            assert f"# HELP {family} " in body, family
+            assert f"# TYPE {family} " in body, family
+        samples = _parse_samples(body)  # also asserts per-line sanity regex
+        assert samples[("snagline_events_total", "")] == 0.0
+        assert samples[("snagline_episodes_active", "")] == 0.0
+        assert samples[("snagline_ingest_seconds_count", "")] == 0.0
+        assert samples[("snagline_ingest_seconds_sum", "")] == 0.0
+        assert samples[("snagline_monitor_detector_errors_total", "")] == 0.0
+        # No risk samples at all on an empty monitor.
+        assert not any(name == "snagline_risks_total" for name, _ in samples)
+    finally:
+        _stop(server)
+
+
+def test_loop_fires_with_exact_labels_and_counters_grow_monotonically():
+    server, base = _start_server()
+    try:
+        # Loop detector default repeat_threshold=3: the third identical
+        # signature fires once; the fourth is suppressed by dedup (issue #4).
+        loop_sig = "aaaa1111bbbb2222"
+        for i in range(4):
+            _post(base, _step(i, loop_sig, episode="ep-loop"))
+        _, _, first_body = _get(base, "/metrics")
+        first = _parse_samples(first_body)
+        assert (
+            first[("snagline_risks_total", 'trigger="loop",severity="warning"')] == 1.0
+        )
+        assert first[("snagline_events_total", "")] == 4.0
+        assert first[("snagline_ingest_seconds_count", "")] == 4.0
+        assert first[("snagline_monitor_risks_emitted_total", "")] == 1.0
+        # Score at count=3 is min(1, 3/3*0.5)=0.5, so severity is "warning"
+        # exactly; no other trigger may have fired from this sequence.
+        assert (
+            "snagline_risks_total",
+            'trigger="loop",severity="critical"',
+        ) not in first
+
+        # Error-cascade default consecutive_threshold=3: three consecutive
+        # failing tool calls with distinct signatures fire error_cascade once
+        # with score 1.0, i.e. severity "critical", and never trip loop.
+        cascade_sigs = ["bbb11111cccc2222", "bbb22222cccc2222", "bbb33333cccc2222"]
+        _post(
+            base,
+            [
+                _step(i + 10, s, episode="ep-cascade", error=True)
+                for i, s in enumerate(cascade_sigs)
+            ],
+        )
+        _, _, second_body = _get(base, "/metrics")
+        second = _parse_samples(second_body)
+
+        assert (
+            second[
+                ("snagline_risks_total", 'trigger="error_cascade",severity="critical"')
+            ]
+            == 1.0
+        )
+        # The earlier loop finding is unchanged (dedup keeps it at one).
+        assert (
+            second[("snagline_risks_total", 'trigger="loop",severity="warning"')] == 1.0
+        )
+        assert second[("snagline_monitor_risks_emitted_total", "")] == 2.0
+        # Monotonic growth between the two scrapes, exact deltas where known.
+        for key, value in first.items():
+            if key[0].endswith("_total") or key[0].startswith("snagline_ingest"):
+                assert second[key] >= value, key
+        assert (
+            second[("snagline_events_total", "")]
+            == first[("snagline_events_total", "")] + 3.0
+        )
+        assert second[("snagline_episodes_active", "")] >= 2.0
+    finally:
+        _stop(server)
+
+
+def test_healthy_sequence_stays_completely_silent():
+    server, base = _start_server()
+    try:
+        # Six distinct successful steps: below every threshold, so nothing
+        # may fire and no risk sample line may appear at all.
+        healthy_sigs = [f"dead{i:04x}beef5678" for i in range(6)]
+        for i, s in enumerate(healthy_sigs):
+            _post(base, _step(i, s))
+        _, _, body = _get(base, "/metrics")
+        assert "snagline_risks_total{" not in body
+        samples = _parse_samples(body)
+        assert samples[("snagline_monitor_risks_emitted_total", "")] == 0.0
+        assert samples[("snagline_episodes_active", "")] == 1.0
+        assert samples[("snagline_events_total", "")] == 6.0
+        # Ingest latency was observed count-wise, sum stays tiny but positive.
+        assert samples[("snagline_ingest_seconds_count", "")] == 6.0
+        assert samples[("snagline_ingest_seconds_sum", "")] > 0.0
+    finally:
+        _stop(server)
+
+
+def test_classic_format_stays_available_for_old_clients():
+    server, base = _start_server()
+    try:
+        status, headers, body = _get(base, "/metrics?format=classic")
+        assert status == 200
+        assert headers["Content-Type"] == "application/json"
+        parsed = json.loads(body)
+        for key in (
+            "events_ingested",
+            "risks_emitted",
+            "detector_errors",
+            "sink_errors",
+        ):
+            assert key in parsed
+
+        # Old JSON clients are also honored via Accept negotiation.
+        status, headers, body = _get(
+            base, "/metrics", headers={"Accept": "application/json"}
+        )
+        assert status == 200
+        assert headers["Content-Type"] == "application/json"
+        json.loads(body)
+
+        # Explicit ?format=prometheus wins over a JSON Accept header.
+        status, headers, body = _get(
+            base, "/metrics?format=prometheus", headers={"Accept": "application/json"}
+        )
+        assert status == 200
+        assert headers["Content-Type"] == PROMETHEUS_CONTENT_TYPE
+    finally:
+        _stop(server)
+
+
+def test_env_toggle_switches_default_format(monkeypatch):
+    monkeypatch.setenv("SNAGLINE_METRICS_FORMAT", "classic")
+    server, base = _start_server()
+    try:
+        _, headers, body = _get(base, "/metrics")
+        assert headers["Content-Type"] == "application/json"
+        json.loads(body)
+    finally:
+        _stop(server)
+
+    # Unknown values fall back to prometheus instead of breaking startup.
+    monkeypatch.setenv("SNAGLINE_METRICS_FORMAT", "nonsense")
+    server, base = _start_server()
+    try:
+        _, headers, _body = _get(base, "/metrics")
+        assert headers["Content-Type"] == PROMETHEUS_CONTENT_TYPE
+    finally:
+        _stop(server)
+
+
+def test_escape_label_handles_backslash_quote_newline():
+    # Hand-derived expectation: backslash doubles, quote gets a backslash,
+    # newline becomes the two-character escape.
+    assert _escape_label('a"b\\c\nd') == 'a\\"b\\\\c\\nd'
+    assert _escape_label("plain") == "plain"
+
+
+def test_episode_table_evicts_oldest_at_cap():
+    collector = SidecarMetricsCollector(max_episodes=2)
+    collector.record_ingest("ep-a", 0.001)
+    collector.record_ingest("ep-b", 0.001)
+    assert collector.snapshot()["episodes_active"] == 2
+    collector.record_ingest("ep-c", 0.001)
+    snap = collector.snapshot()
+    assert snap["episodes_active"] == 2
+    assert snap["events_total"] == 3
+    # Rendering still yields a valid single gauge line after eviction.
+    body = collector.render_prometheus(
+        {
+            "events_ingested": 0,
+            "risks_emitted": 0,
+            "detector_errors": 0,
+            "sink_errors": 0,
+        }
+    )
+    samples = _parse_samples(body)
+    assert samples[("snagline_episodes_active", "")] == 2.0
+
+
+def test_collector_counts_risks_per_label_pair():
+    from snagline.risk import FailureRisk
+
+    collector = SidecarMetricsCollector()
+    ts = 1718300000.0
+    collector.emit(FailureRisk("ep", "s1", 0.9, "loop", "detail", ts))
+    collector.emit(FailureRisk("ep", "s2", 1.0, "error_cascade", "detail", ts))
+    collector.emit(FailureRisk("ep", "s3", 0.6, "loop", "detail", ts))
+    body = collector.render_prometheus(
+        {
+            "events_ingested": 0,
+            "risks_emitted": 0,
+            "detector_errors": 0,
+            "sink_errors": 0,
+        }
+    )
+    samples = _parse_samples(body)
+    # Hand-derived from severity_from_score: >=0.8 critical, >=0.5 warning.
+    # 0.9 -> critical, 1.0 -> critical, 0.6 -> warning.
+    assert samples[("snagline_risks_total", 'trigger="loop",severity="warning"')] == 1.0
+    assert (
+        samples[("snagline_risks_total", 'trigger="loop",severity="critical"')] == 1.0
+    )
+    assert (
+        samples[("snagline_risks_total", 'trigger="error_cascade",severity="critical"')]
+        == 1.0
+    )

--- a/tests/test_http_server.py
+++ b/tests/test_http_server.py
@@ -252,7 +252,11 @@ def test_metrics_endpoint_reports_ingested_counts():
         )
         with urllib.request.urlopen(req, timeout=5) as resp:
             assert resp.status == 202
-        with urllib.request.urlopen(base + "/metrics", timeout=5) as resp:
+        # Issue #98 made prometheus the default /metrics body; the JSON
+        # counters this test exercises remain available via ?format=classic.
+        with urllib.request.urlopen(
+            base + "/metrics?format=classic", timeout=5
+        ) as resp:
             assert resp.status == 200
             body = json.loads(resp.read())
         assert body["events_ingested"] >= 1


### PR DESCRIPTION
## Summary

`GET /metrics` on the sidecar now speaks Prometheus text exposition version 0.0.4, built by hand with stdlib string formatting only (no `prometheus_client`, zero new dependencies, project.md §1 intact). Closes #98.

What ships:

- **New families:** `snagline_events_total`, `snagline_risks_total{trigger="...",severity="..."}`, `snagline_episodes_active` (gauge), `snagline_ingest_seconds_count` / `snagline_ingest_seconds_sum` (summary, count/sum only as specced), plus the four `Monitor.metrics()` counters exposed as `snagline_monitor_events_ingested_total`, `snagline_monitor_risks_emitted_total`, `snagline_monitor_detector_errors_total`, `snagline_monitor_sink_errors_total`.
- **How it is measured without touching monitor.py (scope discipline):** a `SidecarMetricsCollector` joins the Monitor's sinks to count risks per `(trigger, severity)`; the HTTP layer times every accepted event around `monitor.ingest()`; episode ids live in a bounded table with least-recently-seen eviction
(10k cap, ids only, never content, per the privacy rule).
- **Backward compatible default flip:** `?format=classic`, an explicit `Accept: application/json` header, or starting with `SNAGLINE_METRICS_FORMAT=classic` (config key `metrics_format: str = "prometheus"`, appended in its own labeled block) all keep serving the legacy JSON body. `?format=prometheus` forces the new format per request and wins over the Accept header.
- **Fail-open everywhere (rule 2):** the collector swallows its own exceptions; rendering failures degrade to an empty but valid 200 body; unknown format values log a warning and fall back to prometheus; attaching the collector to the monitor cannot break serving.
- **Label escaping** for backslash, double quote, and newline, with a dedicated unit test.

## Verification

All commands run against the branch at ee3c3ea.

Gate:

```
$ python -m pytest tests/ -q -o addopts=""
243 passed, 1 skipped in 19.12s
$ ruff check src tests && ruff format --check src tests
All checks passed!
75 files already formatted
$ mypy src
Success: no issues found in 39 source files
```

Live curl against a real sidecar seeded through POST /events with a deterministic loop sequence (4x repeat) and error cascade (3 consecutive failing tool calls):

```
$ curl -i http://127.0.0.1:55082/metrics
HTTP/1.0 200 OK
Content-Type: text/plain; version=0.0.4; charset=utf-8

# HELP snagline_events_total Steps ingested through this sidecar.
# TYPE snagline_events_total counter
snagline_events_total 7
# HELP snagline_risks_total Risks emitted by trigger and severity.
# TYPE snagline_risks_total counter
snagline_risks_total{trigger="error_cascade",severity="critical"} 1
snagline_risks_total{trigger="loop",severity="warning"} 1
# HELP snagline_episodes_active Distinct episode ids seen since start.
# TYPE snagline_episodes_active gauge
snagline_episodes_active 2
# HELP snagline_ingest_seconds Wall time spent ingesting steps.
# TYPE snagline_ingest_seconds summary
snagline_ingest_seconds_count 7
snagline_ingest_seconds_sum 9.024803875945508e-05
# HELP snagline_monitor_events_ingested_total Events ingested by the Monitor.
...
$ curl "http://127.0.0.1:55082/metrics?format=classic"
{"events_ingested": 7, "risks_emitted": 2, "detector_errors": 0, "sink_errors": 0}
```

The scrape parser in tests rejects duplicate time series (same name plus label set twice), which Prometheus itself refuses to ingest, so every test exercises that property too.

Every commit snapshot was gate-checked individually (config-only, +server, +tests, +docs): each is green, no red commits pushed.

## Test honesty

- **Mutation check performed:** I inverted the format-selection comparison in `_choose_metrics_format` (`return requested` became `return "classic"`), reran pytest, confirmed `test_classic_format_stays_available_for_old_clients` went red, then reverted and confirmed green again.
- Expected values are hand-derived from documented detector thresholds (loop: repeat_threshold 3, deduped once per finding; cascade: consecutive_threshold 3, score 1.0 maps to critical via `severity_from_score`), never computed by calling the code under test.
- Detector-side assertions have both sides: injected loop/cascade sequences that must fire with exact labels, plus a healthy varied sequence asserted totally silent (`snagline_risks_total{` absent, risks counters zero).

## Callouts

- One existing expectation moved with this change, code and test together: `test_metrics_endpoint_reports_ingested_counts` assumed JSON as the plain `/metrics` body. Issue #98 explicitly makes prometheus the default, so that request now targets `/metrics?format=classic`, preserving the test's intent verbatim.
- During development, two `tests/test_hook_bridge.py` reaping tests failed intermittently under full-suite load in my working tree. I proved they are unrelated to this diff: they pass on pristine origin/master, on base plus my changes, and flake independently of both (they are subprocess/timing heavy; a separate fix for them has since landed independently).

Board: #106

Fixes #98
