### PR TITLE
feat(detector): stagnation detector for novelty-rate collapse (Fixes #87)

### DIFF
--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -61,6 +61,7 @@ monitor._detectors.append(MyDetector())   # or: Monitor(default_detectors + [min
 - `detectors/loop.py` - sliding-window repetition count on `action_signature`
 - `detectors/error_cascade.py` - consecutive and windowed error counts
 - `detectors/latency_anomaly.py` - Welford baseline + CUSUM deviation per tool
+- `detectors/stagnation.py` - all-time novelty set plus a sliding novelty share
 - `detectors/goal_drift.py` - compares a live run to a persisted `BaselineProfile`
 - `detectors/ml_ensemble.py` - `MLOrchestrator` combining base detector scores
 
@@ -100,3 +101,35 @@ detectors agree. Pass `model=callable(scores) -> float` (e.g. a fitted
 scikit-learn pipeline from the `ml` extra) to replace the combiner. Enable it
 with `Config(ml_ensemble_enabled=True)`; `Monitor.default()` then wraps the
 base detectors in one orchestrator so there is no double counting.
+
+### `StagnationDetector` (issue #87)
+
+`StagnationDetector(config=cfg)` asks a question the loop detector cannot:
+not "is it repeating?" but "is it discovering anything?". It tracks the share
+of never-before-seen `action_signature` values in the last
+`stagnation_window_size` steps (default 50). When that novelty share stays
+below `stagnation_min_novelty` (default 0.05) for `stagnation_patience`
+(default 2) consecutive full-window observations, it emits exactly one risk
+(score 0.6, trigger `stagnation`). Novelty recovering resets the stale
+counter, so a later collapse fires again: one alert per stagnation period,
+never one per step.
+
+The two detectors are complementary by construction. Near-duplicate actions
+with slightly varied arguments produce fresh signatures each time and evade
+exact-match loop windows entirely; the all-time novelty set still collapses
+because the agent keeps drawing from the same small template space. The tests
+in `tests/detectors/test_stagnation.py` prove a sequence that trips
+stagnation while the loop detector stays silent.
+
+Memory, stated honestly: the per-episode `seen_all_time` set grows
+monotonically by design and only `reset(episode_id)` (called by
+`Monitor.end_episode()`) releases it. Signatures are full 64-character hex
+digests since issue #15; measured on CPython 3.14, retaining one costs about
+105 bytes plus roughly 70 bytes of amortized set overhead, so budget around
+175 bytes per unique action: a pathological all-unique 100k-step episode
+holds on the order of 17 MB. Typical episodes repeat heavily and cost far
+less. The sliding counter itself is bounded (`window_size` booleans per
+episode).
+
+Enable it with `Config(stagnation_enabled=True)`. It ships opt-in so the
+zero-dependency preset and the published bench numbers are untouched.

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -85,6 +85,19 @@ class Config:
     ml_ensemble_enabled: bool = False
     ml_ensemble_score_threshold: float = 0.5  # emit a combined risk above this
 
+    # --- Stagnation detector (issue #87) --------------------------------------
+    # Opt-in novelty-rate tracker: flags an episode whose share of never-
+    # before-seen action signatures collapses, i.e. the agent is busy but
+    # discovering nothing. Distinct from the loop detector, which needs exact
+    # repeats: near-duplicate actions with slightly varied arguments produce
+    # fresh signatures and evade exact matching while still being stuck.
+    # Default off so the zero-dependency preset and the published bench
+    # numbers are untouched.
+    stagnation_enabled: bool = False
+    stagnation_window_size: int = 50  # steps per novelty window
+    stagnation_min_novelty: float = 0.05  # stale when fewer than this share new
+    stagnation_patience: int = 2  # consecutive stale windows before firing
+
     # Global
     fail_open: bool = True
 

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -1,0 +1,138 @@
+"""Stagnation detector: novelty-rate collapse ("stuck" is not "loop").
+
+``LoopDetector`` asks whether the agent repeats identical actions; this
+detector asks whether it discovers anything new at all (issue #87). An agent
+can evade exact loop matching by varying its arguments slightly: near
+duplicates produce distinct signatures, so exact-match windows never trip.
+The share of *never-before-seen* signatures collapses anyway, and that is what
+this detector measures. The two failure shapes need different interventions
+(replan vs interrupt), so they stay independent detectors.
+
+Per episode, every ``action_signature`` is checked against ``seen_all_time``,
+the set of signatures observed so far in that episode. A step whose signature
+was never seen before is "novel". The detector tracks how many of the last
+``window_size`` steps were novel; when that share drops below ``min_novelty``
+for ``patience`` consecutive full-window observations, it emits exactly one
+``FailureRisk(score=0.6, trigger="stagnation")``. The risk fires once per
+collapse and re-arms only after novelty recovers above the threshold, so a
+long stagnant stretch alerts once instead of on every step (issue #4 alert
+spam precedent).
+
+Privacy: only the one-way ``action_signature`` hash is read. No prompt or
+response content, no ``StepEvent.metadata`` (project.md §1.4 / §11).
+
+Performance: O(1) amortized per step. One set membership test, one deque
+append with an optional eviction of a single boolean, two integer updates.
+
+Memory, stated honestly: ``seen_all_time`` grows monotonically per episode by
+design, so worst-case memory is O(unique signatures in the episode) and
+``reset(episode_id)`` releases all of it. Signatures are full 64-character
+hex digests since issue #15 (the issue #87 estimate of single-digit MB
+predates that change and assumed 16-character hashes). Measured on CPython
+3.14: retaining one digest costs about 105 bytes plus roughly 70 bytes of
+amortized set overhead, call it ~175 bytes per unique action, so a pathological
+all-unique 100k-step episode holds on the order of 17 MB. Typical episodes
+repeat actions heavily and cost far less. The sliding novelty counter itself
+is bounded: ``window_size`` booleans plus three integers per episode.
+
+The detector ships opt-in behind ``Config.stagnation_enabled`` (default off)
+so the zero-dependency preset and the published bench numbers are untouched;
+see :meth:`snagline.monitor.Monitor.default`.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.risk import FailureRisk
+
+
+class _EpisodeWindow:
+    """Per-episode state: sliding novelty flags plus the all-time seen set."""
+
+    __slots__ = ("flags", "novel_in_window", "seen_all_time", "stale_windows")
+
+    def __init__(self) -> None:
+        # One bool per step in the current window: was this signature novel
+        # (never seen before in this episode) at push time? Booleans keep the
+        # sliding counter cheap; the signatures themselves live only in
+        # ``seen_all_time``.
+        self.flags: deque[bool] = deque()
+        self.novel_in_window = 0
+        self.seen_all_time: set[str] = set()
+        self.stale_windows = 0
+
+
+class StagnationDetector:
+    """Flags episodes whose rate of new unique actions collapses to near zero.
+
+    Fires once per stagnation period: ``patience`` consecutive full-window
+    observations below ``min_novelty`` novelty emit one risk, then the
+    detector stays quiet until novelty recovers (which resets the stale
+    counter) and a later collapse can fire again.
+    """
+
+    name = "stagnation"
+
+    def __init__(
+        self,
+        window_size: int | None = None,
+        min_novelty: float | None = None,
+        patience: int | None = None,
+        config: Config | None = None,
+    ) -> None:
+        cfg = config or Config()
+        self.window_size = (
+            window_size if window_size is not None else cfg.stagnation_window_size
+        )
+        self.min_novelty = (
+            min_novelty if min_novelty is not None else cfg.stagnation_min_novelty
+        )
+        self.patience = patience if patience is not None else cfg.stagnation_patience
+        if self.window_size < 1:
+            raise ValueError("window_size must be >= 1")
+        if not 0.0 <= self.min_novelty <= 1.0:
+            raise ValueError("min_novelty must be within [0.0, 1.0]")
+        if self.patience < 1:
+            raise ValueError("patience must be >= 1")
+        self._windows: dict[str, _EpisodeWindow] = {}
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        w = self._windows.setdefault(event.episode_id, _EpisodeWindow())
+        sig = event.action_signature
+        novel = sig not in w.seen_all_time
+        w.seen_all_time.add(sig)
+        if len(w.flags) == self.window_size and w.flags.popleft():
+            w.novel_in_window -= 1
+        w.flags.append(novel)
+        if novel:
+            w.novel_in_window += 1
+
+        if len(w.flags) == self.window_size and (
+            w.novel_in_window / self.window_size < self.min_novelty
+        ):
+            w.stale_windows += 1
+            # Escalate exactly when patience is first reached. Continuing past
+            # it must not re-fire (one finding per collapse), and any fresh
+            # observation resets ``stale_windows`` below, re-arming us.
+            if w.stale_windows == self.patience:
+                rate = w.novel_in_window / self.window_size
+                return FailureRisk(
+                    event.episode_id,
+                    event.step_id,
+                    0.6,
+                    "stagnation",
+                    f"{rate:.0%} new actions in last {self.window_size} steps, "
+                    f"below {self.min_novelty:.0%} for {self.patience} "
+                    "consecutive windows",
+                    event.timestamp,
+                )
+        else:
+            w.stale_windows = 0
+        return None
+
+    def reset(self, episode_id: str) -> None:
+        """Drop the window, the stale counter, and the monotonic seen-set."""
+        self._windows.pop(episode_id, None)

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -234,6 +234,7 @@ class Monitor:
         from snagline.detectors.latency_anomaly import LatencyAnomalyDetector
         from snagline.detectors.loop import LoopDetector
         from snagline.detectors.ml_ensemble import MLOrchestrator
+        from snagline.detectors.stagnation import StagnationDetector
         from snagline.sinks.console import ConsoleSink
 
         cfg = config or Config()
@@ -242,6 +243,12 @@ class Monitor:
             ErrorCascadeDetector(config=cfg),
             LatencyAnomalyDetector(config=cfg),
         ]
+        # Stagnation is opt-in (issue #87): novelty-rate collapse detection,
+        # default-off so the zero-dependency preset and the published bench
+        # numbers are untouched. Appended to ``base`` so a concurrent
+        # MLOrchestrator wraps it like any other signal.
+        if cfg.stagnation_enabled:
+            base.append(StagnationDetector(config=cfg))
         # Goal-drift is opt-in: only when explicitly enabled and a baseline is
         # supplied, so the zero-dependency default is unchanged (step 2).
         if cfg.goal_drift_enabled and cfg.goal_drift_baseline is not None:

--- a/src/snagline/risk.py
+++ b/src/snagline/risk.py
@@ -16,6 +16,7 @@ TriggerType = Literal[
     "latency_anomaly",
     "goal_drift",
     "ml_ensemble",
+    "stagnation",
 ]
 
 # Severity ordering is informational only; sinks decide what to do with it.

--- a/tests/detectors/test_stagnation.py
+++ b/tests/detectors/test_stagnation.py
@@ -1,0 +1,251 @@
+"""Tests for the stagnation detector (issue #87).
+
+Every injected-failure scenario below has a mirrored healthy scenario: the
+detector must fire (with the exact ``"stagnation"`` trigger) on collapsing
+novelty and must stay silent on exploration and on repetitive-but-productive
+traffic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from snagline.config import Config
+from snagline.detectors.loop import LoopDetector
+from snagline.detectors.stagnation import StagnationDetector
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+
+
+def _sig(i: int) -> str:
+    return make_signature("tool_call", "t", f"a{i}")
+
+
+def _event(step_id: int, sig: str, episode: str = "ep") -> StepEvent:
+    return StepEvent(
+        step_id=str(step_id),
+        episode_id=episode,
+        timestamp=float(step_id),
+        action_type="tool_call",
+        action_signature=sig,
+    )
+
+
+def _feed(d: StagnationDetector, signatures: list[str], episode: str = "ep"):
+    """Feed ``signatures`` as consecutive steps; return the risks emitted."""
+    risks = []
+    for i, s in enumerate(signatures):
+        r = d.observe(_event(i, s, episode))
+        if r is not None:
+            risks.append(r)
+    return risks
+
+
+# --- Injected failure: sustained novelty collapse ----------------------------
+
+
+def test_fires_once_after_two_consecutive_stale_windows():
+    """Defaults (50/0.05/2): 50 unique steps fill the window fresh, then 50
+    exact repeats starve it. The share of novel steps falls below 5% first at
+    step 97 (2/50 novel, stale 1) and patience=2 is reached at step 98 (1/50,
+    stale 2): one fire, and continuing staleness must not re-fire.
+    """
+    d = StagnationDetector()
+    seq = [_sig(i) for i in range(50)] + [_sig(0)] * 50
+    risks = _feed(d, seq)
+    assert [r.step_id for r in risks] == ["98"]
+    assert risks[0].trigger == "stagnation"
+    assert risks[0].score == 0.6
+    assert risks[0].severity == "warning"
+    assert risks[0].episode_id == "ep"
+
+
+def test_single_stale_window_short_of_patience_stays_silent():
+    """One stale full-window observation is not enough: stop right after the
+    first one (step 97 in the trace above) and nothing may fire.
+    """
+    d = StagnationDetector()
+    seq = [_sig(i) for i in range(50)] + [_sig(0)] * 48
+    assert _feed(d, seq) == []
+
+
+def test_recovery_resets_the_stale_counter_and_rearms():
+    """A fresh observation mid-stagnation must clear the stale counter (so the
+    collapse has to rebuild patience from zero), and a recovered episode that
+    collapses again fires a second time. Trace with window 10 / 0.2 / 2:
+    fires at 19, goes fresh again at 31, fires again at 49.
+    """
+    d = StagnationDetector(window_size=10, min_novelty=0.2, patience=2)
+    seq = (
+        [_sig(i) for i in range(10)]  # explore: fresh
+        + [_sig(0)] * 20  # starve: fire at 19, then quiet
+        + [_sig(10 + i) for i in range(10)]  # recover: counter resets
+        + [_sig(0)] * 10  # starve again: second fire at 49
+    )
+    risks = _feed(d, seq)
+    assert [r.step_id for r in risks] == ["19", "49"]
+    assert all(r.trigger == "stagnation" for r in risks)
+
+
+def test_reset_clears_window_stale_counter_and_all_time_set():
+    """reset() must drop everything: previously-seen signatures become novel
+    again (no instant re-fire), and the detector can still fire afterwards.
+    """
+    d = StagnationDetector(window_size=10, min_novelty=0.2, patience=2)
+    first = _feed(d, [_sig(i) for i in range(10)] + [_sig(0)] * 10)
+    assert [r.step_id for r in first] == ["19"]
+
+    d.reset("ep")
+    assert d._windows == {}
+
+    # The very signatures that starred in the first collapse are novel again.
+    replay = [_event(100 + i, _sig(i), "ep2") for i in range(10)]
+    assert all(d.observe(e) is None for e in replay)
+
+    # And the detector is fully functional after the reset.
+    more = [_event(110 + i, _sig(0), "ep2") for i in range(10)]
+    risks = [r for r in (d.observe(e) for e in more) if r is not None]
+    assert [r.step_id for r in risks] == ["119"]
+
+
+def test_episodes_are_isolated():
+    """State is keyed by episode: one episode starving cannot fire another
+    that is exploring, and vice versa. Interleaved a (constant signature) and
+    b (always-new): only a fires, at its own 20th step (index 38 of the
+    interleaved stream maps to a-step 19).
+    """
+    d = StagnationDetector(window_size=10, min_novelty=0.2, patience=2)
+    risks = []
+    step = 0
+    for k in range(25):
+        for ep, sig in (("a", _sig(7)), ("b", _sig(100 + k))):
+            r = d.observe(_event(step, sig, ep))
+            if r is not None:
+                risks.append(r)
+            step += 1
+    assert len(risks) == 1
+    assert risks[0].episode_id == "a"
+    assert risks[0].trigger == "stagnation"
+
+
+# --- Injected failure that the loop detector structurally cannot see --------
+
+
+def test_near_duplicate_varying_args_trip_stagnation_but_not_loop():
+    """The distinctness requirement (issue #87): an agent that varies its
+    arguments slightly produces recycled-but-spaced-out signatures from a tiny
+    template space. Exact-match looping (window 12, threshold 3) never sees a
+    repetition; the all-time novelty set still collapses. Same events, both
+    detectors: loop silent, stagnation fires.
+    """
+    pool = [
+        make_signature("tool_call", "search", f"query variant {i}") for i in range(40)
+    ]
+    seq = [pool[i % 40] for i in range(200)]
+
+    loop = LoopDetector(window_size=12, repeat_threshold=3)
+    loop_risks = [
+        r for i, s in enumerate(seq) if (r := loop.observe(_event(i, s))) is not None
+    ]
+    assert loop_risks == [], "exact-match loop detector must not fire here"
+
+    stag = StagnationDetector()
+    risks = _feed(stag, seq)
+    assert len(risks) == 1
+    assert risks[0].trigger == "stagnation"
+    assert risks[0].score == 0.6
+
+
+# --- Healthy traffic: the no-false-positive side -----------------------------
+
+
+def test_healthy_exploration_stays_silent():
+    d = StagnationDetector()
+    assert _feed(d, [_sig(i) for i in range(300)]) == []
+
+
+def test_productive_maintenance_repetition_stays_silent():
+    """Legitimate repetitive-but-productive phases (acceptance criteria): four
+    identical maintenance calls per block interleaved with six genuinely new
+    actions keeps every sliding window far above the novelty floor.
+    """
+    d = StagnationDetector()
+    seq: list[str] = []
+    for block in range(30):
+        seq += [_sig(9000)] * 4 + [_sig(block * 6 + k) for k in range(6)]
+    assert _feed(d, seq) == []
+
+
+def test_stays_silent_on_healthy_fixture_trajectory():
+    fixture = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "trajectories"
+        / "healthy_run.jsonl"
+    )
+    events = [
+        StepEvent(**json.loads(line))
+        for line in fixture.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    d = StagnationDetector()
+    assert all(d.observe(e) is None for e in events)
+
+
+# --- Opt-in wiring and configuration -----------------------------------------
+
+
+def test_default_off_in_zero_dependency_preset():
+    m = Monitor.default(config=Config())
+    assert all(getattr(det, "name", "") != "stagnation" for det in m._detectors)
+
+
+def test_config_flag_wires_detector_into_default_monitor():
+    m = Monitor.default(config=Config(stagnation_enabled=True))
+    names = [getattr(det, "name", "") for det in m._detectors]
+    assert names.count("stagnation") == 1
+
+
+def test_enabled_detector_joins_the_ml_ensemble_wrap():
+    cfg = Config(stagnation_enabled=True, ml_ensemble_enabled=True)
+    m = Monitor.default(config=cfg)
+    assert [getattr(det, "name", "") for det in m._detectors] == ["ml_ensemble"]
+    wrapped_names = [getattr(det, "name", "") for det in m._detectors[0]._base]
+    assert "stagnation" in wrapped_names
+
+
+def test_stagnation_settings_flow_through_env_overrides():
+    cfg = Config.from_env(
+        {
+            "SNAGLINE_STAGNATION_ENABLED": "true",
+            "SNAGLINE_STAGNATION_WINDOW_SIZE": "20",
+            "SNAGLINE_STAGNATION_MIN_NOVELTY": "0.1",
+            "SNAGLINE_STAGNATION_PATIENCE": "5",
+        }
+    )
+    assert cfg.stagnation_enabled is True
+    assert cfg.stagnation_window_size == 20
+    assert cfg.stagnation_min_novelty == 0.1
+    assert cfg.stagnation_patience == 5
+
+
+def test_explicit_params_override_config_defaults():
+    d = StagnationDetector(
+        window_size=8,
+        min_novelty=0.5,
+        patience=1,
+        config=Config(stagnation_window_size=50),
+    )
+    assert (d.window_size, d.min_novelty, d.patience) == (8, 0.5, 1)
+
+
+def test_invalid_constructor_arguments_raise():
+    with pytest.raises(ValueError):
+        StagnationDetector(window_size=0)
+    with pytest.raises(ValueError):
+        StagnationDetector(min_novelty=1.5)
+    with pytest.raises(ValueError):
+        StagnationDetector(patience=0)


### PR DESCRIPTION
## Summary

Implements issue #87: `StagnationDetector`, a novelty-rate collapse detector that answers "is it discovering anything?" where LoopDetector only answers "is it repeating?".

- Tracks the share of never-before-seen `action_signature` values in a sliding window (`window_size=50`). When that share stays below `min_novelty=0.05` for `patience=2` consecutive full-window observations, it emits exactly one `FailureRisk(score=0.6, trigger="stagnation")`. Novelty recovery resets the stale counter and re-arms the detector, so one alert fires per stagnation period, never one per step (issue #4 alert-spam precedent).
- Ships opt-in behind `Config.stagnation_enabled` (default `False`), so the zero-dependency preset and the published bench numbers are untouched. Config keys are additive; env overrides (`SNAGLINE_STAGNATION_*`) work through the existing 12-factor machinery.
- Independence from the loop detector is proven, not asserted: `test_near_duplicate_varying_args_trip_stagnation_but_not_loop` feeds one near-duplicate sequence (signatures recycled from a small template space, spaced beyond any exact-match window) to both detectors; loop stays silent, stagnation fires.
- Privacy: reads only the one-way signature hash, per project.md section 1.4 and 11. Detail strings carry percentages and counts only.
- Performance: O(1) amortized per step (one set membership test, one boolean deque append/evict, two integer updates).

**Honest memory documentation (one correction to the issue text):** `seen_all_time` grows monotonically per episode by design. Issue #87 estimated single-digit MB per 100k steps assuming 16-character hashes, but signatures have been full 64-hex digests since #15. Measured on CPython 3.14: about 176 bytes per unique action retained, so a pathological all-unique 100k-step episode holds on the order of 17 MB. That real number is what the docstring and DETECTOR_GUIDE now state, alongside the bounded cost of the sliding counter itself.

Files touched: `src/snagline/detectors/stagnation.py` (new), `src/snagline/config.py` (additive keys), `src/snagline/risk.py` (`"stagnation"` added to the `TriggerType` union), `src/snagline/monitor.py` (opt-in wiring in `Monitor.default()`, appended to `base` so `MLOrchestrator` wraps it when both flags are on), `tests/detectors/test_stagnation.py` (new), `docs/DETECTOR_GUIDE.md` (new section plus reference-list line).

PR #107 is not merged, so its structure was not applicable; the implementation follows the existing `LoopDetector` / `GoalDriftDetector` patterns in DETECTOR_GUIDE.

## Verification

All commands run in a dedicated worktree against this branch after a rebase onto master `673940d` (PRs #122/#124/#125/#126 landed mid-review; rebase was clean, no conflicts):

```
$ python -m pytest tests/ -q -o addopts=""
297 passed, 1 skipped in 29.87s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
82 files already formatted

$ mypy src
Success: no issues found in 41 source files

$ git diff origin/master..HEAD | grep -c "$(printf '\u2014')"
0
```

(282 passing on master `673940d` + 15 new stagnation tests = 297.)

CI on head `35cfa40`: Test (py3.10), (py3.11), (py3.12), (py3.13) all pass.

## Test honesty

- **Mutation check performed:** disabled the stale-window counter by replacing `w.stale_windows += 1` with `pass`, reran pytest, and confirmed 5 of the new tests went red (`test_fires_once_after_two_consecutive_stale_windows`, `test_recovery_resets_the_stale_counter_and_rearms`, `test_reset_clears_window_stale_counter_and_all_time_set`, `test_episodes_are_isolated`, `test_near_duplicate_varying_args_trip_stagnation_but_not_loop`), then reverted and confirmed the full suite green again.
- Both sides present for every claim: injected-failure sequences assert the exact `"stagnation"` trigger, score 0.6, and the exact fire step (hand-traced arithmetic documented in test comments, e.g. step 98 under defaults); healthy sequences (steady exploration, periodic maintenance repetition interleaved with progress, and `healthy_run.jsonl`) assert zero risks.
- Expected values are computed from threshold arithmetic written out in comments, not by calling the detector under test.
- No sleeps, no network, no randomness in the new tests. Existing tests untouched.

Board: #106

Fixes #87
