### PR TITLE
feat(core): public Monitor.add_sink()/remove_sink() (issue #122)

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -136,6 +136,30 @@ class Monitor:
         with self._metrics_lock:
             return self._metrics.as_dict()
 
+    def add_sink(self, sink: AlertSink) -> None:
+        """Register one more sink at runtime (issue #122).
+
+        The sink joins dispatch under the same rules as construction: every
+        registered sink sees every dispatched risk, in registration order,
+        and its exceptions are swallowed exactly like any other sink's
+        (fail-open). Safe to call while ingests run from other threads;
+        dispatch tolerates a concurrent append.
+        """
+        self._sinks.append(sink)
+
+    def remove_sink(self, sink: AlertSink) -> bool:
+        """Unregister ``sink`` (issue #122); returns True when removed.
+
+        Matching follows ``list.remove`` semantics, so a sink registered
+        twice must be removed once per registration. Returns False when the
+        sink was never registered.
+        """
+        try:
+            self._sinks.remove(sink)
+        except ValueError:
+            return False
+        return True
+
     def _log_fault_once(self, key: str) -> None:
         """Log a fail-open fault, but only the first time we see this exact
         message (issue #14). Avoids dumping a traceback on every step when a

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -262,25 +262,14 @@ class SidecarMetricsCollector:
 def _attach_metrics_collector(monitor: Any, collector: SidecarMetricsCollector) -> None:
     """Register ``collector`` as one extra sink so risks are counted per label.
 
-    The base Monitor has no public add-sink API yet, so prefer ``add_sink``
-    when it exists and fall back to appending to its sink list otherwise.
+    Uses the public ``Monitor.add_sink`` (issue #122), so any Monitor that
+    honors the base-class contract works without reaching into privates.
     Guarded end to end: any failure leaves serving fully functional, only the
     per-label risk counters stay empty. Monitor dispatch already treats sinks
     as fail-open, matching project.md §1.2.
     """
     try:
-        add_sink = getattr(monitor, "add_sink", None)
-        if callable(add_sink):
-            add_sink(collector)
-            return
-        sinks = getattr(monitor, "_sinks", None)
-        if isinstance(sinks, list):
-            sinks.append(collector)
-        else:
-            logger.warning(
-                "snagline: cannot attach metrics collector to %s",
-                type(monitor).__name__,
-            )
+        monitor.add_sink(collector)
     except Exception:
         logger.warning(
             "snagline: attaching metrics collector failed; risk labels stay empty",

--- a/tests/test_monitor_add_sink.py
+++ b/tests/test_monitor_add_sink.py
@@ -1,0 +1,124 @@
+"""Public Monitor.add_sink() and remove_sink() (issue #122).
+
+The sidecar used to reach into the private ``_sinks`` list because Monitor
+had no public way to attach a late sink. These tests pin the contract of the
+public methods: a late sink receives subsequent dispatches, removal stops
+dispatch, construction-time sinks are untouched, and fail-open semantics are
+identical for late sinks.
+
+Both sides are covered: an injected-failure stream that must dispatch to the
+late sink (exact trigger asserted) and a healthy stream that must stay
+silent.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from snagline.events import StepEvent
+from snagline.monitor import Monitor
+from snagline.risk import FailureRisk
+
+
+def _event(step_id: str = "s1", episode_id: str = "ep-add") -> StepEvent:
+    return StepEvent(
+        step_id=step_id,
+        episode_id=episode_id,
+        timestamp=1.0,
+        action_type="tool_call",
+        action_signature="deadbeef",
+    )
+
+
+def _loop_risk(step_id: str = "s1") -> FailureRisk:
+    return FailureRisk(
+        episode_id="ep-add",
+        step_id=step_id,
+        score=0.9,
+        trigger="loop",
+        detail="repeated action",
+        timestamp=1.0,
+    )
+
+
+class _FixedRiskDetector:
+    """Returns one fixed verdict for every event: a risk, or None."""
+
+    name = "fixed_risk"
+
+    def __init__(self, risk: FailureRisk | None) -> None:
+        self._risk = risk
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        return self._risk
+
+    def reset(self, episode_id: str) -> None:
+        return None
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.risks: list[FailureRisk] = []
+
+    def emit(self, risk: FailureRisk) -> None:
+        self.risks.append(risk)
+
+
+class _RaisingSink:
+    def emit(self, risk: FailureRisk) -> None:
+        raise RuntimeError("boom in late sink")
+
+
+def test_add_sink_dispatches_to_new_sink_on_subsequent_ingests():
+    monitor = Monitor([_FixedRiskDetector(_loop_risk())], [])
+    late = _RecordingSink()
+    monitor.add_sink(late)
+    monitor.ingest(_event())
+    assert [r.trigger for r in late.risks] == ["loop"]
+    assert late.risks[0].step_id == "s1"
+
+
+def test_healthy_stream_stays_silent_after_add_sink():
+    monitor = Monitor([_FixedRiskDetector(None)], [])
+    late = _RecordingSink()
+    monitor.add_sink(late)
+    for step in range(10):
+        monitor.ingest(_event(step_id=f"s{step}"))
+    assert late.risks == []
+
+
+def test_construction_and_late_sinks_both_receive_the_same_risk():
+    construction = _RecordingSink()
+    late = _RecordingSink()
+    monitor = Monitor([_FixedRiskDetector(_loop_risk())], [construction])
+    monitor.add_sink(late)
+    monitor.ingest(_event())
+    assert len(construction.risks) == 1
+    assert len(late.risks) == 1
+    assert construction.risks[0] == late.risks[0]
+
+
+def test_remove_sink_stops_dispatch_and_reports_unknown():
+    monitor = Monitor([_FixedRiskDetector(_loop_risk())], [])
+    late = _RecordingSink()
+    monitor.add_sink(late)
+    assert monitor.remove_sink(late) is True
+    monitor.ingest(_event())
+    assert late.risks == []
+    assert monitor.remove_sink(late) is False
+
+
+def test_added_raising_sink_is_fail_open():
+    good = _RecordingSink()
+    monitor = Monitor([_FixedRiskDetector(_loop_risk())], [good])
+    monitor.add_sink(_RaisingSink())
+    monitor.ingest(_event())  # must not raise
+    assert len(good.risks) == 1
+    assert monitor.metrics()["sink_errors"] == 1
+
+
+def test_added_raising_sink_propagates_with_fail_open_disabled():
+    monitor = Monitor([_FixedRiskDetector(_loop_risk())], [], fail_open=False)
+    monitor.add_sink(_RaisingSink())
+    with pytest.raises(RuntimeError, match="boom in late sink"):
+        monitor.ingest(_event())


### PR DESCRIPTION
## Summary

Adds the public `Monitor.add_sink(sink)` (plus `remove_sink(sink)` returning a bool) so integrations stop reaching into the private `_sinks` list (issue #122). The sidecar's `_attach_metrics_collector` now calls `monitor.add_sink(collector)` directly; the `getattr` probe and private-list fallback are gone. Late sinks join dispatch under the same rules as construction (same order, same fail-open treatment). No behavior change otherwise; zero new dependencies.

Mutation check performed: made `add_sink` a no-op on purpose, reran pytest, watched 6 tests go red (including 3 of the new ones and `test_loop_fires_with_exact_labels_and_counters_grow_monotonically`, which guards the server-side attach), then reverted and confirmed green again.

## Verification

Full gate on this branch:

```
$ python -m pytest tests/ -q -o addopts=""
269 passed, 1 skipped in 30.04s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
78 files already formatted

$ mypy src
Success: no issues found in 40 source files
```

Mutation check output (before revert):

```
$ python -m pytest tests/test_monitor_add_sink.py tests/server/test_metrics_prometheus.py -q -o addopts=""
6 failed, 8 passed in 3.30s
FAILED tests/test_monitor_add_sink.py::test_added_raising_sink_is_fail_open
FAILED tests/server/test_metrics_prometheus.py::test_loop_fires_with_exact_labels_and_counters_grow_monotonically
...
```

New tests cover both sides: an injected loop risk reaches the late sink with exact trigger name `loop`, and a healthy stream produces no dispatch. Fail-open semantics for late sinks are pinned under both `fail_open=True` and `fail_open=False`.

Board: #106

Fixes #122


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sinks can now be added or removed while monitoring is running.
  * Newly added sinks receive subsequent risk alerts in registration order.
  * Removing a sink reports whether it was successfully removed.

* **Bug Fixes**
  * Sink updates remain safe during concurrent monitoring.
  * Existing failure-handling behavior is preserved for sink errors.

* **Tests**
  * Added coverage for dynamic sink management, alert delivery, removal behavior, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->