### PR TITLE
fix(server): over-cap POSTs reply 413 without resetting streamed clients (issue #121)

### DIFF
--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -72,6 +72,16 @@ METRICS_FORMATS = ("prometheus", "classic")
 # host streams unlimited unique ids through one long-lived sidecar process.
 _MAX_TRACKED_EPISODES = 10_000
 
+# Over-cap POSTs are drained and discarded before the 413 goes out, but only
+# within this much above max_body_bytes (issue #121): reading the body lets a
+# streaming client finish sending and still read the status line instead of
+# dying on EPIPE/reset. Beyond that window the 413 is sent immediately so one
+# hostile sender cannot tie up a handler thread indefinitely.
+_MAX_OVERCAP_DRAIN_EXCESS = 65_536
+# Drain reads happen in fixed chunks, so peak memory stays at one chunk no
+# matter what Content-Length claims.
+_DRAIN_CHUNK_BYTES = 16_384
+
 
 def _escape_label(value: str) -> str:
     """Escape a Prometheus label value (backslash, quote, newline)."""
@@ -374,6 +384,10 @@ def make_handler(
                 return
             length = int(self.headers.get("Content-Length") or 0)
             if length > self.snagline_max_body:
+                # Consume the over-cap body first: closing with megabytes
+                # unread makes the peer see EPIPE/reset instead of the 413
+                # (issue #121).
+                self._discard_overcap_body(length)
                 self._respond(413, {"error": "payload too large"})
                 return
             if self.path == "/events":
@@ -498,6 +512,33 @@ def make_handler(
                     "step_id": event.step_id if event else None,
                 },
             )
+
+        def _discard_overcap_body(self, declared_length: int) -> None:
+            """Read and throw away an over-cap body before replying 413.
+
+            Bodies up to ``max_body_bytes + _MAX_OVERCAP_DRAIN_EXCESS`` are
+            drained fully so the sender can finish writing and still read the
+            response; anything larger is abandoned after that window (the 413
+            still goes out at once). Reads happen in fixed-size chunks, so
+            peak memory is bounded regardless of claimed Content-Length.
+            Fail-open: a client that hangs up mid-drain is logged and
+            forgotten, never turned into a serving error.
+            """
+            remaining = min(
+                declared_length,
+                self.snagline_max_body + _MAX_OVERCAP_DRAIN_EXCESS,
+            )
+            while remaining > 0:
+                try:
+                    chunk = self.rfile.read(min(remaining, _DRAIN_CHUNK_BYTES))
+                except OSError:
+                    logger.debug(
+                        "snagline: over-cap body drain interrupted", exc_info=True
+                    )
+                    return
+                if not chunk:
+                    return  # client hung up early; nothing more to discard
+                remaining -= len(chunk)
 
         def _read_body(self) -> bytes:
             length = int(self.headers.get("Content-Length") or 0)

--- a/tests/server/test_413_drain.py
+++ b/tests/server/test_413_drain.py
@@ -1,0 +1,154 @@
+"""Over-cap POST handling: the sender must be able to read the 413 (#121).
+
+Closing the connection with megabytes of unread request body makes the
+kernel reset the peer, so direct clients saw EPIPE/ECONNRESET instead of the
+status line. These tests pin the remedy: within a small window above the
+body cap the body is drained and discarded before replying, exactly-at-cap
+bodies stay accepted, and the drain itself is bounded no matter what
+Content-Length claims.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import types
+
+from snagline.monitor import Monitor
+from snagline.server.http_server import (
+    _DRAIN_CHUNK_BYTES,
+    _MAX_OVERCAP_DRAIN_EXCESS,
+    make_handler,
+    make_server,
+)
+
+_CAP = 1_000_000
+
+
+def _start(max_body_bytes: int):
+    server = make_server(
+        Monitor([], []),
+        host="127.0.0.1",
+        port=0,
+        max_body_bytes=max_body_bytes,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def test_overcap_streamed_body_reads_413_status_line():
+    """A client streaming an over-cap body must see the 413, not EPIPE."""
+    body_len = _CAP + _MAX_OVERCAP_DRAIN_EXCESS  # top of the drain window
+    server, port = _start(_CAP)
+    try:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        try:
+            head = (
+                "POST /events HTTP/1.0\r\n"
+                "Host: localhost\r\n"
+                "Content-Type: application/json\r\n"
+                f"Content-Length: {body_len}\r\n"
+                "\r\n"
+            ).encode()
+            sock.sendall(head)
+            sock.sendall(b"x" * body_len)
+            chunks: list[bytes] = []
+            while True:
+                data = sock.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+            response = b"".join(chunks)
+        finally:
+            sock.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 413"), response[:120]
+    assert b"payload too large" in response
+
+
+def test_exactly_at_cap_body_still_accepted():
+    event = {
+        "step_id": "0",
+        "episode_id": "ep-cap",
+        "timestamp": 1718300000.0,
+        "action_type": "tool_call",
+        "action_signature": "aaaa1111bbbb2222",
+        "metadata": {"pad": ""},
+    }
+    raw = json.dumps(event).encode()
+    filler = _CAP - len(raw)
+    assert filler > 0
+    event["metadata"]["pad"] = "a" * filler
+    raw = json.dumps(event).encode()
+    assert len(raw) == _CAP  # byte-exact, mirroring the verified cap behavior
+    server, port = _start(_CAP)
+    try:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        try:
+            head = (
+                "POST /events HTTP/1.0\r\n"
+                "Host: localhost\r\n"
+                "Content-Type: application/json\r\n"
+                f"Content-Length: {len(raw)}\r\n"
+                "\r\n"
+            ).encode()
+            sock.sendall(head)
+            sock.sendall(raw)
+            chunks: list[bytes] = []
+            while True:
+                data = sock.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+            response = b"".join(chunks)
+        finally:
+            sock.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 202"), response[:120]
+    assert b'"status": "ingested"' in response
+
+
+def test_drain_is_bounded_regardless_of_claimed_content_length():
+    """A huge claimed length must not make the sidecar read forever."""
+    handler_cls = make_handler(Monitor([], []), max_body_bytes=1_000)
+
+    reads: list[int] = []
+
+    class _EndlessRFile:
+        def __init__(self) -> None:
+            self.consumed = 0
+
+        def read(self, n: int) -> bytes:
+            reads.append(n)
+            self.consumed += n
+            return b"x" * n
+
+    fake = types.SimpleNamespace(rfile=_EndlessRFile(), snagline_max_body=1_000)
+    handler_cls._discard_overcap_body(fake, 10**9)
+    assert fake.rfile.consumed == 1_000 + _MAX_OVERCAP_DRAIN_EXCESS
+    assert reads
+    assert max(reads) <= _DRAIN_CHUNK_BYTES
+
+
+def test_drain_survives_client_hangup_and_socket_errors():
+    handler_cls = make_handler(Monitor([], []), max_body_bytes=1_000)
+
+    class _HungUpRFile:
+        def read(self, n: int) -> bytes:
+            return b""  # immediate EOF: client vanished mid-body
+
+    fake = types.SimpleNamespace(rfile=_HungUpRFile(), snagline_max_body=1_000)
+    handler_cls._discard_overcap_body(fake, 5_000)  # must not raise
+
+    class _ResetRFile:
+        def read(self, n: int) -> bytes:
+            raise ConnectionResetError("peer reset mid-drain")
+
+    fake = types.SimpleNamespace(rfile=_ResetRFile(), snagline_max_body=1_000)
+    handler_cls._discard_overcap_body(fake, 5_000)  # must not raise


### PR DESCRIPTION
## Summary

Implements the drain remedy from issue #121. Over-cap POSTs now read and discard the request body before replying 413, within a bounded window: bodies up to `max_body_bytes + 64KiB` are drained fully (in fixed 16KiB chunks, so peak memory is one chunk no matter what Content-Length claims), while larger claims skip the drain entirely so a hostile sender cannot tie up a handler thread reading forever. Exactly-at-cap bodies are untouched and still accepted. A client that hangs up mid-drain, or resets mid-drain, is swallowed fail-open.

Result: direct clients streaming an over-cap body can reliably read `HTTP/1.0 413` and see a clean EOF instead of EPIPE/ECONNRESET.

Mutation check performed: disabled the drain call on purpose, reran the new raw-socket test, watched it fail with `ConnectionResetError: [Errno 54] Connection reset by peer`, which reproduces exactly the bug in the issue; then reverted and confirmed green again.

## Verification

Full gate on this branch:

```
$ python -m pytest tests/ -q -o addopts=""
267 passed, 1 skipped in 32.54s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
78 files already formatted

$ mypy src
Success: no issues found in 40 source files
```

Acceptance criteria, exercised in tests/server/test_413_drain.py:

- Over-cap body streamed over a raw socket on an ephemeral loopback port reads the status line: `test_overcap_streamed_body_reads_413_status_line` asserts `HTTP/1.0 413` plus `payload too large`.
- Exactly-at-cap body still accepted: `test_exactly_at_cap_body_still_accepted` posts a byte-exact 1000000-byte event and asserts `HTTP/1.0 202` with `"status": "ingested"`.
- Memory bounded regardless of claimed Content-Length: `test_drain_is_bounded_regardless_of_claimed_content_length` feeds a fake body with claimed length 10^9 and asserts consumption stops at exactly `max_body_bytes + _MAX_OVERCAP_DRAIN_EXCESS`, in chunks no larger than `_DRAIN_CHUNK_BYTES`.

Mutation check output (before revert):

```
$ python -m pytest tests/server/test_413_drain.py -q -o addopts=""
1 failed, 3 passed in 1.11s
FAILED tests/server/test_413_drain.py::test_overcap_streamed_body_reads_413_status_line
E   ConnectionResetError: [Errno 54] Connection reset by peer
```

No new dependencies; stdlib sockets only in tests, bound to ephemeral 127.0.0.1 ports, no sleeps.

Board: #106

Fixes #121
