### PR TITLE
feat(baseline): scheduled retrain contract: retrain subcommand, atomic store bump, cadence docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,11 @@ monitor = Monitor.default(config=config)
 
 With `ml_ensemble_enabled`, `Monitor.default()` wraps the base detectors in a single `MLOrchestrator` instead of exposing them individually, so there is no double counting. Both detectors are documented in [docs/DETECTOR_GUIDE.md](docs/DETECTOR_GUIDE.md).
 
+Baselines go stale as your agent evolves. For scheduled refits, use
+`snagline baseline retrain`: it fits from the newest JSONL window and bumps a
+versioned store atomically (cron/systemd examples and the goal_drift caveats
+in [docs/RETRAIN_CADENCE.md](docs/RETRAIN_CADENCE.md)).
+
 ## Features
 
 | Capability | What it gives you |

--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -111,7 +111,10 @@ enterprise-grade alerting. Concretely:
 6. **Baseline lifecycle:** auto-capture cadence, versioned store, per-tenant
    baselines, scheduled retrain. **Done (storage + collector + CLI):** versioned
    per-tenant `BaselineStore`, `BaselineCollector`, and `snagline baseline
-   --store-dir` (#45, #46). Scheduled retrain remains a host-owned cadence.
+   --store-dir` (#45, #46). **Done (retrain contract):** `snagline baseline
+   retrain` refits from the newest JSONL window with an atomic store bump,
+   plus a documented cron/systemd cadence and `--max-age` staleness warning;
+   see docs/RETRAIN_CADENCE.md (#102). The schedule itself stays host-owned.
 
 ### P2 (detection quality, the differentiator)
 
@@ -329,7 +332,6 @@ operational.
   - #48 `feat/batching-sink` - `BatchingSink` async/rate-limited dispatch.
   - #49 `docs/integration-matrix` - `docs/INTEGRATION_MATRIX.md` (P3 item 11).
 - **Status: P0, P1, and most of P3 are complete.** Remaining:
-  - P1 item 6 tail: scheduled/automated retrain cadence (host-owned today).
   - P3 item 10 tail: Prometheus export + structured logging for the monitor.
   - Actual PyPI upload (needs a token); in-process TLS (or documented
     reverse-proxy).

--- a/docs/RETRAIN_CADENCE.md
+++ b/docs/RETRAIN_CADENCE.md
@@ -1,0 +1,132 @@
+# Scheduled baseline retrain cadence (issue #102)
+
+The `goal_drift` detector compares live traffic against a persisted healthy
+reference (`BaselineProfile`). Real deployments drift: tool latencies change,
+new tools ship, error budgets move. A baseline fitted once and never touched
+slowly turns into a false-positive generator. The retrain contract closes that
+loop: refit from the newest healthy-run window on a host-owned schedule, bump
+the versioned store atomically, and warn when the active baseline has gone
+stale anyway.
+
+Everything here is stdlib-only and offline: no new dependencies, no network,
+no content retention (see the privacy note at the end).
+
+## The command
+
+```
+snagline baseline retrain --store-dir ROOT [--tenant T] [--deployment D]
+    (--jsonl FILE | --windows-dir DIR) [--max-age SECONDS] [--max-versions N]
+```
+
+Behavior:
+
+- Refits a fresh profile from the given JSONL window (`--jsonl`) or from the
+  newest `*.jsonl` file in a directory of rotated windows (`--windows-dir`,
+  picked by modification time, non-recursive).
+- Stores the result as a NEW timestamped version in the `BaselineStore` and
+  flips the `latest.json` pointer atomically (see below). The previous version
+  stays loadable for rollback.
+- Prints the stored version id plus a small structural summary (tool count,
+  step count). No content is echoed.
+- Exit codes: `0` success, `2` usage error (missing `--store-dir`, wrong
+  combination of window inputs), `3` input failure (no window found, window
+  unreadable). Malformed lines inside a window are skipped fail-open during
+  the fit, matching replay behavior.
+
+The literal keyword `retrain` replaces the usual trajectory positional. The
+plain form (`snagline baseline run.jsonl --output baseline.json`) is unchanged.
+
+## Cron example
+
+Refit nightly from the newest rotated window; keep a staleness guard so a
+silently broken pipeline pages someone instead of drifting unnoticed:
+
+```cron
+# m h dom mon dow  command
+17 3 * * *  /opt/snagline/.venv/bin/snagline baseline retrain --store-dir /var/lib/snagline/baselines --tenant acme --deployment prod --windows-dir /var/log/agent/windows --max-age 172800 >> /var/log/snagline-retrain.log 2>&1
+```
+
+Notes on this line:
+
+- `17 3`: an off-the-hour minute avoids the midnight cron thundering herd.
+- Absolute paths everywhere: cron's environment has no venv on PATH.
+- `--max-age 172800` (48h): if the ACTIVE baseline was fitted more than two
+  days ago, retrain prints a `WARNING ... consider tightening the retrain
+  cadence` line to stderr before doing its work. With the redirect above that
+  warning lands in `/var/log/snagline-retrain.log`; point a log alert at the
+  word `WARNING` for that file.
+- The exit code is still `0` when retrain succeeds despite the warning. Exit
+  `2`/`3` mean nothing was stored, which is what you want cron mail or a
+  `systemd` `on-failure` handler to catch.
+
+## systemd timer example
+
+Equivalent to the cron line, with catch-up on missed schedules:
+
+```ini
+# /etc/systemd/system/snagline-retrain.service
+[Unit]
+Description=SNAGLINE baseline retrain from newest JSONL window
+
+[Service]
+Type=oneshot
+ExecStart=/opt/snagline/.venv/bin/snagline baseline retrain --store-dir /var/lib/snagline/baselines --tenant acme --deployment prod --windows-dir /var/log/agent/windows --max-age 172800
+```
+
+```ini
+# /etc/systemd/system/snagline-retrain.timer
+[Unit]
+Description=Run SNAGLINE baseline retrain nightly
+
+[Timer]
+OnCalendar=*-*-* 03:17:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable with `systemctl enable --now snagline-retrain.timer`. `Persistent=true`
+runs the service once on boot if the last scheduled run was missed (laptop or
+fleet reboot friendly).
+
+## Why the version bump is atomic
+
+`BaselineStore.save()` writes each JSON payload to a sibling temp file, fsyncs
+it, then renames it over the target with `os.replace` (atomic on POSIX and
+Windows). Order matters: the history entry `versions/<id>.json` lands first,
+then the `latest.json` pointer flips. A crash between the two writes leaves
+the active baseline pointing at the previous complete version; readers of
+`latest.json` never observe torn or half-written JSON, only old-or-new. The
+orphaned history entry is harmless and remains loadable. This guarantee is
+what makes running retrain against a live store safe without locks.
+
+Retention is bounded: versions beyond `--max-versions` (default 10) are pruned
+oldest-first, so the store grows by one small JSON file per retrain, not
+forever. Rollback is reading an older version out of
+`<store-dir>/<tenant>/<deployment>/versions/`.
+
+## Retrain is not a mid-episode reset for goal_drift
+
+Read this before wiring retrain into a fleet of long-running agents:
+
+- A retrain updates files under the store root. It does NOT hot-swap the
+  baseline object held by an already-running monitor. Hosts should reload at
+  an episode boundary: rebuild the monitor config with
+  `BaselineStore.load(...)` (the pattern shown in the README) so future
+  episodes compare against the fresh profile.
+- Even with a new reference loaded mid-flight, the goal_drift detector keeps
+  its per-episode live accumulators and its fired-once flag. Retraining does
+  not un-fire risks already raised and does not wipe partial episode state;
+  scores for the in-flight episode simply continue against the new reference.
+  For a clean-slate comparison, start a new episode rather than expecting the
+  retrain to reset detector state.
+
+## Privacy reminder
+
+Baselines contain structure only: per-tool step counts, latency
+sums/means/std/min/max, and error counts. Fitted windows are read line by line
+and reduced to those aggregates; no prompt or response content ever reaches
+`baseline.json`, the store, or the retrain log output. Rotate window files
+under your normal log-retention policy; the baseline store itself never needs
+to hold content.

--- a/src/snagline/baseline_store.py
+++ b/src/snagline/baseline_store.py
@@ -14,6 +14,7 @@ later; the core stays stdlib-only.
 from __future__ import annotations
 
 import json
+import os
 import time
 from pathlib import Path
 from typing import IO
@@ -24,6 +25,22 @@ from snagline.baseline import BaselineProfile, fit_baseline_from_jsonl
 def _write_json(stream: IO[str], data: dict) -> None:
     json.dump(data, stream, indent=2, sort_keys=True)
     stream.write("\n")
+
+
+def _atomic_write_json(path: Path, data: dict) -> None:
+    """Write ``data`` as JSON so readers see either the old or new file.
+
+    The payload lands in a sibling temp file first, is flushed and fsynced,
+    then moved into place with ``os.replace`` (atomic on POSIX and Windows).
+    A crash mid-write can therefore never leave a torn or half-written JSON
+    file behind; issue #102 relies on this for the version bump.
+    """
+    tmp = path.with_name(path.name + ".tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        _write_json(fh, data)
+        fh.flush()
+        os.fsync(fh.fileno())
+    os.replace(tmp, path)
 
 
 class BaselineStore:
@@ -52,21 +69,25 @@ class BaselineStore:
         """Persist ``profile`` and return the version id used.
 
         Writes both a timestamped history entry and a ``latest.json`` pointer.
-        Old versions beyond ``max_versions`` (this call, else the store
-        default) are pruned oldest-first.
+        Both files are written atomically (temp + fsync + rename): the history
+        entry first, then the pointer flip, so a reader of ``latest.json``
+        always sees one complete profile, never a partial write. Old versions
+        beyond ``max_versions`` (this call, else the store default) are pruned
+        oldest-first.
         """
         version = version or f"{time.time():.6f}"
         scope = self._scope_dir(tenant, deployment)
         versions_dir = scope / "versions"
         versions_dir.mkdir(parents=True, exist_ok=True)
 
-        with open(
-            self._version_path(tenant, deployment, version), "w", encoding="utf-8"
-        ) as fh:
-            _write_json(fh, profile.to_dict())
-        # Latest pointer.
-        with open(scope / "latest.json", "w", encoding="utf-8") as fh:
-            _write_json(fh, profile.to_dict())
+        # History entry first: durable even if the process dies before the
+        # pointer flip, in which case latest.json still resolves to the
+        # previous complete version (issue #102).
+        _atomic_write_json(
+            self._version_path(tenant, deployment, version), profile.to_dict()
+        )
+        # Atomic pointer flip to the new version.
+        _atomic_write_json(scope / "latest.json", profile.to_dict())
 
         limit = max_versions if max_versions is not None else self._max_versions
         self._prune(tenant, deployment, limit)
@@ -126,6 +147,29 @@ def capture_from_jsonl(
         tenant=tenant,
         deployment=deployment,
         version=version,
+        max_versions=max_versions,
+    )
+
+
+def retrain_from_jsonl(
+    store: BaselineStore,
+    window_path: str,
+    tenant: str = "default",
+    deployment: str = "default",
+    max_versions: int | None = None,
+) -> str:
+    """Refit a baseline from a JSONL window and atomically bump the store.
+
+    This is the library-side primitive behind ``snagline baseline retrain``
+    (issue #102): fit a fresh ``BaselineProfile`` from the newest healthy-run
+    window, then persist it as a new timestamped version whose pointer flip is
+    atomic (see ``BaselineStore.save``). Returns the new version id; the
+    previous version stays loadable for rollback.
+    """
+    return store.save(
+        fit_baseline_from_jsonl(window_path),
+        tenant=tenant,
+        deployment=deployment,
         max_versions=max_versions,
     )
 

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -18,6 +18,7 @@ import sys
 import time
 from collections.abc import Iterator
 from contextlib import suppress
+from pathlib import Path
 
 from snagline.config import Config
 from snagline.events import StepEvent
@@ -333,7 +334,34 @@ def _build_parser() -> argparse.ArgumentParser:
         "baseline",
         help="Fit a healthy-run baseline (per-tool latency/error profile) from a trajectory.",
     )
-    sp.add_argument("trajectory", help="Path to a .jsonl trajectory of a healthy run.")
+    sp.add_argument(
+        "trajectory",
+        metavar="trajectory|retrain",
+        help="Path to a .jsonl trajectory of a healthy run, or the literal "
+        "keyword 'retrain' to refit from the newest JSONL window and bump "
+        "the BaselineStore version atomically (issue #102; see docs/RETRAIN_CADENCE.md).",
+    )
+    sp.add_argument(
+        "--jsonl",
+        default=None,
+        help="With 'retrain': refit from exactly this JSONL window file "
+        "(overrides --windows-dir).",
+    )
+    sp.add_argument(
+        "--windows-dir",
+        default=None,
+        help="With 'retrain': directory of rotated window .jsonl files; the "
+        "newest by modification time is used.",
+    )
+    sp.add_argument(
+        "--max-age",
+        type=float,
+        default=None,
+        metavar="SECONDS",
+        help="With 'retrain': warn on stderr when the currently active stored "
+        "baseline is older than this many seconds (staleness guard for the "
+        "host-side cadence).",
+    )
     sp.add_argument(
         "--output",
         default="baseline.json",
@@ -499,13 +527,121 @@ def _event_to_json(event: StepEvent) -> dict:
     }
 
 
+def _newest_window(windows_dir: str) -> str | None:
+    """Return the newest ``*.jsonl`` window file in ``windows_dir``, or None.
+
+    Newest means largest modification time; ties break alphabetically so the
+    pick is deterministic. Non-recursive by design: windows are rotated into
+    one flat directory (issue #102).
+    """
+    root = Path(windows_dir)
+    candidates = [p for p in root.glob("*.jsonl") if p.is_file()]
+    if not candidates:
+        return None
+    return str(max(candidates, key=lambda p: (p.stat().st_mtime_ns, p.name)))
+
+
+def _active_baseline_age(store, tenant: str, deployment: str) -> float | None:
+    """Age in seconds of the newest stored version, or None if unknowable.
+
+    Version ids written by ``save()`` are wall-clock timestamps, so the id
+    doubles as the fit time. Non-numeric (custom) ids are skipped fail-open;
+    staleness is a warning aid, never a hard dependency.
+    """
+    for version_id in reversed(store.list_versions(tenant, deployment)):
+        try:
+            fitted_at = float(version_id)
+        except ValueError:
+            continue
+        return max(0.0, time.time() - fitted_at)
+    return None
+
+
+def _cmd_baseline_retrain(args: argparse.Namespace) -> int:
+    """Refit from the newest JSONL window and atomically bump the store.
+
+    Usage: ``snagline baseline retrain --store-dir ROOT [--tenant T]
+    [--deployment D] (--jsonl FILE | --windows-dir DIR) [--max-age SECONDS]
+    [--max-versions N]``. Exits 0 on success, 2 on usage errors, 3 when the
+    window cannot be resolved or read.
+    """
+    if not args.store_dir:
+        print(
+            "snagline baseline retrain: --store-dir is required (versioned store root)",
+            file=sys.stderr,
+        )
+        return 2
+    if bool(args.jsonl) == bool(args.windows_dir):
+        print(
+            "snagline baseline retrain: give exactly one of --jsonl FILE or "
+            "--windows-dir DIR",
+            file=sys.stderr,
+        )
+        return 2
+
+    from snagline.baseline_store import BaselineStore, retrain_from_jsonl
+
+    store = BaselineStore(args.store_dir, max_versions=args.max_versions or 10)
+
+    # Staleness guard on the previously active baseline, before it is
+    # replaced: this is the signal that the host-side cadence slipped.
+    if args.max_age is not None:
+        age = _active_baseline_age(store, args.tenant, args.deployment)
+        if age is not None and age > args.max_age:
+            print(
+                f"snagline baseline: WARNING: active baseline for "
+                f"{args.tenant}/{args.deployment} is {age / 3600.0:.1f}h old "
+                f"(max-age {args.max_age / 3600.0:.1f}h); consider tightening "
+                f"the retrain cadence",
+                file=sys.stderr,
+            )
+
+    window = args.jsonl or _newest_window(args.windows_dir)
+    if window is None:
+        print(
+            f"snagline baseline retrain: no .jsonl window files found in "
+            f"{args.windows_dir}",
+            file=sys.stderr,
+        )
+        return 3
+    try:
+        version = retrain_from_jsonl(
+            store,
+            window,
+            tenant=args.tenant,
+            deployment=args.deployment,
+            max_versions=args.max_versions,
+        )
+    except OSError as exc:
+        print(
+            f"snagline baseline retrain: cannot read {window}: {exc}", file=sys.stderr
+        )
+        return 3
+
+    profile = store.load_version(args.tenant, args.deployment, version)
+    tools = len(profile.tools) if profile is not None else 0
+    steps = profile.total_steps if profile is not None else 0
+    print(
+        f"snagline baseline retrain: stored version {version} for "
+        f"{args.tenant}/{args.deployment} from {window} "
+        f"({tools} tool(s), {steps} step(s))"
+    )
+    return 0
+
+
 def _cmd_baseline(args: argparse.Namespace) -> int:
     """Fit a healthy-run baseline from a trajectory and persist it.
 
     With ``--store-dir`` the baseline is stored versioned and per-tenant in a
     ``BaselineStore``; ``--list-versions`` just lists what is already stored.
     Otherwise it writes a single JSON file (``--output``).
+
+    The literal keyword ``retrain`` instead of a trajectory path dispatches to
+    the scheduled-retrain contract (issue #102).
     """
+    if getattr(args, "trajectory", None) == "retrain":
+        return _cmd_baseline_retrain(args)
+
     if args.store_dir:
         from snagline.baseline_store import (
             BaselineStore,

--- a/tests/test_baseline_retrain.py
+++ b/tests/test_baseline_retrain.py
@@ -1,0 +1,347 @@
+"""Scheduled baseline retrain contract (issue #102).
+
+Covers the ``snagline baseline retrain`` CLI mode and the
+``retrain_from_jsonl`` store primitive: round-trip through BaselineStore
+versioning, crash-safe atomic pointer flip, newest-window selection, the
+``--max-age`` staleness warning (fires when stale AND stays silent when
+fresh), graceful failure paths, and unchanged behavior of the legacy flat
+``snagline baseline <trajectory>`` form.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from snagline.baseline_store import (
+    BaselineStore,
+    capture_from_jsonl,
+    retrain_from_jsonl,
+)
+from snagline.cli import _active_baseline_age, main
+
+
+class BaselineProfileStub:
+    """Minimal profile stand-in: the store only persists its dict shape."""
+
+    def __init__(self) -> None:
+        self.total_steps = 1
+
+    @property
+    def tools(self) -> dict:
+        return {}
+
+    def to_dict(self) -> dict:
+        return {"version": 1, "total_steps": 1, "tools": {}}
+
+
+def _window(path, tool: str, latencies: list[float]) -> str:
+    rows = [
+        {
+            "step_id": str(i),
+            "episode_id": "ep",
+            "timestamp": 1.0 + i,
+            "action_type": "tool_call",
+            "action_signature": "SIG",
+            "tool_name": tool,
+            "latency_ms": latency,
+        }
+        for i, latency in enumerate(latencies)
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in rows) + "\n")
+    return str(path)
+
+
+def test_retrain_round_trips_through_versioning(tmp_path):
+    """Refit lands as a NEW version; old version stays rollback-loadable."""
+    store_dir = tmp_path / "store"
+    win_a = _window(tmp_path / "a.jsonl", "search", [100.0, 102.0, 104.0, 106.0, 108.0])
+    win_b = _window(tmp_path / "b.jsonl", "search", [200.0, 202.0, 204.0, 206.0, 208.0])
+
+    store = BaselineStore(str(store_dir))
+    v1 = capture_from_jsonl(store, win_a, tenant="acme", deployment="prod")
+    v2 = retrain_from_jsonl(store, win_b, tenant="acme", deployment="prod")
+
+    # The bump really produced a distinct, newer version id.
+    assert v2 != v1
+    assert store.list_versions("acme", "prod") == [v1, v2]
+    # Active profile now reflects the NEW window (mean of B computed by hand).
+    active = store.load("acme", "prod")
+    assert active is not None
+    assert active.total_steps == 5
+    assert active.tools["search"].mean_latency == 204.0
+    assert active.tools["search"].count == 5
+    assert active.tools["search"].error_rate == 0.0
+    # Rollback path: the pre-retrain version still holds window A's stats.
+    old = store.load_version("acme", "prod", v1)
+    assert old is not None
+    assert old.tools["search"].mean_latency == 104.0
+
+
+def test_retrain_pointer_flip_is_crash_safe(tmp_path, monkeypatch):
+    """A crash between history write and pointer flip loses nothing.
+
+    Fault injection on stdlib plumbing only (os.replace): the second rename
+    (the latest.json pointer flip) fails. The active baseline must remain the
+    previous complete version, byte-identical, and a later retrain recovers.
+    """
+    import snagline.baseline_store as bs
+
+    store_dir = tmp_path / "store"
+    win_a = _window(tmp_path / "a.jsonl", "search", [100.0] * 4)
+    win_b = _window(tmp_path / "b.jsonl", "search", [300.0] * 4)
+
+    store = BaselineStore(str(store_dir))
+    v1 = capture_from_jsonl(store, win_a, tenant="t", deployment="d")
+    pointer = store_dir / "t" / "d" / "latest.json"
+    before = pointer.read_bytes()
+
+    real_replace = bs.os.replace
+    calls = {"n": 0}
+
+    def flaky_replace(src, dst):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError("simulated crash before pointer flip")
+        return real_replace(src, dst)
+
+    monkeypatch.setattr(bs.os, "replace", flaky_replace)
+    with pytest.raises(OSError, match="simulated crash"):
+        retrain_from_jsonl(store, win_b, tenant="t", deployment="d")
+    monkeypatch.undo()
+
+    # Pointer untouched: active baseline is still the complete old version.
+    assert pointer.read_bytes() == before
+    active = store.load("t", "d")
+    assert active is not None
+    assert active.tools["search"].mean_latency == 100.0
+    # The history entry for the interrupted attempt may exist as an orphan;
+    # it must be a complete JSON file either way (never torn).
+    versions_before_recovery = store.list_versions("t", "d")
+    for vid in versions_before_recovery:
+        raw = (store_dir / "t" / "d" / "versions" / f"{vid}.json").read_bytes()
+        json.loads(raw)
+    # Recovery: a later retrain flips the pointer to the new window cleanly.
+    v_new = retrain_from_jsonl(store, win_b, tenant="t", deployment="d")
+    recovered = store.load("t", "d")
+    assert recovered is not None
+    assert recovered.tools["search"].mean_latency == 300.0
+    assert v_new != v1
+
+
+def test_cli_retrain_jsonl_round_trip(tmp_path, capsys):
+    store_dir = tmp_path / "store"
+    win_b = _window(tmp_path / "w.jsonl", "fetch", [50.0, 52.0, 54.0])
+
+    rc = main(
+        [
+            "baseline",
+            "retrain",
+            "--store-dir",
+            str(store_dir),
+            "--tenant",
+            "acme",
+            "--deployment",
+            "prod",
+            "--jsonl",
+            win_b,
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "stored version" in out
+    assert "acme/prod" in out
+    store = BaselineStore(str(store_dir))
+    active = store.load("acme", "prod")
+    assert active is not None
+    assert active.tools["fetch"].mean_latency == 52.0
+    assert active.total_steps == 3
+
+
+def test_cli_retrain_windows_dir_picks_newest_by_mtime(tmp_path, capsys):
+    store_dir = tmp_path / "store"
+    older = tmp_path / "win-0001.jsonl"
+    newer = tmp_path / "win-0002.jsonl"
+    _window(older, "search", [100.0] * 3)
+    _window(newer, "search", [400.0] * 3)
+    # Fixed timestamps, no sleeps: make mtimes unambiguous.
+    old_ts, new_ts = 1600000000, 1600000600
+    os.utime(older, (old_ts, old_ts))
+    os.utime(newer, (new_ts, new_ts))
+
+    rc = main(
+        [
+            "baseline",
+            "retrain",
+            "--store-dir",
+            str(store_dir),
+            "--windows-dir",
+            str(tmp_path),
+        ]
+    )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "win-0002.jsonl" in out  # picked the newer window explicitly
+    active = BaselineStore(str(store_dir)).load("default", "default")
+    assert active is not None
+    assert active.tools["search"].mean_latency == 400.0
+
+
+def test_cli_retrain_max_age_warns_on_stale_baseline(tmp_path, capsys):
+    store_dir = tmp_path / "store"
+    win_a = _window(tmp_path / "a.jsonl", "search", [100.0] * 3)
+    win_b = _window(tmp_path / "b.jsonl", "search", [110.0] * 3)
+    store = BaselineStore(str(store_dir))
+    # Fixed ancient version id: wall-clock unix time far in the past.
+    capture_from_jsonl(
+        store, win_a, tenant="acme", deployment="prod", version="1000000000.0"
+    )
+
+    rc = main(
+        [
+            "baseline",
+            "retrain",
+            "--store-dir",
+            str(store_dir),
+            "--tenant",
+            "acme",
+            "--deployment",
+            "prod",
+            "--jsonl",
+            win_b,
+            "--max-age",
+            "3600",
+        ]
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    assert "acme/prod" in err
+    assert "retrain cadence" in err
+
+
+def test_cli_retrain_max_age_silent_when_fresh(tmp_path, capsys):
+    store_dir = tmp_path / "store"
+    win_a = _window(tmp_path / "a.jsonl", "search", [100.0] * 3)
+    win_b = _window(tmp_path / "b.jsonl", "search", [110.0] * 3)
+    store = BaselineStore(str(store_dir))
+    capture_from_jsonl(
+        store,
+        win_a,
+        tenant="acme",
+        deployment="prod",
+        version=f"{time.time():.6f}",
+    )
+
+    rc = main(
+        [
+            "baseline",
+            "retrain",
+            "--store-dir",
+            str(store_dir),
+            "--tenant",
+            "acme",
+            "--deployment",
+            "prod",
+            "--jsonl",
+            win_b,
+            "--max-age",
+            "3600",
+        ]
+    )
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "WARNING" not in err
+
+
+def test_cli_retrain_usage_and_input_errors(tmp_path, capsys):
+    store_dir = tmp_path / "store"
+    win = _window(tmp_path / "w.jsonl", "search", [100.0] * 2)
+
+    # Missing --store-dir.
+    assert main(["baseline", "retrain", "--jsonl", win]) == 2
+    # Neither nor both window inputs.
+    assert main(["baseline", "retrain", "--store-dir", str(store_dir)]) == 2
+    assert (
+        main(
+            [
+                "baseline",
+                "retrain",
+                "--store-dir",
+                str(store_dir),
+                "--jsonl",
+                win,
+                "--windows-dir",
+                str(tmp_path),
+            ]
+        )
+        == 2
+    )
+    # Empty windows directory: resolvable inputs, no window found.
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    assert (
+        main(
+            [
+                "baseline",
+                "retrain",
+                "--store-dir",
+                str(store_dir),
+                "--windows-dir",
+                str(empty),
+            ]
+        )
+        == 3
+    )
+    # Unreadable window file: graceful exit, no traceback.
+    assert (
+        main(
+            [
+                "baseline",
+                "retrain",
+                "--store-dir",
+                str(store_dir),
+                "--jsonl",
+                str(tmp_path / "missing.jsonl"),
+            ]
+        )
+        == 3
+    )
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "no .jsonl window files found" in combined
+    assert "cannot read" in combined
+
+
+def test_active_baseline_age_skips_non_numeric_ids(tmp_path):
+    store = BaselineStore(str(tmp_path / "store"))
+    profile = BaselineProfileStub()
+    store.save(profile, tenant="t", deployment="d", version="v-custom")
+    # Only custom ids: age is unknowable, helper reports None (fail-open).
+    assert _active_baseline_age(store, "t", "d") is None
+    # Numeric timestamped id alongside custom ids: age comes from the newest
+    # numeric one only.
+    now_id = f"{time.time():.6f}"
+    store.save(profile, tenant="t", deployment="d", version=now_id)
+    age = _active_baseline_age(store, "t", "d")
+    assert age is not None
+    assert 0.0 <= age < 60.0
+
+
+def test_legacy_flat_baseline_form_unchanged(tmp_path):
+    """'retrain' dispatch must not disturb plain trajectory fitting."""
+    traj = _window(tmp_path / "h.jsonl", "search", [100.0, 100.0, 100.0])
+    out = tmp_path / "baseline.json"
+
+    rc = main(["baseline", traj, "--output", str(out)])
+
+    assert rc == 0
+    data = json.loads(out.read_text())
+    assert data["tools"]["search"]["mean_latency"] == 100.0


### PR DESCRIPTION
## Summary

Implements the scheduled baseline retrain contract (issue #102):

- `snagline baseline retrain`: new CLI mode (the literal keyword `retrain` replaces the trajectory positional). Refits from the newest JSONL window, either an explicit `--jsonl FILE` or the newest `*.jsonl` in `--windows-dir DIR` by mtime, and stores it as a NEW timestamped version in the `BaselineStore`. Exit codes: 0 success, 2 usage error, 3 input failure. The legacy flat form (`snagline baseline run.jsonl --output baseline.json`) is untouched and covered by a guard test.
- Atomic version bump: `BaselineStore.save()` now writes the history entry first, then flips `latest.json`, each via temp file + fsync + `os.replace`. Readers only ever see the old or the new complete profile, never torn JSON; a crash mid-bump leaves the active baseline intact.
- Library primitive `retrain_from_jsonl(store, window_path, ...)` so hosts can retrain without the CLI.
- Staleness guard: `--max-age SECONDS` warns on stderr when the currently active baseline is older than the limit (version ids are wall-clock timestamps; custom non-numeric ids are skipped fail-open). Fires when stale AND stays silent when fresh: both sides tested.
- Docs: new docs/RETRAIN_CADENCE.md with copy-paste cron line, systemd service+timer pair, atomicity rationale, retention/rollback notes, and the explicit caveat that retrain is NOT a mid-episode reset for goal_drift live profiles (running monitors keep their reference object until the host reloads at an episode boundary). README baseline section points to it; ATTACH_ANY_SYSTEM.md item 6 status updated to shipped.

Zero new dependencies: stdlib only (`os`, `pathlib`, `time`). No content retention: profiles remain aggregates (counts, means, stds, error rates) and retrain output prints structure only.

## Verification

Full gate on the final commit, dedicated worktree venv:

```
$ python -m pytest tests/ -q -o addopts=""
272 passed, 1 skipped in 30.15s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
78 files already formatted

$ mypy src
Success: no issues found in 40 source files
```

New tests (tests/test_baseline_retrain.py, 9 cases): versioning round-trip with hand-computed means (204.0 vs rollback 104.0), crash-safe pointer flip via fault injection on `os.replace` (second rename fails: active baseline stays byte-identical, later retrain recovers), CLI round-trip through `main()`, newest-window selection with fixed `os.utime` timestamps (no sleeps), `--max-age` warning on stale AND silence on fresh, usage/input error paths (2/3), custom version-id fail-open, legacy form unchanged.

Mutation check performed as required: I degraded `_atomic_write_json` from rename to a plain overwrite on purpose and reran pytest; `test_retrain_pointer_flip_is_crash_safe` went red (`1 failed, 8 passed`), then reverted and confirmed green again.

Em-dash scan of the full diff returns nothing (grep for U+2014 over `git diff` output: empty).

## Board

#106

Fixes #102
