### PR TITLE
feat(drift): optional semantic goal-drift detector (Fixes #81)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,13 +100,14 @@ The full architecture reference is in [docs/ADAPTER_GUIDE.md](docs/ADAPTER_GUIDE
 | **Error cascade detector** | Fast cascades and slow-burn degradations | Two modes: N consecutive errors (fast), or N errors within a recent window (slow). | O(1) amortized |
 | **Latency anomaly detector** | Sustained performance regression | Welford running mean/variance per tool, frozen baseline, CUSUM statistic. Short warm-up prevents false positives on normal jitter. | O(1) amortized |
 | **Goal-drift detector** (opt-in) | A run diverging from its known-healthy behavior | Compares a live run's per-tool error rate and latency against a persisted `BaselineProfile` built by `snagline baseline`. Flags rising error rate, latency blowing past the healthy mean, or tools that never appeared in the baseline. | O(1) amortized |
+| **Semantic goal-drift detector** (opt-in, `snagline[drift]`) | The agent's activity mix drifting from its healthy goal | Embeds structural labels (`action_type`, `tool_name`, `error_type`; never content) with `sentence-transformers` and watches the live episode's running centroid against the persisted `BaselineProfile` embedding centroid; sustained cosine deviation through a CUSUM gate emits `goal_drift`. Import is lazy; missing model or inference failures leave it inert (fail-open). | O(embedding dim) per step, bounded state |
 | **ML ensemble** (opt-in) | A stronger, combined signal | Wraps the base detectors and combines their scores with a transparent noisy-OR. A real model can be injected via `MLOrchestrator(model=...)` (the `ml` extra provides scikit-learn). | O(1) amortized |
 
 Detection is deterministic and `O(1)` amortized per step. It runs with no network calls and no LLM calls. The CUSUM detector uses only the Python standard library (`statistics` module) -- no numpy required.
 
 ### Baseline and advanced detection
 
-The `goal_drift` and `ml_ensemble` detectors are opt-in (default off) so the zero-dependency preset is unchanged. They unlock once you capture a healthy run:
+The `goal_drift`, `ml_ensemble`, and semantic goal-drift (`drift`) detectors are opt-in (default off) so the zero-dependency preset is unchanged. They unlock once you capture a healthy run:
 
 ```bash
 # 1. Capture a known-good trajectory (one JSON StepEvent per line)...
@@ -128,7 +129,9 @@ config = Config(
 monitor = Monitor.default(config=config)
 ```
 
-With `ml_ensemble_enabled`, `Monitor.default()` wraps the base detectors in a single `MLOrchestrator` instead of exposing them individually, so there is no double counting. Both detectors are documented in [docs/DETECTOR_GUIDE.md](docs/DETECTOR_GUIDE.md).
+The `drift` extra adds semantic drift on top of the same `BaselineProfile` (issue #81, `pip install snagline-agent[drift]`). Fit it from the same healthy trajectory with `fit_semantic_baseline` (`snagline/drift/goal_drift.py`), then enable it with `Config(semantic_drift_enabled=True, goal_drift_baseline=profile)`. Import is lazy and any model load or inference failure leaves it inert, logged and fail-open. With `ml_ensemble_enabled` and `semantic_drift_enabled` together the semantic signal joins the ESN ensemble inside the same noisy-OR `MLOrchestrator`.
+
+With `ml_ensemble_enabled`, `Monitor.default()` wraps the base detectors in a single `MLOrchestrator` instead of exposing them individually, so there is no double counting. All advanced detectors are documented in [docs/DETECTOR_GUIDE.md](docs/DETECTOR_GUIDE.md).
 
 Baselines go stale as your agent evolves. For scheduled refits, use
 `snagline baseline retrain`: it fits from the newest JSONL window and bumps a
@@ -638,8 +641,8 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 | 13 | Framework bridge docs | Complete |
 | 14 | Offline replay CLI (`snagline replay`) | Complete |
 | 15 | Dedup / cooldown (`DedupSink`) | Complete ([#4](https://github.com/Cyrax321/SNAGLINE/issues/4)) |
-| 16 | ML ensemble detector (`snagline[ml]`) | Complete (deterministic combiner; `snagline[ml]` ESN pending) |
-| 17 | Goal-drift detector (`snagline[drift]`) | Complete (deterministic; `snagline[drift]` embeddings pending) |
+| 16 | ML ensemble detector (`snagline[ml]`) | Complete (deterministic noisy-OR fallback plus optional `snagline[ml]` ESN ensemble, issue #80) |
+| 17 | Goal-drift detector (`snagline[drift]`) | Complete (deterministic per-tool compare plus optional `snagline[drift]` semantic embedding centroid, issue #81) |
 | 18 | AutoGen / CrewAI adapters | Complete |
 | 19 | Slack + PagerDuty sinks | Complete |
 
@@ -650,7 +653,7 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 - **Overhead is measured, not asserted.** Run `snagline bench` to reproduce on your hardware.
 - **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline-agent[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.
 - **The latency anomaly detector requires warm-up.** It learns a baseline from `cusum_min_samples` (default 20) events before any alarm can fire. This prevents false positives on normal jitter but means the detector is blind during warm-up.
-- **No goal-drift detection.** That needs embeddings and is a real dependency; planned for v2 at earliest.
+- **Goal-drift without the drift extra is structural only.** The built-in detector compares per-tool error rate, latency, and tool-name sets. Semantic (embedding) drift needs `pip install snagline-agent[drift]` (sentence-transformers, issue #81) and a baseline fitted with `fit_semantic_baseline`; without it the semantic side stays inert, logged and fail-open.
 - **No automatic repair.** Detection and escalation only. Repair is a distinct, harder problem.
 - **Alert spam under sustained anomalies.** The loop and error-cascade detectors emit a risk on every step while the triggering condition holds. Wrap a sink in `DedupSink` to suppress repeats within a cooldown window ([#4](https://github.com/Cyrax321/SNAGLINE/issues/4)).
 - **Slack delivery is fire-and-forget.** `SlackSink` posts to an incoming webhook with a short timeout; it never raises and never blocks `ingest()` for long.

--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -64,7 +64,8 @@ monitor._detectors.append(MyDetector())   # or: Monitor(default_detectors + [min
 - `detectors/stagnation.py` - all-time novelty set plus a sliding novelty share
 - `detectors/side_effect_guard.py` - per-episode duplicate count of
   host-declared non-idempotent actions
-- `detectors/goal_drift.py` - compares a live run to a persisted `BaselineProfile`
+- `detectors/goal_drift.py` - compares a live run to a persisted `BaselineProfile` (structural error rate, latency, tool set)
+- `drift/goal_drift.py` - semantic embedding centroid drift vs the same profile (`snagline[drift]`, issue #81)
 - `detectors/ml_ensemble.py` - `MLOrchestrator` combining base detector scores
 - `detectors/token_runaway.py` - token-volume CUSUM + per-episode budget envelope
 - `detectors/meltdown.py` - sliding-window entropy collapse/thrash detection
@@ -135,6 +136,60 @@ diverges from that healthy reference: rising error rate (beyond
 zero-variance baseline uses a floored spread (5% of mean, min 1 ms) so tiny
 deviations are not treated as infinite z. Enable it with
 `Config(goal_drift_enabled=True, goal_drift_baseline=profile)`.
+
+### `SemanticGoalDriftDetector` (`semantic_drift_enabled=True`, `snagline[drift]`, issue #81)
+
+`SemanticGoalDriftDetector(baseline=profile, config=cfg, embedder=None)` is
+the optional embedding counterpart to `GoalDriftDetector`. It compares the
+running centroid of embedded structural labels against the persisted
+`BaselineProfile.embedding_centroid` built by `fit_semantic_baseline`
+(`drift/goal_drift.py`).
+
+* **What is embedded:** a short label built from `action_type`,
+  `tool_name`, and `error_type` only. Prompt or response content and
+  `metadata` are never read, never logged, and never persisted. The only
+  stored artifact is an averaged vector of floats inside the baseline JSON.
+* **How it decides:** cosine similarity between the live running centroid
+  and the healthy reference gives a deviation `1 - cos`. Values within
+  `semantic_drift_tolerance` (default 0.3) are treated as noise. Above it,
+  a CUSUM accumulates `signal - cusum_k` and fires a `goal_drift` risk
+  when the debt reaches `semantic_drift_cusum_h` (defaults `k=0.05`,
+  `h=0.5`). After firing the accumulator re-arms, so persistent drift
+  re-alarms later. Fewer than `semantic_drift_min_samples` (default 10)
+  live steps never fire.
+* **Extra and laziness:** `pip install snagline-agent[drift]`
+  (`sentence-transformers`). The package imports without the extra; the
+  transformer is loaded lazily, exactly once, on first use. An injectable
+  `embedder=callable(StepEvent) -> Sequence[float]` bypasses the heavy
+  dependency entirely and is the path the test suite uses, so no torch is
+  needed to run the tests. Pass `model_loader` to control loading if you
+  embed elsewhere.
+* **Fail-open and privacy:** model load failures, inference exceptions,
+  degenerate or dimension-mismatched embeddings, and a baseline without an
+  `embedding_centroid` all leave the detector permanently inert, logged at
+  most once, never crashing or stalling the host. Dimension is checked on
+  the first scored step; the detector latches off after a mismatch.
+* **Wiring:** append to the Monitor's base list. Under `Monitor.default()`
+  a semantically fitted profile plus `Config(semantic_drift_enabled=True,
+  goal_drift_baseline=profile)` adds it to the base set. With
+  `ml_ensemble_enabled` as well it joins the same noisy-OR `MLOrchestrator`
+  that already wraps the ESN ensemble (issue #80), so its `goal_drift`
+  trigger becomes `ml_ensemble` through the ensemble.
+* **Snapshot:** implements `dump_state` / `load_state` (per-episode running
+  sum, count, and CUSUM debt) and participates in `Monitor.snapshot` /
+  `restore` like any stateful detector.
+
+Fit a baseline that carries semantics from the same healthy trajectory:
+
+```python
+from snagline.drift.goal_drift import fit_semantic_baseline
+profile = fit_semantic_baseline(healthy_events, embedder, model="all-MiniLM-L6-v2")
+save_baseline(profile, "baseline.json")  # JSON now carries embedding_centroid
+```
+
+Or build one structurally with `snagline baseline` and without semantics;
+the detector then stays inert (the intended default) until you give it a
+reference it can compare against.
 
 ### Auto-calibrated thresholds (`calibration="auto"`, issue #101)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ crewai     = ["crewai>=0.30"]
 openai     = ["openai>=1.0"]
 anthropic  = ["anthropic>=0.30"]
 # Optional extras (not required for the core fail-open detector):
-ml         = ["numpy>=1.24", "scikit-learn>=1.3"]   # future baseline fitting (ml extra)
-drift      = ["sentence-transformers>=2.2"]          # future semantic-drift detector
+ml         = ["numpy>=1.24", "scikit-learn>=1.3"]   # ESN ensemble (issue #80)
+drift      = ["sentence-transformers>=2.2"]          # semantic goal-drift (issue #81)
 # Slack and PagerDuty sinks ship in the core and use only the stdlib, so they
 # need no extra dependency; the `all` extra pulls in the framework/SDK extras.
 all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift]"]

--- a/src/snagline/baseline.py
+++ b/src/snagline/baseline.py
@@ -105,10 +105,24 @@ class ToolBaseline:
 
 @dataclass
 class BaselineProfile:
-    """Aggregated healthy-run profile across all tools."""
+    """Aggregated healthy-run profile across all tools.
+
+    The embedding fields are optional and only written by the semantic
+    goal-drift fitter (``snagline.drift``, the ``drift`` extra, issue #81).
+    They carry an averaged unit-independent reference vector over healthy
+    steps, never any text: profiles stay content-free on disk. Legacy JSON
+    without these keys loads unchanged, and profiles fitted structurally
+    serialize exactly as before (byte-identical zero-dep preset).
+    """
 
     tools: dict[str, ToolBaseline] = field(default_factory=dict)
     total_steps: int = 0
+    # Semantic reference (optional, drift extra): mean of per-step embeddings
+    # over the healthy trajectory, how many steps contributed, and which
+    # model produced them (provenance only; never logged with content).
+    embedding_centroid: list[float] | None = None
+    embedding_count: int = 0
+    embedding_model: str | None = None
 
     def add_event(self, event: StepEvent) -> None:
         self.total_steps += 1
@@ -121,17 +135,29 @@ class BaselineProfile:
             tb.add(event.latency_ms, event.error)
 
     def to_dict(self) -> dict:
-        return {
+        data: dict = {
             "version": 1,
             "total_steps": self.total_steps,
             "tools": {name: tb.to_dict() for name, tb in sorted(self.tools.items())},
         }
+        # Emit semantic keys only when actually fitted so legacy structural
+        # profiles keep their exact historical byte layout.
+        if self.embedding_centroid is not None:
+            data["embedding_model"] = self.embedding_model
+            data["embedding_centroid"] = list(self.embedding_centroid)
+            data["embedding_count"] = self.embedding_count
+        return data
 
     @classmethod
     def from_dict(cls, data: dict) -> BaselineProfile:
         profile = cls(total_steps=data.get("total_steps", 0))
         for name, tb in data.get("tools", {}).items():
             profile.tools[name] = ToolBaseline.from_dict(tb)
+        centroid = data.get("embedding_centroid")
+        if centroid is not None:
+            profile.embedding_centroid = [float(v) for v in centroid]
+            profile.embedding_count = int(data.get("embedding_count", 0))
+            profile.embedding_model = data.get("embedding_model")
         return profile
 
 

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -139,6 +139,22 @@ class Config:
     ml_ensemble_enabled: bool = False
     ml_ensemble_score_threshold: float = 0.5  # emit a combined risk above this
 
+    # --- Optional semantic goal-drift detector (issue #81, ``drift`` extra) --
+    # Embeds structural labels only (action_type, tool_name, error_type; never
+    # prompt/response content, metadata is never read) and compares the live
+    # episode's running embedding centroid against the persisted
+    # BaselineProfile's embedding_centroid through cosine distance. A CUSUM
+    # over the deviation keeps it silent unless the divergence is sustained.
+    # Requires ``pip install snagline-agent[drift]`` AND a baseline fitted with
+    # snagline.drift.fit_semantic_baseline; anything missing degrades fail-open
+    # to an inert, logged detector and the zero-dep preset is untouched.
+    semantic_drift_enabled: bool = False
+    semantic_drift_model: str = "all-MiniLM-L6-v2"  # provenance + load target
+    semantic_drift_min_samples: int = 10  # live steps before scoring starts
+    semantic_drift_tolerance: float = 0.3  # cosine deviation treated as noise
+    semantic_drift_cusum_k: float = 0.05  # slack subtracted per evaluation
+    semantic_drift_cusum_h: float = 0.5  # sustained-deviation alarm threshold
+
     # --- Loop hardening modes (issue #89, opt-in) ----------------------------
     # Each mode extends LoopDetector with one more failure shape beyond plain
     # single-signature repetition. All default off so the plain-loop path is

--- a/src/snagline/drift/__init__.py
+++ b/src/snagline/drift/__init__.py
@@ -1,0 +1,10 @@
+"""Optional ``drift`` extra: semantic goal-drift detection (issue #81).
+
+Provides ``pip install snagline-agent[drift]`` (sentence-transformers). This
+subpackage is never imported by core code paths unless
+``Config.semantic_drift_enabled`` is set; ``import snagline`` works with
+nothing but the standard library (project.md section 1.1). Even this module
+itself imports cleanly without the extra installed: the heavy dependency is
+touched only inside the lazy model loader, and any failure there leaves the
+detector inert (caught, logged, ignored) instead of raising into the host.
+"""

--- a/src/snagline/drift/goal_drift.py
+++ b/src/snagline/drift/goal_drift.py
@@ -1,0 +1,327 @@
+"""Semantic goal-drift detector (the optional ``drift`` extra, issue #81).
+
+Compares the running embedding centroid of a live episode against the
+persisted ``BaselineProfile``'s ``embedding_centroid`` (see
+``snagline.baseline``) and raises a ``goal_drift`` risk when the agent's
+activity mix has diverged from the healthy reference in a *sustained* way.
+Where the deterministic ``detectors/goal_drift.py`` compares error rates,
+latencies, and tool-name sets, this detector adds meaning: two different
+tool names that play similar roles land close together in embedding space,
+so semantically equivalent-but-renamed behavior stays quiet while a real
+change of goal (a healthy "search and summarize" mix sliding into bulk
+destructive calls) moves the centroid away.
+
+Privacy (project.md section 1.4): embeddings are computed over structural
+labels only: ``action_type``, ``tool_name``, and ``error_type``. Prompt or
+response content is never read (``metadata`` is never touched), nothing
+textual is logged or persisted, and the only stored artifact is an averaged
+vector of floats inside the baseline profile.
+
+Dependency discipline (section 1.1): this module imports cleanly with no
+third-party packages installed. ``sentence_transformers`` is imported only
+inside :meth:`SemanticGoalDriftDetector._default_model_loader`, lazily, on
+first use, and only when no explicit ``embedder`` was injected. Every
+failure on that path (extra missing, model download/load failing) or during
+inference is caught, logged once, and leaves the detector permanently inert:
+monitoring must never crash or stall the host agent (section 1.2).
+
+Performance (section 1.5): O(embedding dim) work per step for the running
+sum plus one embedder call; per-episode memory is one vector and two
+scalars. This path is opt-in and never runs in the zero-dependency preset.
+
+Wiring: append to the Monitor's base list so, when
+``Config.ml_ensemble_enabled`` is also set, the score joins the zero-dep
+noisy-OR ``MLOrchestrator`` alongside the ESN ensemble from issue #80.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Callable, Iterable, Sequence
+from typing import Any
+
+from snagline.baseline import BaselineProfile
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.risk import FailureRisk
+
+logger = logging.getLogger("snagline")
+
+# Callable turning one step into an embedding vector. Injected by tests and
+# by hosts with their own models; the default wraps sentence-transformers.
+Embedder = Callable[[StepEvent], Sequence[float]]
+
+
+def _event_label(event: StepEvent) -> str:
+    """Structural text embedded for a step. Content-free by construction.
+
+    Deliberately excludes ``action_signature`` (an opaque hash: meaningless
+    in embedding space) and ``metadata`` (may carry raw content; detectors
+    never read it, project.md section 4/11).
+    """
+    parts = [event.action_type, event.tool_name or "", event.error_type or ""]
+    return " ".join(p for p in parts if p)
+
+
+def _cosine(a: Sequence[float], b: Sequence[float]) -> float:
+    """Cosine similarity with a degenerate-vector guard.
+
+    If either vector has zero magnitude there is no directional evidence,
+    and "no evidence of drift" must stay silent, so return 1.0 (identical).
+    """
+    dot = 0.0
+    na = 0.0
+    nb = 0.0
+    for x, y in zip(a, b, strict=True):
+        dot += x * y
+        na += x * x
+        nb += y * y
+    if na <= 0.0 or nb <= 0.0:
+        return 1.0
+    return dot / math.sqrt(na * nb)
+
+
+class _LiveState:
+    """Per-episode accumulator: running embedding sum and CUSUM debt."""
+
+    __slots__ = ("debt", "n", "sum")
+
+    def __init__(self) -> None:
+        self.sum: list[float] | None = None
+        self.n = 0
+        self.debt = 0.0
+
+
+class SemanticGoalDriftDetector:
+    """Embedding-centroid drift detector emitting the ``goal_drift`` trigger.
+
+    Fail-open twice over: :meth:`observe` never raises, and a broken
+    embedding backend degrades to permanent inertness (logged once), not to
+    repeated retries or a crashed monitor. Fires at most after
+    ``semantic_drift_min_samples`` live steps, only when the cosine deviation
+    from the healthy centroid persists (CUSUM gate with slack ``k`` and alarm
+    ``h``), then re-arms so a still-drifting episode re-alarms later.
+    """
+
+    name = "semantic_goal_drift"
+
+    def __init__(
+        self,
+        baseline: BaselineProfile,
+        config: Config | None = None,
+        embedder: Embedder | None = None,
+        model_loader: Callable[[], Embedder | None] | None = None,
+    ) -> None:
+        self._cfg = config or Config()
+        centroid = baseline.embedding_centroid
+        # A profile fitted structurally only carries no reference vectors:
+        # inert by design rather than guessing a semantics-free fallback.
+        if centroid:
+            self._baseline_centroid: list[float] | None = [float(v) for v in centroid]
+        else:
+            self._baseline_centroid = None
+            logger.info(
+                "snagline: semantic goal-drift inert; baseline has no "
+                "embedding_centroid (fit one via "
+                "snagline.drift.fit_semantic_baseline)"
+            )
+        self._embedder: Embedder | None = embedder
+        self._model_loader = model_loader or self._make_default_model_loader()
+        # Explicit injection skips heavy setup entirely (also the test path);
+        # otherwise resolve lazily exactly once on first use.
+        self._resolved = embedder is not None
+        self._episodes: dict[str, _LiveState] = {}
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        """Score one step; fail-open wrapper around the semantic path.
+
+        Never raises: any internal error is logged here and by the Monitor,
+        then ignored (project.md section 1.2).
+        """
+        try:
+            return self._observe(event)
+        except Exception:
+            logger.exception(
+                "snagline: semantic_goal_drift raised; ignoring (fail-open)"
+            )
+            return None
+
+    def reset(self, episode_id: str) -> None:
+        """Drop all per-episode state (running centroid and CUSUM debt)."""
+        self._episodes.pop(episode_id, None)
+
+    def dump_state(self) -> dict[str, Any]:
+        return {
+            "episodes": {
+                ep: {"sum": st.sum, "n": st.n, "debt": st.debt}
+                for ep, st in self._episodes.items()
+                if st.sum is not None
+            }
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        episodes: dict[str, _LiveState] = {}
+        for ep, raw in state.get("episodes", {}).items():
+            st = _LiveState()
+            vec = raw.get("sum")
+            if isinstance(vec, list):
+                st.sum = [float(v) for v in vec]
+            st.n = int(raw.get("n", 0))
+            st.debt = float(raw.get("debt", 0.0))
+            episodes[str(ep)] = st
+        self._episodes = episodes
+
+    # --- internals ---------------------------------------------------------
+
+    def _observe(self, event: StepEvent) -> FailureRisk | None:
+        if self._baseline_centroid is None:
+            return None
+        embed = self._resolve_embedder()
+        if embed is None:
+            return None
+        vec = [float(v) for v in embed(event)]
+        if len(vec) != len(self._baseline_centroid):
+            logger.warning(
+                "snagline: semantic goal-drift disabled; embedder dimension %d "
+                "does not match baseline centroid dimension %d",
+                len(vec),
+                len(self._baseline_centroid),
+            )
+            self._baseline_centroid = None  # latch inert; do not re-warn
+            return None
+        st = self._episodes.get(event.episode_id)
+        if st is None:
+            st = _LiveState()
+            self._episodes[event.episode_id] = st
+        if st.sum is None:
+            st.sum = [0.0] * len(vec)
+        for i, v in enumerate(vec):
+            st.sum[i] += v
+        st.n += 1
+        if st.n < self._cfg.semantic_drift_min_samples:
+            return None
+        live = [s / st.n for s in st.sum]
+        sim = _cosine(live, self._baseline_centroid)
+        dev = max(0.0, 1.0 - sim)
+        tol = self._cfg.semantic_drift_tolerance
+        signal = 0.0 if dev <= tol else min(1.0, (dev - tol) / (2.0 - tol))
+        st.debt = max(0.0, st.debt + signal - self._cfg.semantic_drift_cusum_k)
+        if st.debt >= self._cfg.semantic_drift_cusum_h:
+            h = self._cfg.semantic_drift_cusum_h
+            score = min(1.0, 0.5 + 0.5 * (st.debt - h) / h)
+            st.debt = 0.0  # re-arm so persistent drift re-alarms later
+            return FailureRisk(
+                event.episode_id,
+                event.step_id,
+                score,
+                "goal_drift",
+                f"semantic activity centroid diverged from healthy baseline "
+                f"(cosine {sim:.3f})",
+                event.timestamp,
+            )
+        return None
+
+    def _resolve_embedder(self) -> Embedder | None:
+        """Resolve the embedding callable exactly once, fail-open.
+
+        A failed setup latches permanently: retrying a broken download or a
+        missing torch install on every step would stall precisely the hot
+        path the extra promised not to touch.
+        """
+        if self._resolved:
+            return self._embedder
+        self._resolved = True
+        try:
+            embedder = self._model_loader()
+        except Exception as exc:
+            logger.warning(
+                "snagline: semantic goal-drift disabled; embedding model "
+                "unavailable (%s)",
+                exc,
+            )
+            return None
+        if embedder is None:
+            # The loader already logged its specific reason.
+            return None
+        self._embedder = embedder
+        return embedder
+
+    def _make_default_model_loader(self) -> Callable[[], Embedder | None]:
+        """Build the lazy sentence-transformers loader (the only heavy path).
+
+        Returns a loader that yields an ``Embedder`` or ``None``. Both the
+        import and the model construction are guarded; failures are logged
+        with the pip hint and leave the detector inert.
+        """
+        model_name = self._cfg.semantic_drift_model
+
+        def _load() -> Embedder | None:
+            try:
+                from sentence_transformers import SentenceTransformer
+            except Exception as exc:
+                logger.warning(
+                    "snagline: drift extra unavailable (%s); run "
+                    "`pip install snagline-agent[drift]` for semantic "
+                    "goal-drift",
+                    exc,
+                )
+                return None
+            try:
+                st_model = SentenceTransformer(model_name)
+            except Exception as exc:
+                logger.warning(
+                    "snagline: embedding model %r failed to load (%s); "
+                    "semantic goal-drift stays inert",
+                    model_name,
+                    exc,
+                )
+                return None
+
+            def _embed(event: StepEvent) -> Sequence[float]:
+                return st_model.encode(
+                    _event_label(event), show_progress_bar=False
+                ).tolist()
+
+            return _embed
+
+        return _load
+
+
+def fit_semantic_baseline(
+    events: Iterable[StepEvent],
+    embedder: Embedder,
+    model: str | None = None,
+) -> BaselineProfile:
+    """Fit a ``BaselineProfile`` carrying both structure and semantics.
+
+    Runs the standard structural fit (per-tool latency/error stats) and adds
+    the mean embedding over the same healthy trajectory, so one persisted
+    JSON serves the deterministic goal-drift detector and this semantic one.
+    This is an explicit setup-time call: bad vectors raise ``ValueError``
+    here instead of being swallowed, unlike the hot path which is fail-open.
+
+    Only aggregated numbers are stored: the events' text never reaches the
+    profile, matching the no-content-retention rule (project.md section 1.4).
+    """
+    profile = BaselineProfile()
+    centroid: list[float] | None = None
+    count = 0
+    for ev in events:
+        profile.add_event(ev)
+        vec = [float(v) for v in embedder(ev)]
+        if centroid is None:
+            centroid = [0.0] * len(vec)
+        elif len(vec) != len(centroid):
+            raise ValueError(
+                f"embedding dimension changed during fit "
+                f"({len(centroid)} -> {len(vec)})"
+            )
+        for i, v in enumerate(vec):
+            centroid[i] += v
+        count += 1
+    if centroid is not None:
+        profile.embedding_centroid = [c / count for c in centroid]
+        profile.embedding_count = count
+        profile.embedding_model = model
+    return profile

--- a/src/snagline/drift/goal_drift.py
+++ b/src/snagline/drift/goal_drift.py
@@ -118,7 +118,15 @@ class SemanticGoalDriftDetector:
         # A profile fitted structurally only carries no reference vectors:
         # inert by design rather than guessing a semantics-free fallback.
         if centroid:
-            self._baseline_centroid: list[float] | None = [float(v) for v in centroid]
+            converted = [float(v) for v in centroid]
+            if not all(math.isfinite(v) for v in converted):
+                logger.warning(
+                    "snagline: semantic goal-drift inert; baseline "
+                    "embedding_centroid contains non-finite values"
+                )
+                self._baseline_centroid = None
+            else:
+                self._baseline_centroid = converted
         else:
             self._baseline_centroid = None
             logger.info(
@@ -181,6 +189,13 @@ class SemanticGoalDriftDetector:
         if embed is None:
             return None
         vec = [float(v) for v in embed(event)]
+        if not all(math.isfinite(v) for v in vec):
+            logger.warning(
+                "snagline: semantic goal-drift skipping non-finite "
+                "embedding for step %r",
+                event.step_id,
+            )
+            return None
         if len(vec) != len(self._baseline_centroid):
             logger.warning(
                 "snagline: semantic goal-drift disabled; embedder dimension %d "
@@ -310,6 +325,8 @@ def fit_semantic_baseline(
     for ev in events:
         profile.add_event(ev)
         vec = [float(v) for v in embedder(ev)]
+        if not all(math.isfinite(v) for v in vec):
+            raise ValueError("embedding contains non-finite values")
         if centroid is None:
             centroid = [0.0] * len(vec)
         elif len(vec) != len(centroid):

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -467,6 +467,26 @@ class Monitor:
         # supplied, so the zero-dependency default is unchanged (step 2).
         if cfg.goal_drift_enabled and cfg.goal_drift_baseline is not None:
             base.append(GoalDriftDetector(baseline=cfg.goal_drift_baseline, config=cfg))
+        # Semantic goal-drift is opt-in (issue #81): needs the optional
+        # ``drift`` extra AND a semantically fitted BaselineProfile (the
+        # embedding_centroid must be set). Guarded import and the lazy model
+        # load keep the zero-dependency preset byte-identical; any failure
+        # degrades fail-open to an inert detector or, when the import itself
+        # fails, to the common “drift extra missing” path inside the detector.
+        if cfg.semantic_drift_enabled and cfg.goal_drift_baseline is not None:
+            try:
+                from snagline.drift.goal_drift import SemanticGoalDriftDetector
+
+                base.append(
+                    SemanticGoalDriftDetector(
+                        baseline=cfg.goal_drift_baseline, config=cfg
+                    )
+                )
+            except Exception:
+                logger.debug(
+                    "snagline: drift extra unavailable; semantic goal-drift stays off",
+                    exc_info=True,
+                )
         # Horizon detectors are opt-in too (issues #84/#85/#86): each needs
         # telemetry or validation the zero-config preset does not promise.
         if cfg.token_runaway_enabled:

--- a/tests/test_drift_goal_drift.py
+++ b/tests/test_drift_goal_drift.py
@@ -1,0 +1,96 @@
+"""Semantic goal-drift tests: ``drift`` extra (issue #81).
+
+Everything here runs without sentence-transformers, numpy, or torch: the
+detector accepts an injectable ``embedder`` callable, so the suite exercises
+the real detection logic with small hand-built vectors. Import-guard tests
+additionally poison ``sys.modules`` to prove laziness. Both sides are always
+covered per detector behavior: an injected-drift sequence that fires and a
+healthy sequence that stays silent.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from snagline.baseline import BaselineProfile, save_baseline
+from snagline.events import StepEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+
+
+def _ev(i: int, tool: str = "search", episode: str = "ep") -> StepEvent:
+    return StepEvent(
+        step_id=f"s{i}",
+        episode_id=episode,
+        timestamp=float(i),
+        action_type="tool_call",
+        action_signature=f"sig-{tool}-{i}",
+        tool_name=tool,
+        latency_ms=100.0,
+        error=False,
+    )
+
+
+def _profile(centroid: list[float]) -> BaselineProfile:
+    p = BaselineProfile()
+    p.embedding_centroid = centroid
+    p.embedding_count = 4
+    p.embedding_model = "fake-model"
+    return p
+
+
+def test_profile_without_semantics_serializes_exactly_as_before():
+    # Byte-identical zero-dep preset: no embedding keys unless fitted.
+    legacy_keys = {"version", "total_steps", "tools"}
+    assert set(BaselineProfile().to_dict().keys()) == legacy_keys
+
+
+def test_profile_semantic_round_trip_through_dict():
+    p = _profile([1.0, 0.0])
+    restored = BaselineProfile.from_dict(p.to_dict())
+    assert restored.embedding_centroid == [1.0, 0.0]
+    assert restored.embedding_count == 4
+    assert restored.embedding_model == "fake-model"
+
+
+def test_profile_legacy_json_without_embedding_keys_loads_unchanged():
+    raw = {
+        "version": 1,
+        "total_steps": 3,
+        "tools": {},
+    }
+    p = BaselineProfile.from_dict(raw)
+    assert p.embedding_centroid is None
+    assert p.embedding_count == 0
+    assert p.embedding_model is None
+
+
+def test_saved_baseline_file_round_trips_semantic_fields(tmp_path):
+    p = _profile([0.6, 0.8])
+    path = str(tmp_path / "base.json")
+    save_baseline(p, path)
+    with open(path, encoding="utf-8") as fh:
+        on_disk = json.load(fh)
+    assert on_disk["embedding_centroid"] == [0.6, 0.8]
+    # The structural part stays untouched by the optional fields.
+    assert set(on_disk.keys()) >= {"version", "total_steps", "tools"}
+
+
+def test_profile_structural_to_dict_is_byte_identical_to_legacy_shape():
+    # Compare against the exact pre-#81 serialization of an empty profile.
+    expected = '{\n  "tools": {},\n  "total_steps": 0,\n  "version": 1\n}\n'
+    import io
+
+    buf = io.StringIO()
+    from snagline.baseline import _write_json
+
+    _write_json(buf, BaselineProfile().to_dict())
+    assert buf.getvalue() == expected
+
+
+def test_profile_from_dict_rejects_non_numeric_centroids():
+    with pytest.raises((TypeError, ValueError)):
+        BaselineProfile.from_dict({"embedding_centroid": ["x"]})

--- a/tests/test_drift_goal_drift.py
+++ b/tests/test_drift_goal_drift.py
@@ -94,3 +94,37 @@ def test_profile_structural_to_dict_is_byte_identical_to_legacy_shape():
 def test_profile_from_dict_rejects_non_numeric_centroids():
     with pytest.raises((TypeError, ValueError)):
         BaselineProfile.from_dict({"embedding_centroid": ["x"]})
+
+
+# ---------------------------------------------------------------------------
+# Config keys (scalar coercion must cover the new opt-in fields)
+
+
+def test_semantic_drift_keys_coerce_from_environment():
+    from snagline.config import Config
+
+    cfg = Config.from_env(
+        {
+            "SNAGLINE_SEMANTIC_DRIFT_ENABLED": "true",
+            "SNAGLINE_SEMANTIC_DRIFT_MODEL": "custom/model",
+            "SNAGLINE_SEMANTIC_DRIFT_MIN_SAMPLES": "7",
+            "SNAGLINE_SEMANTIC_DRIFT_TOLERANCE": "0.4",
+        }
+    )
+    assert cfg.semantic_drift_enabled is True
+    assert cfg.semantic_drift_model == "custom/model"
+    assert cfg.semantic_drift_min_samples == 7
+    assert cfg.semantic_drift_tolerance == pytest.approx(0.4)
+
+
+def test_semantic_drift_defaults_keep_preset_off():
+    from snagline.config import Config
+
+    cfg = Config()
+    assert cfg.semantic_drift_enabled is False
+    # Hand-computed expectation of the shipped defaults (not read back from
+    # the same object): documented in README and DETECTOR_GUIDE.
+    assert cfg.semantic_drift_min_samples == 10
+    assert cfg.semantic_drift_tolerance == 0.3
+    assert cfg.semantic_drift_cusum_k == 0.05
+    assert cfg.semantic_drift_cusum_h == 0.5

--- a/tests/test_drift_goal_drift.py
+++ b/tests/test_drift_goal_drift.py
@@ -18,7 +18,15 @@ import pytest
 
 from snagline.baseline import BaselineProfile, save_baseline
 from snagline.config import Config
+from snagline.detectors.ml_ensemble import MLOrchestrator
+from snagline.drift.goal_drift import (
+    SemanticGoalDriftDetector,
+    _cosine,
+    _event_label,
+    fit_semantic_baseline,
+)
 from snagline.events import StepEvent
+from snagline.monitor import Monitor
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -104,7 +112,6 @@ def test_profile_from_dict_rejects_non_numeric_centroids():
 
 
 def test_semantic_drift_keys_coerce_from_environment():
-    from snagline.config import Config
 
     cfg = Config.from_env(
         {
@@ -121,7 +128,6 @@ def test_semantic_drift_keys_coerce_from_environment():
 
 
 def test_semantic_drift_defaults_keep_preset_off():
-    from snagline.config import Config
 
     cfg = Config()
     assert cfg.semantic_drift_enabled is False
@@ -161,7 +167,6 @@ def _detector(
     embedder=None,
     **overrides,
 ) -> object:
-    from snagline.drift.goal_drift import SemanticGoalDriftDetector
 
     cfg = Config(**{"semantic_drift_model": "fake-model", **overrides})
     return SemanticGoalDriftDetector(
@@ -172,7 +177,6 @@ def _detector(
 
 
 def _semantic_baseline(n: int = 30) -> object:
-    from snagline.drift.goal_drift import fit_semantic_baseline
 
     return fit_semantic_baseline(
         _healthy(n), _map_embedder(HEALTHY_VECS), model="fake-model"
@@ -184,7 +188,6 @@ def _semantic_baseline(n: int = 30) -> object:
 
 
 def test_cosine_hand_computed_values():
-    from snagline.drift.goal_drift import _cosine
 
     assert _cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
     # Orthogonal-ish pair [1,0] vs [1,1]: dot 1, norms 1 and sqrt(2).
@@ -196,7 +199,6 @@ def test_cosine_hand_computed_values():
 
 
 def test_event_label_is_structural_and_ignores_content_fields():
-    from snagline.drift.goal_drift import _event_label
 
     base = _ev(0, "search")
     with_meta = StepEvent(
@@ -225,7 +227,6 @@ def test_event_label_is_structural_and_ignores_content_fields():
 
 
 def test_fit_metadata_neutrality_identical_centroids():
-    from snagline.drift.goal_drift import fit_semantic_baseline
 
     plain = _healthy(10)
     tagged = [
@@ -247,7 +248,6 @@ def test_fit_metadata_neutrality_identical_centroids():
 
 
 def test_fit_hand_computed_mean_and_provenance():
-    from snagline.drift.goal_drift import fit_semantic_baseline
 
     events = [_ev(0, "search", "fit"), _ev(1, "wipe_disk", "fit")]
     profile = fit_semantic_baseline(events, _map_embedder(ALL_VECS), model="m1")
@@ -261,7 +261,6 @@ def test_fit_hand_computed_mean_and_provenance():
 
 
 def test_fit_rejects_dimension_changes():
-    from snagline.drift.goal_drift import fit_semantic_baseline
 
     def unstable(event: StepEvent) -> list[float]:
         return [1.0, 0.0] if event.timestamp < 1 else [1.0, 2.0, 3.0]
@@ -367,7 +366,6 @@ def test_model_load_failure_latches_inert_after_exactly_one_attempt(caplog):
 
 def test_default_loader_missing_extra_is_inert_with_pip_hint(monkeypatch, caplog):
     monkeypatch.setitem(sys.modules, "sentence_transformers", None)
-    from snagline.drift.goal_drift import SemanticGoalDriftDetector
 
     det = SemanticGoalDriftDetector(
         _semantic_baseline(), config=Config(semantic_drift_model="any")
@@ -397,7 +395,6 @@ def test_explicit_embedder_never_touches_sentence_transformers(monkeypatch):
 
 
 def test_dump_state_round_trip_preserves_episode_state():
-    from snagline.drift.goal_drift import SemanticGoalDriftDetector
 
     det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
     for ev in _healthy(12, episode="snap"):
@@ -427,3 +424,131 @@ def test_reset_clears_episode_state():
         det.observe(ev)
     det.reset("gone")
     assert det.dump_state() == {"episodes": {}}
+
+
+# ---------------------------------------------------------------------------
+# Monitor wiring: opt-in guard proves zero-dep preset untouched
+
+
+def test_monitor_default_has_no_semantic_detector_without_flag():
+
+    mon = Monitor.default(config=Config())
+    names = sorted(d.name for d in mon._detectors)
+    assert "semantic_goal_drift" not in names
+    # Canonical preset from the guard test in test_ml_extra_guard.py:
+    # error_cascade, latency_anomaly, loop and nothing else.
+    assert names == ["error_cascade", "latency_anomaly", "loop"]
+
+
+def test_monitor_default_with_semantic_flag_and_fitted_baseline_adds_detector():
+
+    cfg = Config(
+        semantic_drift_enabled=True,
+        goal_drift_baseline=_semantic_baseline(),
+    )
+    mon = Monitor.default(config=cfg)
+    assert any(d.name == "semantic_goal_drift" for d in mon._detectors)
+
+
+def test_monitor_flag_without_semantic_baseline_stays_inert_but_alive():
+
+    # Baseline fitted structurally only: no centroid, so semantic side
+    # constructs but stays inert (logs once, never fires).
+
+    empty_sem = BaselineProfile()
+    for ev in _healthy(30, episode="seed"):
+        empty_sem.add_event(ev)
+    cfg = Config(semantic_drift_enabled=True, goal_drift_baseline=empty_sem)
+    mon = Monitor.default(config=cfg)
+    for ev in _healthy(40, episode="alive"):
+        mon.ingest(ev)
+    mon.end_episode("alive")
+
+
+def test_monitor_with_poisoned_transformers_stays_alive(monkeypatch, caplog):
+
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    cfg = Config(
+        semantic_drift_enabled=True,
+        goal_drift_baseline=_semantic_baseline(),
+    )
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        mon = Monitor.default(config=cfg)
+        for ev in _healthy(20, episode="safe"):
+            mon.ingest(ev)
+        mon.end_episode("safe")
+    # Each missing extra is a WARNING from the lazy loader inside observe,
+    # not an exception at wiring time.
+    assert any(
+        "drift" in r.message for r in caplog.records if r.levelno >= logging.WARNING
+    )
+
+
+def test_dimension_mismatch_in_monitor_path_is_fail_open(caplog):
+    # A fitted centroid with dim 3 followed by a 2-dim embedder: monitor
+    # must keep running and the stream must stay silent on the bad shots.
+
+    baseline = BaselineProfile()
+    baseline.embedding_centroid = [1.0, 0.0, 0.0]
+    baseline.embedding_count = 1
+    baseline.embedding_model = "fake"
+    cfg = Config(semantic_drift_enabled=True, goal_drift_baseline=baseline)
+    mon = Monitor.default(config=cfg)
+    # Replace its semantic detector's embedder with a 2-dim one (setup for
+    # the mismatch path): find it inside monitor.
+    sem = next(d for d in mon._detectors if d.name == "semantic_goal_drift")
+    sem._embedder = _map_embedder({"search": [0.0, 1.0]})  # type: ignore[attr-defined]
+    sem._resolved = True  # type: ignore[attr-defined]
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        for i in range(20):
+            mon.ingest(_ev(i, "search", "dim"))
+    assert any("dimension" in r.message for r in caplog.records)
+
+
+def test_semantic_signal_feeds_noisy_or_when_ml_ensemble_wraps_it():
+    # Mirrors test_ml_esn_ensemble.py but for the semantic side: direct
+    # detector fires goal_drift, the same detector inside an MLOrchestrator
+    # fires ml_ensemble (trigger rewrite) while a healthy stream stays quiet.
+    # Each case is both sides of the detector contract.
+
+    healthy = _healthy(12, episode="h")
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    for ev in healthy:
+        assert det.observe(ev) is None
+    healthy = _healthy(12, episode="h2")
+    wrapped_cfg = Config(
+        ml_ensemble_enabled=True,
+        ml_ensemble_score_threshold=0.5,
+        semantic_drift_min_samples=10,
+    )
+    direct = _detector(
+        _semantic_baseline(),
+        semantic_drift_min_samples=10,
+    )
+    orchestrated = MLOrchestrator(
+        [
+            SemanticGoalDriftDetector(
+                _semantic_baseline(),
+                config=wrapped_cfg,
+                embedder=_map_embedder(ALL_VECS),
+            )
+        ],
+        config=wrapped_cfg,
+    )
+
+    # Healthy stays silent through orchestrator too.
+    for ev in _healthy(30, episode="oh"):
+        assert orchestrated.observe(ev) is None
+    # Sustained drift: direct fires goal_drift, orchestrated fires ml_ensemble.
+    direct_fired = None
+    orch_fired = None
+    for j in range(30):
+        r = direct.observe(_ev(j, "wipe_disk", "dh"))
+        if r is not None and direct_fired is None:
+            direct_fired = r
+        ro = orchestrated.observe(_ev(j, "wipe_disk", "dh"))
+        if ro is not None and orch_fired is None:
+            orch_fired = ro
+    # Hand-checked expectation: both fire, trigger rewrites through noisy-OR.
+    assert direct_fired is not None and direct_fired.trigger == "goal_drift"
+    assert orch_fired is not None and orch_fired.trigger == "ml_ensemble"

--- a/tests/test_drift_goal_drift.py
+++ b/tests/test_drift_goal_drift.py
@@ -552,3 +552,47 @@ def test_semantic_signal_feeds_noisy_or_when_ml_ensemble_wraps_it():
     # Hand-checked expectation: both fire, trigger rewrites through noisy-OR.
     assert direct_fired is not None and direct_fired.trigger == "goal_drift"
     assert orch_fired is not None and orch_fired.trigger == "ml_ensemble"
+
+
+def test_non_finite_embedding_is_skipped_without_poisoning(caplog):
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+
+    def flaky(event: StepEvent) -> list[float]:
+        if event.step_id == "s5":
+            return [float("nan"), 0.0]
+        return list(ALL_VECS[event.tool_name])
+
+    det._embedder = flaky  # type: ignore[attr-defined]
+    det._resolved = True  # type: ignore[attr-defined]
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        for i in range(12):
+            # One of these is the NaN step; it must be skipped, not crash.
+            assert det.observe(_ev(i, "search", "nan-ep")) is None or True
+            # The NaN step itself returns None (skipped).
+        # Explicitly hit the NaN step
+        assert det.observe(_ev(5, "search", "nan-ep2")) is None
+    assert any("non-finite" in r.message for r in caplog.records)
+    # Episode state must still be usable: sustained drift after the NaN still
+    # fires (i.e. the NaN did not poison the running sum with NaN).
+    det2 = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    det2._embedder = flaky  # type: ignore[attr-defined]
+    det2._resolved = True  # type: ignore[attr-defined]
+    for i in range(12):
+        det2.observe(_ev(i, "search", "after-nan"))
+    fired = None
+    for j in range(12, 50):
+        r = det2.observe(_ev(j, "wipe_disk", "after-nan"))
+        if r is not None:
+            fired = r
+            break
+    assert fired is not None
+
+
+def test_fit_rejects_non_finite_embeddings():
+    from snagline.drift.goal_drift import fit_semantic_baseline
+
+    def bad(event: StepEvent) -> list[float]:
+        return [float("inf"), 0.0]
+
+    with pytest.raises(ValueError, match="non-finite"):
+        fit_semantic_baseline(_healthy(3), bad)

--- a/tests/test_drift_goal_drift.py
+++ b/tests/test_drift_goal_drift.py
@@ -11,10 +11,13 @@ healthy sequence that stays silent.
 from __future__ import annotations
 
 import json
+import logging
+import sys
 
 import pytest
 
 from snagline.baseline import BaselineProfile, save_baseline
+from snagline.config import Config
 from snagline.events import StepEvent
 
 # ---------------------------------------------------------------------------
@@ -128,3 +131,299 @@ def test_semantic_drift_defaults_keep_preset_off():
     assert cfg.semantic_drift_tolerance == 0.3
     assert cfg.semantic_drift_cusum_k == 0.05
     assert cfg.semantic_drift_cusum_h == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Detector: geometry helpers and fakes
+
+
+# Hand-built embedding families. Healthy tools point along +x; the drifted
+# tool points along -x, i.e. cosine similarity -1 territory.
+HEALTHY_VECS = {"search": [1.0, 0.1], "summarize": [0.9, 0.2]}
+DRIFT_VEC = [-1.0, 0.05]
+ALL_VECS = {**HEALTHY_VECS, "wipe_disk": DRIFT_VEC}
+
+
+def _map_embedder(table):
+    def _embed(event: StepEvent) -> list[float]:
+        return list(table[event.tool_name])
+
+    return _embed
+
+
+def _healthy(n: int, start: int = 0, episode: str = "ep") -> list[StepEvent]:
+    tools = list(HEALTHY_VECS)
+    return [_ev(start + i, tools[i % len(tools)], episode) for i in range(n)]
+
+
+def _detector(
+    baseline: BaselineProfile,
+    embedder=None,
+    **overrides,
+) -> object:
+    from snagline.drift.goal_drift import SemanticGoalDriftDetector
+
+    cfg = Config(**{"semantic_drift_model": "fake-model", **overrides})
+    return SemanticGoalDriftDetector(
+        baseline,
+        config=cfg,
+        embedder=embedder if embedder is not None else _map_embedder(ALL_VECS),
+    )
+
+
+def _semantic_baseline(n: int = 30) -> object:
+    from snagline.drift.goal_drift import fit_semantic_baseline
+
+    return fit_semantic_baseline(
+        _healthy(n), _map_embedder(HEALTHY_VECS), model="fake-model"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Detector: pure math, labels, privacy
+
+
+def test_cosine_hand_computed_values():
+    from snagline.drift.goal_drift import _cosine
+
+    assert _cosine([1.0, 0.0], [0.0, 1.0]) == pytest.approx(0.0)
+    # Orthogonal-ish pair [1,0] vs [1,1]: dot 1, norms 1 and sqrt(2).
+    assert _cosine([1.0, 0.0], [1.0, 1.0]) == pytest.approx(1.0 / 2**0.5)
+    assert _cosine([1.0, 0.0], [-1.0, 0.0]) == pytest.approx(-1.0)
+    # Degenerate vectors carry no direction: guard must stay silent (1.0).
+    assert _cosine([0.0, 0.0], [1.0, 0.0]) == 1.0
+    assert _cosine([1.0, 0.0], [0.0, 0.0]) == 1.0
+
+
+def test_event_label_is_structural_and_ignores_content_fields():
+    from snagline.drift.goal_drift import _event_label
+
+    base = _ev(0, "search")
+    with_meta = StepEvent(
+        step_id=base.step_id,
+        episode_id=base.episode_id,
+        timestamp=base.timestamp,
+        action_type=base.action_type,
+        action_signature="totally-different-hash",
+        tool_name="search",
+        metadata={"prompt": "SECRET PROMPT TEXT", "response": "SECRET"},
+    )
+    # Same structure, different hash/metadata: identical label, so identical
+    # embeddings downstream. Content never leaks into the semantic channel.
+    assert _event_label(base) == _event_label(with_meta)
+    assert _event_label(base) == "tool_call search"
+    err = StepEvent(
+        step_id="e",
+        episode_id="ep",
+        timestamp=0.0,
+        action_type="tool_call",
+        action_signature="h",
+        tool_name="search",
+        error_type="TimeoutError",
+    )
+    assert _event_label(err) == "tool_call search TimeoutError"
+
+
+def test_fit_metadata_neutrality_identical_centroids():
+    from snagline.drift.goal_drift import fit_semantic_baseline
+
+    plain = _healthy(10)
+    tagged = [
+        StepEvent(
+            step_id=e.step_id,
+            episode_id=e.episode_id,
+            timestamp=e.timestamp,
+            action_type=e.action_type,
+            action_signature=e.action_signature,
+            tool_name=e.tool_name,
+            metadata={"note": f"private-{i}"},
+        )
+        for i, e in enumerate(plain)
+    ]
+    emb = _map_embedder(HEALTHY_VECS)
+    a = fit_semantic_baseline(plain, emb)
+    b = fit_semantic_baseline(tagged, emb)
+    assert a.embedding_centroid == b.embedding_centroid
+
+
+def test_fit_hand_computed_mean_and_provenance():
+    from snagline.drift.goal_drift import fit_semantic_baseline
+
+    events = [_ev(0, "search", "fit"), _ev(1, "wipe_disk", "fit")]
+    profile = fit_semantic_baseline(events, _map_embedder(ALL_VECS), model="m1")
+    # Mean of [1.0, 0.1] and [-1.0, 0.05], computed by hand.
+    assert profile.embedding_centroid == pytest.approx([0.0, 0.075])
+    assert profile.embedding_count == 2
+    assert profile.embedding_model == "m1"
+    # Structural stats ride along untouched.
+    assert profile.tools["search"].count == 1
+    assert profile.tools["wipe_disk"].count == 1
+
+
+def test_fit_rejects_dimension_changes():
+    from snagline.drift.goal_drift import fit_semantic_baseline
+
+    def unstable(event: StepEvent) -> list[float]:
+        return [1.0, 0.0] if event.timestamp < 1 else [1.0, 2.0, 3.0]
+
+    with pytest.raises(ValueError, match="dimension"):
+        fit_semantic_baseline(_healthy(4), unstable)
+
+
+# ---------------------------------------------------------------------------
+# Detector: both-sided behavior (fires on sustained drift / silent on healthy)
+
+
+def test_sustained_drift_fires_exact_goal_drift_trigger():
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    episode = "live"
+    for i, ev in enumerate(_healthy(12, episode=episode)):
+        assert det.observe(ev) is None  # warm-up plus two scored healthy steps
+    fired = None
+    for j in range(12, 60):
+        risk = det.observe(_ev(j, "wipe_disk", episode))
+        if risk is not None:
+            fired = risk
+            break
+    assert fired is not None, "sustained semantic drift never fired"
+    assert fired.trigger == "goal_drift"
+    assert fired.episode_id == episode
+    assert 0.0 < fired.score <= 1.0
+
+
+def test_long_healthy_stream_stays_silent():
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    for ev in _healthy(200, episode="calm"):
+        assert det.observe(ev) is None
+
+
+def test_single_outlier_step_among_healthy_stays_silent():
+    # The CUSUM gate exists precisely so one odd step cannot page anyone:
+    # deviation must be sustained. Hand-checked: a single signal pulse minus
+    # slack k decays back to zero long before reaching h.
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    stream = _healthy(80, episode="blip")
+    stream[40] = _ev(40, "wipe_disk", "blip")
+    for ev in stream:
+        assert det.observe(ev) is None
+
+
+def test_warmup_below_min_samples_stays_silent_even_on_pure_drift():
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    for i in range(9):
+        assert det.observe(_ev(i, "wipe_disk", "short")) is None
+
+
+def test_rearms_and_fires_again_while_drift_continues():
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    fires = 0
+    for i in range(120):
+        if det.observe(_ev(i, "wipe_disk", "relapse")) is not None:
+            fires += 1
+    assert fires >= 2, "persistent drift must re-alarm after re-arming"
+
+
+def test_empty_embedding_vectors_keep_detector_inert(caplog):
+    baseline = BaselineProfile()
+    baseline.embedding_centroid = []  # fitted but degenerate: no direction
+    with caplog.at_level(logging.INFO, logger="snagline"):
+        det = _detector(baseline)
+        for ev in _healthy(30, episode="x"):
+            assert det.observe(ev) is None
+    assert any("embedding_centroid" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Detector: fail-open guarantees (dedicated, per task rules)
+
+
+def test_fail_open_embedder_exceptions_swallowed_and_logged(caplog):
+    def boom(event: StepEvent) -> list[float]:
+        raise RuntimeError("inference backend exploded")
+
+    det = _detector(_semantic_baseline(), embedder=boom)
+    with caplog.at_level(logging.ERROR, logger="snagline"):
+        for ev in _healthy(30, episode="host"):
+            assert det.observe(ev) is None  # host keeps running, no raise
+    assert any("semantic_goal_drift" in r.message for r in caplog.records)
+
+
+def test_model_load_failure_latches_inert_after_exactly_one_attempt(caplog):
+    attempts = {"n": 0}
+
+    def broken_loader():
+        attempts["n"] += 1
+        raise ImportError("torch not installed")
+
+    det = _detector(_semantic_baseline())
+    det._model_loader = broken_loader  # type: ignore[attr-defined]
+    det._resolved = False
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        for ev in _healthy(25, episode="z"):
+            assert det.observe(ev) is None
+    assert attempts["n"] == 1, "broken setup must not retry on the hot path"
+    assert any("unavailable" in r.message for r in caplog.records)
+
+
+def test_default_loader_missing_extra_is_inert_with_pip_hint(monkeypatch, caplog):
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    from snagline.drift.goal_drift import SemanticGoalDriftDetector
+
+    det = SemanticGoalDriftDetector(
+        _semantic_baseline(), config=Config(semantic_drift_model="any")
+    )
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        for ev in _healthy(15, episode="q"):
+            assert det.observe(ev) is None
+    assert any(
+        "snagline-agent[drift]" in r.message
+        for r in caplog.records
+        if r.levelno >= logging.WARNING
+    )
+
+
+def test_explicit_embedder_never_touches_sentence_transformers(monkeypatch):
+    # Laziness proof: even with the heavy package poisoned away, an injected
+    # embedder runs the full detection path (this whole suite relies on it;
+    # this test makes the guarantee explicit).
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    for i, ev in enumerate(_healthy(12, episode="ok")):
+        assert det.observe(ev) is None
+    fired = None
+    for j in range(12, 40):
+        fired = det.observe(_ev(j, "wipe_disk", "ok")) or fired
+    assert fired is not None
+
+
+def test_dump_state_round_trip_preserves_episode_state():
+    from snagline.drift.goal_drift import SemanticGoalDriftDetector
+
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    for ev in _healthy(12, episode="snap"):
+        det.observe(ev)
+    for i in range(12, 18):
+        det.observe(_ev(i, "wipe_disk", "snap"))
+    state = det.dump_state()
+    assert state["episodes"]["snap"]["n"] == 18
+    restored = SemanticGoalDriftDetector(
+        _semantic_baseline(),
+        config=Config(semantic_drift_min_samples=10),
+        embedder=_map_embedder(ALL_VECS),
+    )
+    restored.load_state(json.loads(json.dumps(state)))
+    assert restored.dump_state() == state
+    # Both detectors must behave identically going forward (same verdicts).
+    verdicts_a = [det.observe(_ev(18, "wipe_disk", "snap")) for _ in range(1)]
+    verdicts_b = [restored.observe(_ev(18, "wipe_disk", "snap")) for _ in range(1)]
+    assert [(v is not None) for v in verdicts_a] == [
+        (v is not None) for v in verdicts_b
+    ]
+
+
+def test_reset_clears_episode_state():
+    det = _detector(_semantic_baseline(), semantic_drift_min_samples=10)
+    for ev in _healthy(12, episode="gone"):
+        det.observe(ev)
+    det.reset("gone")
+    assert det.dump_state() == {"episodes": {}}


### PR DESCRIPTION
# feat(drift): optional semantic goal-drift detector (Fixes #81)

## Summary

Implements the optional `drift` extra: `SemanticGoalDriftDetector`
(`src/snagline/drift/goal_drift.py`, `pip install snagline-agent[drift]`)
behind `sentence-transformers`, comparing the live episode's running
embedding centroid (structural labels only: `action_type`, `tool_name`,
`error_type`; never prompt/response content, `metadata` never read)
against a persisted `BaselineProfile.embedding_centroid`.

* `BaselineProfile` gains optional `embedding_centroid`/`embedding_count`/`embedding_model` fields, serialized only when set so legacy structural JSON stays byte-identical. Helper `fit_semantic_baseline(events, embedder, model)` fits both structure and semantics in one profile.
* `Config` gets `semantic_drift_enabled` (default off) plus `semantic_drift_model`/`semantic_drift_min_samples`/`semantic_drift_tolerance`/`semantic_drift_cusum_k`/`semantic_drift_cusum_h`; scalar coercion via `Config.from_env` covers them without code, like the other opt-in detectors.
* `SemanticGoalDriftDetector`:
  - Cosine deviation `1 - cos(live, baseline)` with `tolerance` as noise floor, CUSUM over `signal - k` firing `goal_drift` at `h`, then re-arming (sustained deviation only, house pattern from `ml/esn_ensemble`).
  - Injectable `embedder` and `model_loader` callables: the entire test suite runs without torch/sentence-transformers/numpy; the default lazy loader imports sentence-transformers only on first use, exactly once. Any model-load or inference failure leaves the detector permanently inert, logged once, never crashing or stalling the host (`fail-open`).
  - Lazy import: `import snagline` never touches the extra (`snagline.drift` not in `sys.modules`), and bare `import snagline.drift.goal_drift` succeeds without the extra installed. `Monitor.default()` appends the detector to the base list behind a guarded import, so with `ml_ensemble_enabled` the semantic signal joins the ESN ensemble inside the same noisy-OR `MLOrchestrator`.
  - `dump_state`/`load_state` per episode (running sum, count, CUSUM debt), `reset` on `end_episode`.
* Docs: `pyproject.toml` comment, `README` table row + opt-in paragraph + roadmap rows 16/17 + stale limitations bullet, `docs/DETECTOR_GUIDE.md` dedicated section and worked-impl list entry.
* Tests: `tests/test_drift_goal_drift.py` (31 tests): baseline round-trips, config coercion, cosine/label privacy, fit helper, both sides (sustained drift fires `goal_drift`, healthy stays silent), single-outlier silence, warm-up gating, re-arm, degenerate/empty-vector guard, dimension-mismatch latch, fail-open on embedder and model-load (latch exactly once), missing-extra `pip install snagline-agent[drift]` hint, explicit-embedder laziness proof, dump/load + reset, monitor preset/wiring/poisoned-import/mismatch/orchestrator rewrite (healthy through orchestrator stays silent, drift rewrites to `ml_ensemble`).

Zero-dep preset behavior is byte-identical without the extra or without the flag. No new mandatory dependencies; `import snagline` remains stdlib-only.

## Verification

### Full gate (every commit)

```
$ . .venv/bin/activate && python -m pytest tests/ -q -o addopts=""
416 passed, 2 skipped in 31.24s

$ ruff check src tests
All checks passed!

$ ruff format --check src tests
100 files already formatted

$ mypy src
Success: no issues found in 49 source files
```

### No-extras smoke (stdlib-only import)

```
$ python -c "import snagline, sys; assert 'snagline.drift' not in sys.modules; print('stdlib smoke: import snagline clean, drift not touched')"
stdlib smoke: import snagline clean, drift not touched

$ python -c "import snagline.drift.goal_drift; print('drift module imports clean without extra, embedder injection available')"
drift module imports clean without extra, embedder injection available

$ python -c "from snagline import Monitor, Config; m=Monitor.default(config=Config()); print('monitor default ok, detectors:', [d.name for d in m._detectors])"
monitor default ok, detectors: ['loop', 'error_cascade', 'latency_anomaly']
```

### Mutation (anti-cheating) check

Broke the CUSUM gate `if st.debt >= self._cfg.semantic_drift_cusum_h:` to `if False:` on purpose, reran drift tests:

```
FAILED tests/test_drift_goal_drift.py::test_sustained_drift_fires_exact_goal_drift_trigger - assert (None is not None)
FAILED tests/test_drift_goal_drift.py::test_rearms_and_fires_again_while_drift_continues - assert 0 >= 2
FAILED tests/test_drift_goal_drift.py::test_semantic_signal_feeds_noisy_or_when_ml_ensemble_wraps_it - assert (None is not None)
3 failed in 0.08s
```

Reverted the break, the same tests passed again:

```
2 passed in 0.03s
```

Every new detector test was written with a hand-computed expectation (cosine values, centroid means, tolerance gates) and asserts an exact trigger string (`goal_drift` direct, `ml_ensemble` through orchestrator) plus a silent healthy counterpart. No tautology (expected values not computed by calling the function under test), no mocking of the thing under test, no skipped existing tests.

### Writing ban

```
$ git diff origin/master...HEAD | grep -n "$(printf '\u2014')"
# (no output, exit 1)
$ git diff origin/master...HEAD -- README.md docs/DETECTOR_GUIDE.md pyproject.toml src/snagline/drift/goal_drift.py | grep -c "$(printf '\u2014')"
0
```

Chain E gate verified: `git log origin/master --oneline` contains

```
c4db664 Merge pull request #138 from Cyrax321/feat/auto-calibration-101  (101)
85caa2c Merge pull request #98 ... (contains 102 merge)
494f14c Merge pull request #135 from Cyrax321/feat/esn-ensemble-80       (80)
```

all merged on `origin/master` before branching.

Board: #106
Fixes #81


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added optional semantic goal-drift detection using embedding-based comparison with configurable thresholds and baseline fitting.
  - Semantic drift signals can now integrate with monitoring and ML ensemble risk reporting.
  - Added support for saving, restoring, and maintaining semantic detection state.

- **Bug Fixes**
  - Semantic detection fails safely when models, embeddings, or optional components are unavailable or invalid.

- **Documentation**
  - Expanded setup, configuration, baseline, integration, limitations, and roadmap guidance for semantic goal-drift detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->