### PR TITLE
ci(matrix): add windows-latest legs with a linux-only coverage gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,11 @@ jobs:
         include:
           # Windows legs (issue #116): the two newest interpreters only, so
           # Windows-only regressions surface in CI without an 8-way matrix.
-          # Lint, type-check, and the coverage gate stay Linux-only (steps
-          # below): they are OS-independent checks, and branch coverage of
-          # POSIX-gated code paths would let one runner spuriously fail a
-          # shared --cov-fail-under threshold.
+          # Coverage policy: each job checks its own threshold independently;
+          # the Linux legs enforce the single canonical 80% gate from
+          # pyproject.toml while the Windows legs run report-only
+          # (--cov-fail-under=0 below), so per-OS numbers stay visible
+          # without becoming extra gates that must be moved in lockstep.
           - os: windows-latest
             python-version: "3.12"
           - os: windows-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,24 @@ on:
 
 jobs:
   test:
-    name: Test (py${{ matrix.python-version }})
-    runs-on: ubuntu-latest
+    name: Test (${{ matrix.os }}, py${{ matrix.python-version }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        include:
+          # Windows legs (issue #116): the two newest interpreters only, so
+          # Windows-only regressions surface in CI without an 8-way matrix.
+          # Lint, type-check, and the coverage gate stay Linux-only (steps
+          # below): they are OS-independent checks, and branch coverage of
+          # POSIX-gated code paths would let one runner spuriously fail a
+          # shared --cov-fail-under threshold.
+          - os: windows-latest
+            python-version: "3.12"
+          - os: windows-latest
+            python-version: "3.13"
     steps:
       - uses: actions/checkout@v7
 
@@ -22,31 +34,46 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install (zero core deps + dev tooling)
+        shell: bash
         run: |
           python -m venv .venv
-          . .venv/bin/activate
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            . .venv/Scripts/activate
+          else
+            . .venv/bin/activate
+          fi
           python -m pip install --upgrade pip
           pip install -e . --no-deps
           # optional extra: without langchain-core the integration test silently
-          # skips, so CI would never run it — install it explicitly
+          # skips, so CI would never run it; install it explicitly
           pip install "langchain-core>=0.2"
           pip install "pytest" "pytest-cov==7.1.0" "ruff==0.16.3" "mypy"
 
       - name: Lint (ruff)
+        if: runner.os == 'Linux'
         run: |
           . .venv/bin/activate
           ruff check src tests
           ruff format --check src tests
 
       - name: Type-check (mypy)
+        if: runner.os == 'Linux'
         run: |
           . .venv/bin/activate
           mypy src
 
-      - name: Run tests with coverage
+      - name: Run tests with coverage gate (Linux)
+        if: runner.os == 'Linux'
         run: |
           . .venv/bin/activate
           python -m pytest tests/ -q
+
+      - name: Run tests, coverage reported but not gated (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          . .venv/Scripts/activate
+          python -m pytest tests/ -q --cov-fail-under=0
 
   test-ml:
     # Exercises the optional ml extra so its tests always run somewhere;

--- a/tests/adapters/test_langchain_adapter.py
+++ b/tests/adapters/test_langchain_adapter.py
@@ -142,23 +142,42 @@ def test_error_callbacks_carry_latency_ms():
     # Issue #17: error callbacks (tool/llm/chain) must compute latency_ms from
     # the captured start time, just like the success callbacks, so the CUSUM
     # detector can analyze latency for failed operations too.
-    import time
+    #
+    # A scripted fake clock keeps this deterministic on every platform:
+    # time.monotonic ticks at roughly 15.6 ms on Windows, so the previous
+    # 10 ms sleep measured as latency 0.0 and failed the positive-latency
+    # assertion intermittently there (first windows-latest CI leg). Read
+    # order per operation: on_*_start captures one reading, the error
+    # callback reads twice more (once in _latency_from, once for the event
+    # timestamp), so nine scripted readings cover all three operations; any
+    # unexpected extra read raises StopIteration and fails loudly instead
+    # of drifting.
+    reads = iter(
+        [
+            10.0,
+            10.5,
+            11.0,  # tool pair: 500 ms
+            20.0,
+            20.25,
+            21.0,  # chat model pair: 250 ms
+            30.0,
+            35.0,
+            36.0,  # chain pair: 5000 ms
+        ]
+    )
 
     mon = _monitor()
-    h = SnaglineCallbackHandler(mon, "ep-lat", clock=time.monotonic)
+    h = SnaglineCallbackHandler(mon, "ep-lat", clock=lambda: next(reads))
 
     h.on_tool_start({"name": "search"}, "query=cat", run_id="e1")
-    time.sleep(0.01)
     h.on_tool_error(RuntimeError("timeout"), run_id="e1")
     h.on_chat_model_start({"name": "chat"}, [["user", "hi"]], run_id="e2")
-    time.sleep(0.01)
     h.on_llm_error(RuntimeError("model down"), run_id="e2")
     h.on_chain_start({"name": "planner"}, {"input": 1}, run_id="e3")
-    time.sleep(0.01)
     h.on_chain_error(ValueError("bad plan"), run_id="e3")
 
     errors = [e for e in mon.events if e.error]
     assert len(errors) == 3
-    for e in errors:
-        assert e.latency_ms is not None
-        assert e.latency_ms > 0
+    # Exact deltas from the scripted clock (values chosen to be binary
+    # exact), stronger than the former > 0.
+    assert [e.latency_ms for e in errors] == [500.0, 250.0, 5000.0]


### PR DESCRIPTION
## Summary

Adds `windows-latest` to the test matrix so Windows-only regressions surface in CI (issue #116, deferred from #69/#113). The new legs immediately earned their keep: run two exposed a real intermittent Windows-only test failure, fixed here tests-only.

Decisions, including the per-OS coverage question the issue flags:

- **Matrix shape:** ubuntu legs stay exactly as today (py3.10-3.13); two windows-latest legs are added via `matrix.include` for py3.12 and py3.13 (the issue asks for at minimum these two). Job names now carry the OS.
- **Coverage policy: one canonical gate, on Linux.** Each matrix job checks its own coverage independently. The Linux legs enforce the single 80% threshold from `pyproject.toml`; the Windows legs run pytest-cov report-only, passing `--cov-fail-under=0` on the command line, which overrides the ini `addopts` value (proof below). Rationale: per-OS thresholds would be extra gates that must be moved in lockstep without adding signal, since the measured code (`src/snagline`) contains no platform-conditional branches at all. A correction here: an earlier version of this body and of the workflow comment claimed POSIX-gated test ladders would make Windows branch coverage fail spuriously; that mechanism was wrong (those ladders live in `tests/`, which does not feed the src coverage measurement), and the wording was fixed after the CodeRabbit review caught it (commit 76c60b8).
- **Lint and type-check stay Linux-only** (`if: runner.os == 'Linux'`): ruff and mypy results are OS-independent, so re-running them on Windows doubles runner minutes for zero extra signal. Tests are the thing Windows needs to exercise.
- **Install step is OS-safe:** venv activation picks `.venv/Scripts/activate` vs `.venv/bin/activate` via `$RUNNER_OS`, with `shell: bash` pinned explicitly (Git Bash exists on Windows runners), keeping the script identical on both families.
- **Windows-only flake found and fixed tests-only (commit b42d47c, per this issue's scope rule):** `tests/adapters/test_langchain_adapter.py::test_error_callbacks_carry_latency_ms` failed intermittently on `windows-latest` (green on run 1, red on run 2). Root cause: it injected `time.monotonic` and slept 10 ms between callback start and error, but `monotonic()` ticks at roughly 15.6 ms on Windows, so latency measured as 0.0 about half the time; the first green leg was luck. The test now scripts a fake clock through the handler's existing `clock=` injection point (nine readings: one per operation start, two per error callback for the latency end and event timestamp) and asserts exact binary-exact latencies (500/250/5000 ms) instead of a bare `> 0`. Deterministic across 30 consecutive local runs, removes three sleeps per the repo's no-sleeps rule, and any unexpected extra clock read fails loudly via StopIteration. No assertion was weakened; the check got stronger.

## Verification

Local full gate on the branch tip (b42d47c), macOS, CPython 3.14:

```
$ python -m pytest tests/ -q -o addopts=""
387 passed, 1 skipped in 30.41s
$ ruff check src tests && ruff format --check src tests
All checks passed!
97 files already formatted
$ mypy src
Success: no issues found in 47 source files
```

Flake-proofing evidence for the repaired test:

```
$ for i in $(seq 1 30); do pytest tests/adapters/test_langchain_adapter.py::test_error_callbacks_carry_latency_ms -q -o addopts=""; done | sort | uniq -c
  18 1 passed in 0.02s
   6 1 passed in 0.03s
   4 1 passed in 0.04s
   2 1 passed in 0.05s
```

(30/30 passes; previously the same test failed on the real windows-latest runner.)

Proof that `--cov-fail-under=0` genuinely overrides the ini `addopts` (single-file run where total coverage is 9.31%, far below the 80% bar):

```
$ python -m pytest tests/test_console_sink.py -q -p no:cacheprovider
FAIL Required test coverage of 80% not reached. Total coverage: 9.31%
3 passed in 0.39s        # exit=1

$ python -m pytest tests/test_console_sink.py -q -p no:cacheprovider --cov-fail-under=0
3 passed in 0.36s        # exit=0
```

CI evidence: run 1 all green including both Windows legs; run 2 caught the flake above (windows py3.12); run 3 expected green with the scripted clock.

Scope: `.github/workflows/ci.yml` plus one tests-only file (`tests/adapters/test_langchain_adapter.py`) under this issue's fix-Windows-failures-in-this-PR rule. No production code touched; no existing test modified beyond that repair, nothing skipped or deleted; nothing to mutation-check since neither change adds logic under test (the repaired test strengthens its assertion from `> 0` to exact values).

Fixes #116
Board: #106
Refs #69, #113
