### PR TITLE
feat(detectors): SideEffectGuardDetector flags duplicate non-idempotent actions

### DIFF
--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -62,6 +62,8 @@ monitor._detectors.append(MyDetector())   # or: Monitor(default_detectors + [min
 - `detectors/error_cascade.py` - consecutive and windowed error counts
 - `detectors/latency_anomaly.py` - Welford baseline + CUSUM deviation per tool
 - `detectors/stagnation.py` - all-time novelty set plus a sliding novelty share
+- `detectors/side_effect_guard.py` - per-episode duplicate count of
+  host-declared non-idempotent actions
 - `detectors/goal_drift.py` - compares a live run to a persisted `BaselineProfile`
 - `detectors/ml_ensemble.py` - `MLOrchestrator` combining base detector scores
 - `detectors/token_runaway.py` - token-volume CUSUM + per-episode budget envelope
@@ -200,6 +202,48 @@ episode).
 
 Enable it with `Config(stagnation_enabled=True)`. It ships opt-in so the
 zero-dependency preset and the published bench numbers are untouched.
+
+### `SideEffectGuardDetector` (`side_effect_guard_enabled=True`, issue #88)
+
+`SideEffectGuardDetector(config=cfg)` watches steps the *host* marked as
+non-idempotent (`StepEvent.side_effect=True`: a payment, a send, a deploy)
+and fires on the second identical occurrence within one episode: same
+`(tool_name, action_signature)` pair counted per `episode_id`. With the
+default `side_effect_allowed_repeats=1` a repeated charge escalates
+immediately at score 0.9, which routes as critical severity. Trigger:
+`side_effect_duplicate`. That string is API: CONTINUUM's policy table maps
+it to ABORT plus immediate reconcile.
+
+Deliberately stricter than `LoopDetector`, and different in three ways:
+
+1. **Scope:** the loop detector watches a sliding window of arbitrary
+   signatures for wasted-work repetition; this guard watches only
+   host-declared side-effect steps, where repetition is itself the incident.
+2. **Threshold:** the loop detector needs `repeat_threshold` hits (default 3)
+   inside its window before saying anything; here one repeat is already the
+   finding.
+3. **Edge:** the loop detector re-arms when its window drains; this guard
+   fires exactly once per `(episode_id, tool_name, action_signature)` key and
+   stays quiet for the rest of the episode. A repeated payment must not
+   alert-spam while the agent keeps making it worse; recovery is
+   `end_episode()` territory. Different-argument retries produce different
+   signatures and never fire here (that shape belongs to the loop/stall
+   modes).
+
+How hosts mark steps: adapters forward the flag mechanically and never
+invent it. Today you can pass it to the raw adapter's `step(...,
+side_effect=True)`, `observe_openai_call(...)`, `observe_anthropic_call(...)`,
+or `observe_crewai_step(...)`. Framework callback paths (LangChain hooks,
+Autogen events, LangGraph nodes, Claude Code hook payloads) have no
+caller-supplied flag source, so their events carry the schema default
+(`False`) and legacy payloads written before #88 load unchanged.
+
+Privacy and cost, as everywhere: the detector reads the boolean, the tool
+name, and the one-way signature digest, nothing else, and never touches
+`StepEvent.metadata`. Non-marked steps cost one attribute check; marked
+steps do one dict upsert. Per-episode memory grows with distinct marked
+actions, never with repeats: replaying one charge a thousand times still
+costs a single counter entry, and `reset(episode_id)` releases all of it.
 
 ## The horizon detectors (long-run set, issues #84/#85/#86)
 

--- a/src/snagline/adapters/anthropic.py
+++ b/src/snagline/adapters/anthropic.py
@@ -55,6 +55,7 @@ def observe_anthropic_call(
     error_type: str | None = None,
     result: Any | None = None,
     step_id: str | None = None,
+    side_effect: bool = False,
 ) -> StepEvent:
     sig_text = str(messages or "")
     sig = make_signature("tool_call", model or "anthropic", sig_text)
@@ -74,6 +75,7 @@ def observe_anthropic_call(
         tokens_in=tokens_in,
         tokens_out=tokens_out,
         metadata={"adapter": "anthropic"},
+        side_effect=side_effect,
     )
     with contextlib.suppress(Exception):
         monitor.ingest(event)

--- a/src/snagline/adapters/autogen.py
+++ b/src/snagline/adapters/autogen.py
@@ -115,6 +115,7 @@ class SnaglineAutogenHandler:
         args: str,
         error: bool,
         latency_ms: float | None = None,
+        side_effect: bool = False,
     ) -> StepEvent:
         sig = make_signature(action_type, tool_name, args)
         event = StepEvent(
@@ -127,6 +128,7 @@ class SnaglineAutogenHandler:
             latency_ms=latency_ms,
             error=error,
             metadata={"agent_name": self._agent_name, "adapter": "autogen"},
+            side_effect=side_effect,
         )
         self._monitor.ingest(event)
         return event

--- a/src/snagline/adapters/crewai.py
+++ b/src/snagline/adapters/crewai.py
@@ -108,6 +108,7 @@ def _map_step(
     step_id: str,
     agent_name: str | None,
     clock: Callable[[], float],
+    side_effect: bool = False,
 ) -> StepEvent:
     d = _to_dict(step)
     tool_name = _extract_tool_name(d)
@@ -141,6 +142,7 @@ def _map_step(
         latency_ms=latency,
         error=error,
         metadata={"agent_name": agent_name, "adapter": "crewai"},
+        side_effect=side_effect,
     )
 
 
@@ -203,11 +205,14 @@ def observe_crewai_step(
     agent_name: str | None = None,
     clock: Callable[[], float] | None = None,
     step_id: str | None = None,
+    side_effect: bool = False,
 ) -> StepEvent:
     """Manually map a single CrewAI step object to a ``StepEvent`` and ingest it.
 
     Useful when you manage the agent loop yourself and want the same mapping the
-    callback uses, without registering ``step_callback``.
+    callback uses, without registering ``step_callback``. ``side_effect=True``
+    marks the step as a non-idempotent action (issue #88); set it only from
+    your own knowledge of the tool, never heuristically.
     """
     event = _map_step(
         step,
@@ -215,6 +220,7 @@ def observe_crewai_step(
         step_id=step_id or "manual",
         agent_name=agent_name,
         clock=clock or time.time,
+        side_effect=side_effect,
     )
     monitor.ingest(event)
     return event

--- a/src/snagline/adapters/langchain_adapter.py
+++ b/src/snagline/adapters/langchain_adapter.py
@@ -69,6 +69,7 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
         error_type: str | None = None,
         tokens_in: int | None = None,
         tokens_out: int | None = None,
+        side_effect: bool = False,
     ) -> StepEvent:
         sig = make_signature(action_type, tool_name, str(args))
         event = StepEvent(
@@ -84,6 +85,7 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
             tokens_in=tokens_in,
             tokens_out=tokens_out,
             metadata={},
+            side_effect=side_effect,
         )
         self._monitor.ingest(event)
         return event

--- a/src/snagline/adapters/openai.py
+++ b/src/snagline/adapters/openai.py
@@ -68,12 +68,15 @@ def observe_openai_call(
     error_type: str | None = None,
     result: Any | None = None,
     step_id: str | None = None,
+    side_effect: bool = False,
 ) -> StepEvent:
     """Observe a single OpenAI call as a ``StepEvent`` and ingest it.
 
     ``messages``/``prompt`` are hashed into the signature, not stored.
     If ``result`` is given, tokens are extracted from ``result.usage``.
-    Returns the ingested event.
+    Returns the ingested event. ``side_effect=True`` marks the call as a
+    non-idempotent action (issue #88); set it only from your own knowledge
+    of what the call does, never heuristically.
     """
     sig_text = str(messages or prompt or "")
     # Include model + message shape hash; exclude volatile content already hashed.
@@ -94,6 +97,7 @@ def observe_openai_call(
         tokens_in=tokens_in,
         tokens_out=tokens_out,
         metadata={"adapter": "openai"},
+        side_effect=side_effect,
     )
     with contextlib.suppress(Exception):
         monitor.ingest(event)

--- a/src/snagline/adapters/raw.py
+++ b/src/snagline/adapters/raw.py
@@ -46,9 +46,11 @@ def watch(
 
     ``step(action_type, tool_name=None, *, args="", latency_ms=None,
     error=False, error_type=None, tokens_in=None, tokens_out=None,
-    metadata=None, **extra)`` builds a ``StepEvent`` (with an auto-incrementing
-    ``step_id``), ingests it, and returns it. Any extra kwargs are folded into
-    ``metadata`` (which detectors never read).
+    metadata=None, side_effect=False, **extra)`` builds a ``StepEvent`` (with
+    an auto-incrementing ``step_id``), ingests it, and returns it. Any extra
+    kwargs are folded into ``metadata`` (which detectors never read).
+    ``side_effect=True`` marks the action as non-idempotent (issue #88); set
+    it deliberately from your own knowledge of the tool, never heuristically.
     """
     counter = itertools.count()
 
@@ -63,6 +65,7 @@ def watch(
         tokens_in: int | None = None,
         tokens_out: int | None = None,
         metadata: dict[str, Any] | None = None,
+        side_effect: bool = False,
         **extra: Any,
     ) -> StepEvent:
         sig = _build_signature(action_type, tool_name, args)
@@ -81,6 +84,7 @@ def watch(
             tokens_in=tokens_in,
             tokens_out=tokens_out,
             metadata=md,
+            side_effect=side_effect,
         )
         monitor.ingest(event)
         return event

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -174,6 +174,19 @@ class Config:
     # arXiv:2608.02464 that caught 7/7 organic failures-of-omission there.
     silent_abort_enabled: bool = False
 
+    # --- Side-effect guard detector (issue #88, opt-in) ----------------------
+    # Duplicate detection for host-declared non-idempotent actions
+    # (``StepEvent.side_effect``): a second identical (tool_name,
+    # action_signature) pair within one episode fires "side_effect_duplicate"
+    # immediately. Deliberately stricter than the loop detector, which waits
+    # for ``loop_repeat_threshold`` hits inside a sliding window and targets
+    # wasted-work loops; here one repeated payment/send/deploy is already the
+    # incident. Default off so the zero-dependency preset and its published
+    # bench numbers are untouched.
+    side_effect_guard_enabled: bool = False
+    side_effect_allowed_repeats: int = 1  # occurrences tolerated before firing
+    side_effect_score: float = 0.9  # routes as critical severity
+
     # --- Opt-in auto-calibration from a fitted BaselineProfile (issue #101) --
     # calibration="auto" derives error-cascade thresholds and the CUSUM latency
     # reference from a healthy-run profile (see snagline.calibration) instead

--- a/src/snagline/detectors/side_effect_guard.py
+++ b/src/snagline/detectors/side_effect_guard.py
@@ -1,0 +1,104 @@
+"""Side-effect guard: duplicate non-idempotent action detection (issue #88).
+
+Adapters and hosts mark steps whose action is known to be non-idempotent (a
+payment, a send, a deploy) with ``StepEvent.side_effect=True``. Within one
+episode, the second occurrence of the same ``(tool_name, action_signature)``
+pair emits a HIGH-severity risk with trigger ``"side_effect_duplicate"``:
+duplicate sends/payments/deploys are the single most expensive failure class
+in production agents, so by default the detector tolerates exactly one
+occurrence (``allowed_repeats=1`` fires on the 2nd step).
+
+Deliberately stricter than ``LoopDetector``, and different in three ways:
+
+1. Scope: the loop detector watches a sliding window of arbitrary signatures
+   to catch wasted-work repetition; this guard watches only host-declared
+   side-effect steps, where repetition is itself the incident.
+2. Threshold: the loop detector needs ``repeat_threshold`` (default 3) hits
+   inside its window; here one repeat is already actionable.
+3. Edge: the loop detector re-arms when its window drains; this guard fires
+   once per ``(episode_id, tool_name, action_signature)`` key and stays quiet
+   for the rest of the episode. A repeated payment must not alert-spam while
+   the agent keeps making it worse; recovery is ``end_episode`` territory.
+   Different-argument retries produce different signatures and never fire
+   here (that shape belongs to the loop/stall detectors).
+
+Privacy: only the boolean flag, tool name, and the one-way SHA-256
+``action_signature`` digest are read. No prompt/response content, no
+``StepEvent.metadata`` (project.md §1.4 / §11).
+
+Performance: O(1) per step. Non-side-effect steps cost one attribute read
+and a branch; marked steps do one dict upsert on a bounded inner dict.
+
+Memory, stated honestly: state grows with *distinct* (tool_name, signature)
+pairs per episode, not with repeats -- replaying the same charge a thousand
+times still costs one entry. ``reset(episode_id)`` releases all of it.
+
+The trigger string is API: CONTINUUM's policy table maps
+``side_effect_duplicate`` to ABORT + immediate reconcile by name.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.risk import FailureRisk, TriggerType
+
+# Declared here with the loop hardening modes' precedent (issue #89): widening
+# the TriggerType literal in risk.py belongs to a change scoped to that module;
+# the cast keeps mypy exact while the runtime value is a str.
+TRIGGER_SIDE_EFFECT_DUPLICATE = cast(TriggerType, "side_effect_duplicate")
+
+
+class SideEffectGuardDetector:
+    """Fires once per repeated non-idempotent action within an episode."""
+
+    name = "side_effect_guard"
+
+    def __init__(
+        self,
+        allowed_repeats: int | None = None,
+        score: float | None = None,
+        config: Config | None = None,
+    ) -> None:
+        cfg = config or Config()
+        self.allowed_repeats = (
+            allowed_repeats
+            if allowed_repeats is not None
+            else cfg.side_effect_allowed_repeats
+        )
+        self.score = score if score is not None else cfg.side_effect_score
+        if self.allowed_repeats < 1:
+            raise ValueError("allowed_repeats must be >= 1")
+        if not 0.0 <= self.score <= 1.0:
+            raise ValueError("score must be within [0.0, 1.0]")
+        # episode_id -> {(tool_name, action_signature): occurrence count}.
+        # Inner dicts hold distinct actions only, so per-episode memory is
+        # bounded by the episode's distinct marked actions, never by retries.
+        self._counts: dict[str, dict[tuple[str | None, str], int]] = {}
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        if not event.side_effect:
+            return None
+        per_episode = self._counts.setdefault(event.episode_id, {})
+        key = (event.tool_name, event.action_signature)
+        count = per_episode.get(key, 0) + 1
+        per_episode[key] = count
+        # Edge-triggered: escalate exactly when the tolerated count is first
+        # exceeded. Every later identical occurrence stays silent until
+        # end_episode resets the episode (see module docstring).
+        if count != self.allowed_repeats + 1:
+            return None
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            self.score,
+            TRIGGER_SIDE_EFFECT_DUPLICATE,
+            f"non-idempotent {event.tool_name} fired {count}x in episode",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        """Drop every counted action for ``episode_id`` (Monitor.end_episode)."""
+        self._counts.pop(episode_id, None)

--- a/src/snagline/events.py
+++ b/src/snagline/events.py
@@ -25,6 +25,12 @@ class StepEvent:
     Everything else is optional and improves detector quality but nothing in
     core requires it. ``metadata`` is explicitly NEVER read by detectors and
     must not be forwarded by sinks (see project.md §11).
+
+    ``side_effect`` (issue #88) marks a step whose action is known to be
+    non-idempotent (a payment, a send, a deploy). It is a plain boolean the
+    host sets deliberately: adapters only forward it and never derive it,
+    because guessing wrong either hides duplicate charges or flags harmless
+    reads. Detectors may read this boolean (it is a flag, not content).
     """
 
     step_id: str
@@ -44,6 +50,7 @@ class StepEvent:
     metadata: dict = field(
         default_factory=dict
     )  # adapter-specific; detectors never read this
+    side_effect: bool = False  # host-declared non-idempotent action (issue #88)
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -417,6 +417,7 @@ class Monitor:
         from snagline.detectors.loop import LoopDetector
         from snagline.detectors.meltdown import MeltdownDetector
         from snagline.detectors.ml_ensemble import MLOrchestrator
+        from snagline.detectors.side_effect_guard import SideEffectGuardDetector
         from snagline.detectors.silent_abort import SilentAbortDetector
         from snagline.detectors.stagnation import StagnationDetector
         from snagline.detectors.token_runaway import TokenRunawayDetector
@@ -461,6 +462,11 @@ class Monitor:
             base.append(MeltdownDetector(config=cfg))
         if cfg.silent_abort_enabled:
             base.append(SilentAbortDetector(config=cfg))
+        # Side-effect guard is opt-in (issue #88): duplicate non-idempotent
+        # action detection, default-off so the zero-dependency preset and the
+        # published bench numbers are untouched.
+        if cfg.side_effect_guard_enabled:
+            base.append(SideEffectGuardDetector(config=cfg))
         if cfg.ml_ensemble_enabled:
             # Optional ml extra: add the one-class ESN + CUSUM detector to the
             # ensemble when numpy is importable (issue #80). The import is

--- a/tests/detectors/test_side_effect_guard.py
+++ b/tests/detectors/test_side_effect_guard.py
@@ -1,0 +1,296 @@
+"""Tests for the side-effect guard detector (issue #88).
+
+Every injected-failure scenario below has a mirrored healthy scenario: the
+detector must fire (with the exact ``"side_effect_duplicate"`` trigger) on a
+repeated host-declared non-idempotent action and must stay silent on
+idempotent reads, distinct-argument retries, and other episodes' traffic.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from snagline.config import Config
+from snagline.detectors.side_effect_guard import SideEffectGuardDetector
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+
+
+def _sig(i: int) -> str:
+    return make_signature("tool_call", "payment_tool", f"a{i}")
+
+
+def _event(
+    step_id: int,
+    sig: str,
+    episode: str = "ep",
+    *,
+    tool_name: str | None = "payment_tool",
+    side_effect: bool = True,
+) -> StepEvent:
+    return StepEvent(
+        step_id=str(step_id),
+        episode_id=episode,
+        timestamp=float(step_id),
+        action_type="tool_call",
+        action_signature=sig,
+        tool_name=tool_name,
+        side_effect=side_effect,
+    )
+
+
+def _feed(d: SideEffectGuardDetector, events: list[StepEvent]) -> list:
+    return [r for e in events if (r := d.observe(e)) is not None]
+
+
+# --- Injected failure: duplicate non-idempotent action -----------------------
+
+
+def test_duplicate_side_effect_fires_once_on_second_occurrence():
+    """Two identical payment-shape steps fire exactly one risk, attached to the
+    2nd step. The 3rd identical step stays silent: edge-triggered like the
+    loop detector's dedupe, because alert spam during an ongoing duplicate is
+    worse than one escalation."""
+    d = SideEffectGuardDetector()
+    sig = _sig(7)
+    first = _feed(d, [_event(1, sig)])
+    assert first == []
+    second = _feed(d, [_event(2, sig)])
+    assert len(second) == 1
+    r = second[0]
+    assert r.trigger == "side_effect_duplicate"
+    assert r.step_id == "2"
+    assert r.episode_id == "ep"
+    assert r.score == 0.9
+    assert r.severity == "critical"
+    assert r.detail == "non-idempotent payment_tool fired 2x in episode"
+    # Edge-triggered: nothing more from continued identical steps.
+    assert _feed(d, [_event(3, sig), _event(4, sig)]) == []
+
+
+def test_allowed_repeats_two_fires_on_third_occurrence():
+    d = SideEffectGuardDetector(allowed_repeats=2)
+    seq = [
+        _event(1, _sig(1)),
+        _event(2, _sig(1)),
+        _event(3, _sig(1)),
+        _event(4, _sig(1)),
+    ]
+    risks = _feed(d, seq)
+    assert [r.step_id for r in risks] == ["3"]
+
+
+def test_tool_name_is_part_of_the_key():
+    """The same signature under two different tools is two distinct actions:
+    interleaved, each tool escalates on its own 2nd occurrence."""
+    d = SideEffectGuardDetector()
+    sig = _sig(5)
+    inter = [
+        _event(1, sig, tool_name="charge_card"),
+        _event(2, sig, tool_name="refund_card"),
+        _event(3, sig, tool_name="charge_card"),
+        _event(4, sig, tool_name="refund_card"),
+    ]
+    risks = _feed(d, inter)
+    assert [r.step_id for r in risks] == ["3", "4"]
+    assert "charge_card" in risks[0].detail
+    assert "refund_card" in risks[1].detail
+
+
+def test_none_tool_name_still_counts_and_fires():
+    d = SideEffectGuardDetector()
+    sig = _sig(9)
+    assert _feed(d, [_event(1, sig, tool_name=None)]) == []
+    risks = _feed(d, [_event(2, sig, tool_name=None)])
+    assert [r.trigger for r in risks] == ["side_effect_duplicate"]
+
+
+# --- Healthy traffic: the no-false-positive side -----------------------------
+
+
+def test_idempotent_reads_never_fire_even_when_repeated():
+    """Read-only steps repeated forever are exactly what must stay silent,
+    regardless of how often they repeat."""
+    d = SideEffectGuardDetector()
+    sig = _sig(3)
+    reads = [_event(i, sig, side_effect=False) for i in range(50)]
+    assert _feed(d, reads) == []
+
+
+def test_unmarked_repeats_of_a_marked_action_shape_stay_silent():
+    """Only the boolean decides: the same action shape without the flag never
+    fires, so legacy adapters that predate #88 see zero behavior change."""
+    d = SideEffectGuardDetector()
+    marked = _feed(d, [_event(1, _sig(1)), _event(2, _sig(1))])
+    assert [r.step_id for r in marked] == ["2"]
+    unmarked = [_event(i, _sig(1), side_effect=False) for i in range(10, 30)]
+    assert _feed(d, unmarked) == []
+
+
+def test_distinct_signature_retries_stay_silent():
+    """Different-argument retries produce different signatures and never fire
+    here (issue #88 acceptance); that failure shape belongs to LoopDetector."""
+    d = SideEffectGuardDetector()
+    retries = [_event(i, _sig(i), side_effect=True) for i in range(200)]
+    assert _feed(d, retries) == []
+
+
+def test_stays_silent_on_healthy_fixture_trajectory():
+    fixture = (
+        Path(__file__).resolve().parents[1]
+        / "fixtures"
+        / "trajectories"
+        / "healthy_run.jsonl"
+    )
+    events = [
+        StepEvent(**json.loads(line))
+        for line in fixture.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    d = SideEffectGuardDetector()
+    assert all(d.observe(e) is None for e in events)
+
+
+# --- State: bounded per episode, isolated across episodes, resettable --------
+
+
+def test_state_is_bounded_by_distinct_actions_not_by_repeats():
+    """A thousand replays of one charge cost one counter entry: memory grows
+    with distinct marked actions only."""
+    d = SideEffectGuardDetector()
+    sig = _sig(11)
+    _feed(d, [_event(i, sig) for i in range(1000)])
+    assert len(d._counts) == 1
+    assert d._counts["ep"] == {("payment_tool", sig): 1000}
+
+
+def test_episodes_are_isolated():
+    """Episode b replaying the same charge is judged independently of episode
+    a's history, and vice versa."""
+    d = SideEffectGuardDetector()
+    sig = _sig(13)
+    events: list[StepEvent] = []
+    events.append(_event(0, sig, "a"))  # a: 1st occurrence
+    events.append(_event(1, sig, "b"))  # b: 1st occurrence
+    events.append(_event(2, sig, "a"))  # a: fires
+    events.append(_event(3, sig, "b"))  # b: fires
+    events.append(_event(4, sig, "c"))  # c: still silent
+    risks = _feed(d, events)
+    assert [(r.episode_id, r.step_id) for r in risks] == [("a", "2"), ("b", "3")]
+
+
+def test_reset_clears_episode_state_and_rearms_from_zero():
+    d = SideEffectGuardDetector()
+    sig = _sig(17)
+    assert [r.step_id for r in _feed(d, [_event(1, sig), _event(2, sig)])] == ["2"]
+    d.reset("ep")
+    assert d._counts == {}
+    # After reset even the same episode starts from zero: the next occurrence
+    # is a 1st, not a 3rd.
+    assert _feed(d, [_event(3, sig)]) == []
+    assert [r.step_id for r in _feed(d, [_event(4, sig)])] == ["4"]
+
+
+# --- End-to-end through Monitor.default ---------------------------------------
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.risks: list = []
+
+    def emit(self, risk) -> None:
+        self.risks.append(risk)
+
+
+def _monitor_with_guard(**cfg_kwargs) -> tuple[Monitor, _RecordingSink]:
+    sink = _RecordingSink()
+    monitor = Monitor.default(
+        config=Config(side_effect_guard_enabled=True, **cfg_kwargs), sinks=[sink]
+    )
+    return monitor, sink
+
+
+def test_monitor_dispatches_exactly_one_duplicate_alert_end_to_end():
+    from snagline.adapters.raw import watch
+
+    monitor, sink = _monitor_with_guard()
+    with watch(monitor, "ep") as step:
+        step("tool_call", tool_name="search", args={"q": "x"})
+        step(
+            "tool_call", tool_name="charge_card", args={"amount": 42}, side_effect=True
+        )
+        step("tool_call", tool_name="search", args={"q": "x"})
+        # The retry loop every production incident report contains: identical
+        # charge re-fired after a timeout.
+        step(
+            "tool_call", tool_name="charge_card", args={"amount": 42}, side_effect=True
+        )
+        step(
+            "tool_call", tool_name="charge_card", args={"amount": 42}, side_effect=True
+        )
+    dupes = [r for r in sink.risks if r.trigger == "side_effect_duplicate"]
+    assert len(dupes) == 1
+    assert dupes[0].severity == "critical"
+
+    # end_episode teardown clears the guard: the same episode id replayed
+    # fresh must start counting from zero again.
+    with watch(monitor, "ep") as step:
+        step(
+            "tool_call", tool_name="charge_card", args={"amount": 42}, side_effect=True
+        )
+    dupes = [r for r in sink.risks if r.trigger == "side_effect_duplicate"]
+    assert len(dupes) == 1
+
+
+# --- Opt-in wiring and configuration -----------------------------------------
+
+
+def test_default_off_in_zero_dependency_preset():
+    m = Monitor.default(config=Config())
+    assert all(getattr(det, "name", "") != "side_effect_guard" for det in m._detectors)
+
+
+def test_config_flag_wires_detector_into_default_monitor():
+    m = Monitor.default(config=Config(side_effect_guard_enabled=True))
+    names = [getattr(det, "name", "") for det in m._detectors]
+    assert names.count("side_effect_guard") == 1
+
+
+def test_enabled_detector_joins_the_ml_ensemble_wrap():
+    cfg = Config(side_effect_guard_enabled=True, ml_ensemble_enabled=True)
+    m = Monitor.default(config=cfg)
+    wrapped_names = [getattr(det, "name", "") for det in m._detectors[0]._base]
+    assert "side_effect_guard" in wrapped_names
+
+
+def test_settings_flow_through_env_overrides():
+    cfg = Config.from_env(
+        {
+            "SNAGLINE_SIDE_EFFECT_GUARD_ENABLED": "true",
+            "SNAGLINE_SIDE_EFFECT_ALLOWED_REPEATS": "3",
+            "SNAGLINE_SIDE_EFFECT_SCORE": "0.95",
+        }
+    )
+    assert cfg.side_effect_guard_enabled is True
+    assert cfg.side_effect_allowed_repeats == 3
+    assert cfg.side_effect_score == 0.95
+
+
+def test_explicit_params_override_config_defaults():
+    d = SideEffectGuardDetector(
+        allowed_repeats=4,
+        score=0.8,
+        config=Config(side_effect_allowed_repeats=1),
+    )
+    assert d.allowed_repeats == 4
+    assert d.score == 0.8
+
+
+def test_invalid_constructor_arguments_raise():
+    with pytest.raises(ValueError):
+        SideEffectGuardDetector(allowed_repeats=0)
+    with pytest.raises(ValueError):
+        SideEffectGuardDetector(score=1.5)

--- a/tests/test_side_effect_field.py
+++ b/tests/test_side_effect_field.py
@@ -1,0 +1,115 @@
+"""Schema and adapter pass-through tests for ``StepEvent.side_effect`` (#88).
+
+The field is host-declared: adapters must forward it exactly as given and
+must never derive it heuristically. These tests pin both halves of that
+contract, plus backward compatibility with payloads written before #88.
+"""
+
+from __future__ import annotations
+
+from snagline.adapters.anthropic import observe_anthropic_call
+from snagline.adapters.crewai import observe_crewai_step
+from snagline.adapters.openai import observe_openai_call
+from snagline.adapters.raw import watch
+from snagline.events import StepEvent, make_signature
+
+
+class _RecordingMonitor:
+    """Minimal ingest stand-in so adapter calls need no real Monitor."""
+
+    def __init__(self) -> None:
+        self.events: list[StepEvent] = []
+
+    def ingest(self, event: StepEvent) -> None:
+        self.events.append(event)
+
+
+def test_side_effect_defaults_to_false():
+    event = StepEvent(
+        step_id="0",
+        episode_id="ep",
+        timestamp=0.0,
+        action_type="tool_call",
+        action_signature="abc",
+    )
+    assert event.side_effect is False
+
+
+def test_step_event_loads_old_payloads_without_the_field():
+    payload = {
+        "step_id": "s1",
+        "episode_id": "ep",
+        "timestamp": 1.0,
+        "action_type": "tool_call",
+        "action_signature": "abc123",
+    }
+    assert StepEvent(**payload).side_effect is False
+
+
+def test_raw_adapter_passes_side_effect_through():
+    mon = _RecordingMonitor()
+    with watch(mon, "ep") as step:
+        read = step("tool_call", tool_name="search", args="q")
+        pay = step("tool_call", tool_name="charge_card", args="42", side_effect=True)
+    assert read.side_effect is False
+    assert pay.side_effect is True
+    assert [e.side_effect for e in mon.events] == [False, True]
+
+
+def test_openai_observe_passes_side_effect_through():
+    mon = _RecordingMonitor()
+    event = observe_openai_call(
+        mon,
+        episode_id="ep",
+        model="gpt-4o",
+        messages=[{"role": "user", "content": "hi"}],
+        side_effect=True,
+    )
+    assert event.side_effect is True
+    assert mon.events == [event]
+
+
+def test_anthropic_observe_passes_side_effect_through():
+    mon = _RecordingMonitor()
+    event = observe_anthropic_call(
+        mon,
+        episode_id="ep",
+        model="claude-3-5-sonnet-20241022",
+        messages=[{"role": "user", "content": "hi"}],
+        side_effect=True,
+    )
+    assert event.side_effect is True
+    assert mon.events == [event]
+
+
+def test_crewai_observe_passes_side_effect_through():
+    mon = _RecordingMonitor()
+    step = {"tool": "charge_card", "tool_input": {"amount": 42}}
+    plain = observe_crewai_step(mon, "ep", step)
+    marked = observe_crewai_step(mon, "ep2", step, side_effect=True)
+    assert plain.side_effect is False
+    assert marked.side_effect is True
+
+
+def test_framework_paths_never_invent_the_flag():
+    """Framework-driven paths have no caller-supplied flag source: every event
+    they build must carry the schema default, proving no heuristic crept in."""
+    from snagline.adapters.langgraph_adapter import watch_graph
+
+    mon = _RecordingMonitor()
+
+    def stream():
+        yield {"node_a": {"result": "x"}}
+        yield {"node_a": {"result": "x"}}
+
+    list(watch_graph(mon, "ep", stream()))
+    assert len(mon.events) == 2
+    assert all(e.side_effect is False for e in mon.events)
+
+
+def test_signature_helper_unchanged_by_the_new_field():
+    """The flag is not part of the signature: marking an action after the fact
+    must not change loop-detection identity."""
+    a = make_signature("tool_call", "t", "args")
+    b = make_signature("tool_call", "t", "args")
+    assert a == b


### PR DESCRIPTION
## Summary

Implements #88 with the recommended Option B schema: `StepEvent` gains an optional host-declared `side_effect: bool = False` marking non-idempotent actions (payments, sends, deploys).

- **Detector:** `SideEffectGuardDetector` (`src/snagline/detectors/side_effect_guard.py`) counts `(tool_name, action_signature)` occurrences per `episode_id` and emits HIGH-severity `side_effect_duplicate` (score 0.9, routes as critical) on the first occurrence past `allowed_repeats` (default 1, i.e. the 2nd step). Edge-triggered exactly once per key until `end_episode()`, deliberately stricter than LoopDetector; the difference is documented in DETECTOR_GUIDE.md.
- **Schema pass-through:** every adapter funnel forwards the flag mechanically: raw `step()`, langchain `_emit`, autogen `_emit`, crewai `_map_step` + `observe_crewai_step`, `observe_openai_call`, `observe_anthropic_call`. No adapter invents the flag: framework callback paths (LangChain hooks, Autogen events, LangGraph nodes, Claude Code payloads) carry the schema default, so legacy payloads load unchanged.
- **Opt-in only:** wired via `Config.side_effect_guard_enabled` (default off); the zero-dependency preset and published bench numbers are untouched.
- **Privacy/fail-open/perf:** reads only the boolean, tool name, and one-way signature hash; never touches `metadata`; O(1) per step (one attribute check on unmarked steps, one dict upsert on marked ones); state bounded per episode by distinct marked actions, released by `reset()`. Trigger string is API (CONTINUUM policy table maps it by name).

**Mutation check (test honesty):** done. I mutated the fire condition from `count != self.allowed_repeats + 1` to `count < self.allowed_repeats + 1` (breaks edge-triggering), reran pytest, and 3 of my tests failed as intended (`test_duplicate_side_effect_fires_once_on_second_occurrence`, `test_allowed_repeats_two_fires_on_third_occurrence`, `test_monitor_dispatches_exactly_one_duplicate_alert_end_to_end`), then reverted and confirmed green again.

## Verification

Full gate on the finished branch (Python 3.13 venv):

```
$ python -m pytest tests/ -q -o addopts=""
411 passed, 2 skipped in 27.65s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
100 files already formatted

$ mypy src
Success: no issues found in 48 source files
```

Baseline master was 385 passed / 2 skipped; this branch adds 26 tests (8 schema/pass-through + 18 detector), all new detector scenarios assert both sides: injected duplicate fires with exact trigger `side_effect_duplicate`, healthy sequences (idempotent repeats, distinct-signature retries, other episodes, healthy fixture trajectory) stay silent.

Em-dash sweep: `git log -p origin/master..HEAD | grep -c "—"` returns 0.

Board: #106

Fixes #88
