### PR TITLE
fix(config): make SNAGLINE_LOG_FORMAT operational end to end

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,81 @@ detectors = [
 ]
 ```
 
+### Environment variables and config keys
+
+Every scalar field of `Config` doubles as a 12-factor environment variable:
+take the key name, uppercase it, prefix it with `SNAGLINE_` (so
+`loop_window_size` becomes `SNAGLINE_LOOP_WINDOW_SIZE`; lookup is
+case-insensitive). Layering, lowest to highest: built-in defaults, then an
+optional JSON/TOML file passed as `--config <path>`, then environment
+variables. `Config.resolve()` applies that ordering everywhere: `Monitor.default()`,
+`snagline watch`, `snagline replay`, and `snagline serve` all go through it.
+Booleans accept `1/true/yes/on/t`. Unknown keys and values that fail to
+coerce are ignored with a logged warning; the one exception is
+`SNAGLINE_LOG_FORMAT`, whose closed value set fails loudly at startup.
+The two object-typed fields (`goal_drift_baseline`, `calibration_baseline`)
+cannot come from files or the environment; pass those objects in code, or use
+the path variant below.
+
+| Environment variable | Config key | Default | Meaning |
+|---|---|---|---|
+| `SNAGLINE_LOOP_WINDOW_SIZE` | `loop_window_size` | 12 | Loop detector sliding window (steps) |
+| `SNAGLINE_LOOP_REPEAT_THRESHOLD` | `loop_repeat_threshold` | 3 | Repeats within the window that fire a loop risk |
+| `SNAGLINE_CASCADE_WINDOW_SIZE` | `cascade_window_size` | 10 | Error-cascade window (steps) |
+| `SNAGLINE_CASCADE_ERROR_THRESHOLD` | `cascade_error_threshold` | 3 | Errors in window that fire a cascade |
+| `SNAGLINE_CASCADE_CONSECUTIVE_THRESHOLD` | `cascade_consecutive_threshold` | 3 | Consecutive errors that fire a cascade |
+| `SNAGLINE_CASCADE_COUNT_NON_TOOL_ERRORS` | `cascade_count_non_tool_errors` | False | Count non-tool errors toward cascades |
+| `SNAGLINE_CUSUM_K` | `cusum_k` | 0.5 | CUSUM slack parameter |
+| `SNAGLINE_CUSUM_H` | `cusum_h` | 5.0 | CUSUM alarm threshold |
+| `SNAGLINE_CUSUM_MIN_SAMPLES` | `cusum_min_samples` | 5 | Latency warm-up samples before alarming |
+| `SNAGLINE_CUSUM_SIGMA_FLOOR_ABS` | `cusum_sigma_floor_abs` | 1.0 | Absolute floor on baseline std (ms) |
+| `SNAGLINE_CUSUM_SIGMA_FLOOR_REL` | `cusum_sigma_floor_rel` | 0.05 | Relative floor on baseline std (share of mean) |
+| `SNAGLINE_GOAL_DRIFT_ENABLED` | `goal_drift_enabled` | False | Enable GoalDriftDetector |
+| `SNAGLINE_GOAL_DRIFT_ERROR_TOLERANCE` | `goal_drift_error_tolerance` | 0.1 | Allowed error-rate rise over baseline |
+| `SNAGLINE_GOAL_DRIFT_LATENCY_K` | `goal_drift_latency_k` | 3.0 | Sigmas above baseline mean counting as drift |
+| `SNAGLINE_GOAL_DRIFT_MIN_SAMPLES` | `goal_drift_min_samples` | 10 | Live steps before scoring an episode |
+| `SNAGLINE_GOAL_DRIFT_SCORE_THRESHOLD` | `goal_drift_score_threshold` | 0.5 | Emit a goal-drift risk above this score |
+| `SNAGLINE_ML_ENSEMBLE_ENABLED` | `ml_ensemble_enabled` | False | Wrap detectors in MLOrchestrator (noisy-OR) |
+| `SNAGLINE_ML_ENSEMBLE_SCORE_THRESHOLD` | `ml_ensemble_score_threshold` | 0.5 | Emit a combined risk above this score |
+| `SNAGLINE_LOOP_NEAR_DUPLICATE_ENABLED` | `loop_near_duplicate_enabled` | False | Loop hardening: collapse volatile ids before hashing |
+| `SNAGLINE_LOOP_CYCLE_ENABLED` | `loop_cycle_enabled` | False | Loop hardening: periodic A,B,A,B cycle scan |
+| `SNAGLINE_LOOP_CYCLE_WINDOW_SIZE` | `loop_cycle_window_size` | 12 | Window scanned for cycles |
+| `SNAGLINE_LOOP_CYCLE_MIN_PERIOD` | `loop_cycle_min_period` | 2 | Shortest repeating period considered |
+| `SNAGLINE_LOOP_CYCLE_MAX_PERIOD` | `loop_cycle_max_period` | 6 | Longest repeating period considered |
+| `SNAGLINE_LOOP_STALL_ENABLED` | `loop_stall_enabled` | False | Loop hardening: identical-signature stall detection |
+| `SNAGLINE_LOOP_STALL_STEPS` | `loop_stall_steps` | 25 | Consecutive identical steps before firing |
+| `SNAGLINE_STAGNATION_ENABLED` | `stagnation_enabled` | False | Enable StagnationDetector (novelty-rate collapse) |
+| `SNAGLINE_STAGNATION_WINDOW_SIZE` | `stagnation_window_size` | 50 | Novelty window (steps) |
+| `SNAGLINE_STAGNATION_MIN_NOVELTY` | `stagnation_min_novelty` | 0.05 | Stale when fewer than this share of steps are new |
+| `SNAGLINE_STAGNATION_PATIENCE` | `stagnation_patience` | 2 | Consecutive stale windows before firing |
+| `SNAGLINE_TOKEN_RUNAWAY_ENABLED` | `token_runaway_enabled` | False | Enable TokenRunawayDetector (needs token telemetry) |
+| `SNAGLINE_TOKEN_CUSUM_K` | `token_cusum_k` | 0.5 | Token-burn CUSUM slack |
+| `SNAGLINE_TOKEN_CUSUM_H` | `token_cusum_h` | 5.0 | Token-burn CUSUM alarm threshold |
+| `SNAGLINE_TOKEN_MIN_SAMPLES` | `token_min_samples` | 20 | Warm-up before sustained-burn alarms |
+| `SNAGLINE_EPISODE_TOKEN_BUDGET` | `episode_token_budget` | *(unset)* | Per-episode token budget; unset disables the envelope |
+| `SNAGLINE_TOKEN_BUDGET_WARN_FRACTION` | `token_budget_warn_fraction` | 0.8 | Warn at this fraction of the budget |
+| `SNAGLINE_MELTDOWN_ENABLED` | `meltdown_enabled` | False | Enable MeltdownDetector (tool entropy collapse/churn) |
+| `SNAGLINE_MELTDOWN_WINDOW_SIZE` | `meltdown_window_size` | 20 | Entropy window (tool calls) |
+| `SNAGLINE_MELTDOWN_LOW_ENTROPY` | `meltdown_low_entropy` | 0.4 | Below this many bits the window is rote collapse |
+| `SNAGLINE_MELTDOWN_HIGH_ENTROPY` | `meltdown_high_entropy` | 2.8 | Above this many bits the window is thrash |
+| `SNAGLINE_MELTDOWN_REARM_STEPS` | `meltdown_rearm_steps` | 10 | In-band steps before re-arming |
+| `SNAGLINE_SILENT_ABORT_ENABLED` | `silent_abort_enabled` | False | Silent-abort check at end of episode |
+| `SNAGLINE_CALIBRATION` | `calibration` | manual | manual, or auto to derive thresholds from a baseline |
+| `SNAGLINE_CALIBRATION_ALPHA` | `calibration_alpha` | 0.001 | False-alarm probability budget per window evaluation |
+| `SNAGLINE_CALIBRATION_BASELINE_PATH` | `calibration_baseline_path` | *(unset)* | Path to a saved BaselineProfile for auto calibration |
+| `SNAGLINE_FAIL_OPEN` | `fail_open` | True | Swallow detector/sink exceptions instead of propagating |
+| `SNAGLINE_LOG_FORMAT` | `log_format` | text | text or json; json installs LoggingSink next to ConsoleSink |
+| `SNAGLINE_METRICS_FORMAT` | `metrics_format` | prometheus | Sidecar GET /metrics body: prometheus or classic |
+
+A handful of variables sit outside `Config` because they are consumed
+directly by one component each:
+
+| Environment variable | Used by | Meaning |
+|---|---|---|
+| `SNAGLINE_SERVE_AUTH_TOKEN` | `snagline serve` | Bearer token fallback when `--auth-token` is not passed |
+| `SNAGLINE_STATE_BACKEND` | snapshot/state backend | `memory` (default) or `redis` |
+| `SNAGLINE_STATE_REDIS_URL` | redis state backend | Redis URL when the backend is `redis` |
+
 ## Empirical Verification
 
 SNAGLINE is verified not just with unit tests, but against real LLM agents, live protocol boundaries, and real HTTP pipelines.
@@ -331,7 +406,7 @@ Sinks consume `FailureRisk` and escalate it. Only `FailureRisk` fields are ever 
 |:--|:--|:--|:--|
 | **Console** (default) | `sinks/console.py` | (built-in) | Writes `FailureRisk` as a JSON line to stderr. Zero dependency. |
 | **Webhook** | `sinks/webhook.py` | (built-in) | POSTs `FailureRisk` JSON via stdlib `urllib.request`. Fire-and-forget with a short timeout (default 2s). Silently ignores a dead endpoint. |
-| **Logging** | `sinks/logging_sink.py` | (built-in) | Emits one compact JSON object per risk on the `snagline` logger for log aggregators (`Config.log_format`: `text` or `json`, env `SNAGLINE_LOG_FORMAT`). Fail-open with a plain-text fallback if serialization breaks. Zero dependency. |
+| **Logging** | `sinks/logging_sink.py` | (built-in) | Emits one compact JSON object per risk on the `snagline` logger for log aggregators (`Config.log_format`: `text` or `json`, env `SNAGLINE_LOG_FORMAT`). Wired end to end: with `json`, `Monitor.default()` and every CLI run path install it next to ConsoleSink. Fail-open with a plain-text fallback if serialization breaks. Zero dependency. |
 
 Custom sinks implement the `AlertSink` protocol:
 

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -106,7 +106,26 @@ def _maybe_dedup(sinks: list[AlertSink], cooldown_seconds: float) -> list[AlertS
     return [DedupSink(s, cooldown_seconds=cooldown_seconds) for s in sinks]
 
 
-def _build_sinks(args: argparse.Namespace) -> list[AlertSink]:
+def _console_sinks(cfg: Config) -> list[AlertSink]:
+    """Console escalation plus LoggingSink when ``log_format == "json"``.
+
+    Issue #99 settled composition as emission "alongside console"; issue #119
+    wires the knob end to end so ``SNAGLINE_LOG_FORMAT=json`` makes risks
+    machine-readable with zero code changes, everywhere the console sink is
+    the default choice. Explicit non-console ``--sink`` selections replace the
+    console pair entirely and stay untouched.
+    """
+    from snagline.sinks.console import ConsoleSink
+
+    pair: list[AlertSink] = [ConsoleSink()]
+    if cfg.log_format == "json":
+        from snagline.sinks.logging_sink import LoggingSink
+
+        pair.append(LoggingSink())
+    return pair
+
+
+def _build_sinks(args: argparse.Namespace, cfg: Config) -> list[AlertSink]:
     """Resolve the escalation sinks from --sink / --slack-url / --pagerduty-key.
 
     Unknown/invalid combinations fail closed with a clear stderr message and a
@@ -141,9 +160,7 @@ def _build_sinks(args: argparse.Namespace) -> list[AlertSink]:
             )
         )
     else:
-        from snagline.sinks.console import ConsoleSink
-
-        sinks.append(ConsoleSink())
+        sinks.extend(_console_sinks(cfg))
     return _maybe_dedup(sinks, args.cooldown_seconds)
 
 
@@ -415,12 +432,15 @@ def _iter_lines(path: str | None, follow: bool) -> Iterator[str]:
 
 
 def _cmd_watch(args: argparse.Namespace) -> int:
+    # Resolve the effective config once (config file -> SNAGLINE_* env) so
+    # log_format and every other knob layer identically across subcommands.
+    cfg = _build_config(args)
     try:
-        sinks = _build_sinks(args)
+        sinks = _build_sinks(args, cfg)
     except SystemExit as exc:
         return int(exc.code or 2)
     monitor = Monitor.default(
-        config=_build_config(args),
+        config=cfg,
         sinks=_maybe_dedup(sinks, args.cooldown_seconds),
     )
     episode = args.episode_id or (args.file or "stdin")
@@ -695,8 +715,9 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
 def _cmd_serve(args: argparse.Namespace) -> int:
     from snagline.server.http_server import serve
 
+    cfg = _build_config(args)
     try:
-        sinks = _build_sinks(args)
+        sinks = _build_sinks(args, cfg)
     except SystemExit as exc:
         return int(exc.code or 2)
     # Prefer the flag, fall back to the environment so the secret need not
@@ -714,7 +735,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         )
     with suppress(KeyboardInterrupt):
         serve(
-            Monitor.default(config=_build_config(args), sinks=sinks),
+            Monitor.default(config=cfg, sinks=sinks),
             host=args.host,
             port=args.port,
             auth_token=auth_token,
@@ -788,14 +809,15 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     if args.command == "replay":
-        sinks: list[AlertSink] = []
         counter = _CountingSink()
+        cfg = _build_config(args)
+        sinks: list[AlertSink] = []
         if not args.quiet:
-            from snagline.sinks.console import ConsoleSink
-
-            sinks.append(ConsoleSink())
+            # Same composition as Monitor.default(): console plus, for
+            # log_format="json", LoggingSink alongside it (issues #99/#119).
+            sinks.extend(_console_sinks(cfg))
         sinks.append(counter)
-        monitor = Monitor.default(config=_build_config(args), sinks=sinks)
+        monitor = Monitor.default(config=cfg, sinks=sinks)
         steps = replay(args.trajectory, monitor=monitor)
         if args.summary:
             print(

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -71,6 +71,28 @@ def _load_toml(text: str) -> dict[str, Any]:
     return tomllib.loads(text)
 
 
+# Valid values for ``Config.log_format`` (issue #119). Anything else is a
+# configuration error and fails loudly at construction/resolve time instead
+# of being silently accepted and left undefined downstream.
+LOG_FORMATS: tuple[str, ...] = ("text", "json")
+
+
+def _validated_log_format(value: str) -> str:
+    """Normalize and validate a ``log_format`` value; raise when invalid.
+
+    Surrounding whitespace and case are forgiven (" JSON " means "json") so
+    operators are not punished for spelling, but anything outside
+    ``LOG_FORMATS`` raises ``ValueError`` (issue #119): an undefined value used
+    to be silently accepted, which hid typos until exactly the moment someone
+    relied on the knob.
+    """
+    normalized = value.strip().lower() if isinstance(value, str) else value
+    if normalized not in LOG_FORMATS:
+        allowed = ", ".join(repr(v) for v in LOG_FORMATS)
+        raise ValueError(f"log_format must be one of {allowed}; got {value!r}")
+    return normalized
+
+
 @dataclass
 class Config:
     # Loop detector
@@ -201,7 +223,10 @@ class Config:
     # "text" keeps plain lines, "json" emits one compact JSON object per risk
     # with exactly the keys ts, episode_id, step_id, trigger, severity, score,
     # detail. Selectable via env ``SNAGLINE_LOG_FORMAT`` or a config-file
-    # ``log_format`` key; values other than "text"/"json" are undefined.
+    # ``log_format`` key. Values outside {"text", "json"} raise ValueError at
+    # construction/resolve time (issue #119); when "json" is selected,
+    # Monitor.default() and the CLI install LoggingSink next to ConsoleSink
+    # so SNAGLINE_LOG_FORMAT=json needs zero code changes.
     # Structure only: the emitted object never carries prompt/response content.
     log_format: str = "text"
 
@@ -211,6 +236,11 @@ class Config:
     # counters body. Per-request override via ?format=classic or
     # ?format=prometheus; environment override SNAGLINE_METRICS_FORMAT.
     metrics_format: str = "prometheus"
+
+    def __post_init__(self) -> None:
+        # Issue #119: an invalid log_format is a configuration error and must
+        # fail loudly here instead of being silently ignored downstream.
+        self.log_format = _validated_log_format(self.log_format)
 
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
@@ -305,4 +335,7 @@ class Config:
             environ=environ, prefix=prefix
         ).items():
             setattr(cfg, name, value)
+        # setattr bypasses __post_init__, so re-validate the fields that carry
+        # a closed value set after env layering (issue #119).
+        cfg.log_format = _validated_log_format(cfg.log_format)
         return cfg

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -409,7 +409,16 @@ class Monitor:
 
         Wires up the three tier-1 detectors that ship in this build
         (loop, error-cascade, and the latency-anomaly/CUSUM detector) and,
-        unless ``sinks`` is given, the console sink.
+        unless ``sinks`` is given, the console sink. With
+        ``config.log_format == "json"`` (env ``SNAGLINE_LOG_FORMAT=json``),
+        LoggingSink is installed next to ConsoleSink so risk emission is also
+        machine-readable JSON lines on the ``snagline`` logger (issues #99 and
+        #119). Explicitly passed ``sinks`` lists are honored verbatim.
+
+        With no ``config``, the effective ``Config`` is resolved through the
+        12-factor layering (defaults < config file < ``SNAGLINE_*`` env vars,
+        via ``Config.resolve()``), so ``SNAGLINE_LOG_FORMAT=json`` works with
+        zero code changes. Pass an explicit ``Config`` to pin every knob.
         """
         from snagline.detectors.error_cascade import ErrorCascadeDetector
         from snagline.detectors.goal_drift import GoalDriftDetector
@@ -421,8 +430,12 @@ class Monitor:
         from snagline.detectors.stagnation import StagnationDetector
         from snagline.detectors.token_runaway import TokenRunawayDetector
         from snagline.sinks.console import ConsoleSink
+        from snagline.sinks.logging_sink import LoggingSink
 
-        cfg = config or Config()
+        # No explicit config: resolve the 12-factor layering so bare
+        # Monitor.default() callers (examples, hooks) honor SNAGLINE_* env
+        # vars exactly like the CLI does (issue #119 acceptance).
+        cfg = config or Config.resolve()
         # Auto-calibration (issue #101): opt-in via calibration="auto" plus a
         # healthy BaselineProfile; None keeps every hand-tuned constant.
         cal = _auto_calibration_plan(cfg)
@@ -480,7 +493,16 @@ class Monitor:
             detectors: list[Detector] = [MLOrchestrator(base, config=cfg)]
         else:
             detectors = list(base)
-        chosen_sinks: list[AlertSink] = sinks if sinks is not None else [ConsoleSink()]
+        if sinks is not None:
+            chosen_sinks: list[AlertSink] = list(sinks)
+        else:
+            # Default composition (issues #99/#119): console stays the human
+            # channel; log_format="json" adds LoggingSink NEXT TO it (the
+            # agreed "alongside console" semantics) so SNAGLINE_LOG_FORMAT=json
+            # makes risks machine-readable with zero code changes.
+            chosen_sinks = [ConsoleSink()]
+            if cfg.log_format == "json":
+                chosen_sinks.append(LoggingSink())
         monitor = cls(detectors, chosen_sinks, fail_open=cfg.fail_open)
         # Set after construction so subclasses with a fixed __init__ signature
         # (e.g. test doubles) still work; base Monitor.__init__ also sets it.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -7,6 +7,7 @@ import json
 from argparse import Namespace
 
 from snagline.cli import main
+from snagline.config import Config
 from snagline.sinks.dedup import DedupSink
 from snagline.sinks.pagerduty import PagerDutySink
 from snagline.sinks.slack import SlackSink
@@ -30,7 +31,7 @@ def test_build_sinks_console_default():
     from snagline.cli import _build_sinks
     from snagline.sinks.console import ConsoleSink
 
-    sinks = _build_sinks(_args())
+    sinks = _build_sinks(_args(), Config())
     assert len(sinks) == 1
     assert isinstance(sinks[0], ConsoleSink)
 
@@ -38,9 +39,11 @@ def test_build_sinks_console_default():
 def test_build_sinks_slack_and_pagerduty():
     from snagline.cli import _build_sinks
 
-    assert isinstance(_build_sinks(_args(sink="slack", slack_url="u")).pop(), SlackSink)
     assert isinstance(
-        _build_sinks(_args(sink="pagerduty", pagerduty_key="k")).pop(),
+        _build_sinks(_args(sink="slack", slack_url="u"), Config()).pop(), SlackSink
+    )
+    assert isinstance(
+        _build_sinks(_args(sink="pagerduty", pagerduty_key="k"), Config()).pop(),
         PagerDutySink,
     )
 
@@ -51,17 +54,17 @@ def test_build_sinks_requires_url():
     from snagline.cli import _build_sinks
 
     with pytest.raises(SystemExit) as exc:
-        _build_sinks(_args(sink="slack"))
+        _build_sinks(_args(sink="slack"), Config())
     assert exc.value.code == 2
     with pytest.raises(SystemExit) as exc:
-        _build_sinks(_args(sink="pagerduty"))
+        _build_sinks(_args(sink="pagerduty"), Config())
     assert exc.value.code == 2
 
 
 def test_build_sinks_cooldown_wraps():
     from snagline.cli import _build_sinks
 
-    sinks = _build_sinks(_args(sink="console", cooldown_seconds=60.0))
+    sinks = _build_sinks(_args(sink="console", cooldown_seconds=60.0), Config())
     assert len(sinks) == 1
     assert isinstance(sinks[0], DedupSink)
 

--- a/tests/test_log_format_operational.py
+++ b/tests/test_log_format_operational.py
@@ -1,0 +1,46 @@
+"""Loud validation of ``Config.log_format`` / ``SNAGLINE_LOG_FORMAT`` (issue #119).
+
+Values outside {"text", "json"} raise ValueError at construction or resolve
+time instead of silently doing nothing; case and surrounding whitespace are
+normalized so operators are not punished for spelling.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from snagline.config import Config
+
+
+def test_log_format_defaults_to_text():
+    assert Config().log_format == "text"
+
+
+def test_constructor_rejects_invalid_log_format():
+    with pytest.raises(ValueError, match="log_format must be one of"):
+        Config(log_format="yaml")
+
+
+def test_constructor_normalizes_case_and_whitespace():
+    assert Config(log_format=" JSON ").log_format == "json"
+
+
+@pytest.mark.parametrize("value", ["xml", "JSONL", "", "text,json"])
+def test_invalid_values_are_rejected_everywhere(value, tmp_path):
+    with pytest.raises(ValueError, match="log_format"):
+        Config(log_format=value)
+    with pytest.raises(ValueError, match="log_format"):
+        Config.from_env({"SNAGLINE_LOG_FORMAT": value})
+    with pytest.raises(ValueError, match="log_format"):
+        Config.resolve(environ={"SNAGLINE_LOG_FORMAT": value})
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps({"log_format": value}), encoding="utf-8")
+    with pytest.raises(ValueError, match="log_format"):
+        Config.load_file(str(path))
+
+
+def test_resolve_env_layering_still_applies_valid_json():
+    cfg = Config.resolve(environ={"SNAGLINE_LOG_FORMAT": " json "})
+    assert cfg.log_format == "json"

--- a/tests/test_log_format_operational.py
+++ b/tests/test_log_format_operational.py
@@ -1,17 +1,80 @@
-"""Loud validation of ``Config.log_format`` / ``SNAGLINE_LOG_FORMAT`` (issue #119).
+"""End-to-end wiring of ``Config.log_format`` / ``SNAGLINE_LOG_FORMAT`` (#119).
 
-Values outside {"text", "json"} raise ValueError at construction or resolve
-time instead of silently doing nothing; case and surrounding whitespace are
-normalized so operators are not punished for spelling.
+Every contract here is tested from BOTH sides:
+
+* fire side: ``log_format="json"`` makes risks surface as machine-readable
+  JSON lines on the ``snagline`` logger through ``Monitor.default()``,
+  ``watch``, and ``replay`` with zero code changes;
+* silence side: the default ``"text"`` keeps that logging channel silent,
+  and an explicitly passed ``sinks`` list is never augmented.
+
+Validation is loud: values outside {"text", "json"} raise ValueError at
+construction or resolve time instead of silently doing nothing.
 """
 
 from __future__ import annotations
 
 import json
+import logging
+from pathlib import Path
 
 import pytest
 
-from snagline.config import Config
+from snagline import Config, Monitor
+from snagline.cli import _build_parser, _build_sinks, main
+from snagline.events import StepEvent
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _event(i: int, sig: str | None = None) -> dict:
+    """A healthy step; latency-free so only injected loops can fire."""
+    return {
+        "step_id": str(i),
+        "episode_id": "ep-log",
+        "timestamp": 1_000.0 + i,
+        "action_type": "tool_call",
+        "action_signature": sig or f"unique-{i}",
+        "tool_name": "search",
+    }
+
+
+def _trajectory(tmp_path: Path) -> Path:
+    """Healthy steps plus one injected repetition loop (fires the detector)."""
+    events = [_event(i) for i in range(5)]
+    events += [_event(100, sig="retry-same-attempt") for _ in range(4)]
+    path = tmp_path / "loop.jsonl"
+    path.write_text("".join(json.dumps(e) + "\n" for e in events), encoding="utf-8")
+    return path
+
+
+class _FakeStdin:
+    def __init__(self, lines: list[str]) -> None:
+        self._lines = lines
+
+    def __iter__(self):
+        return iter(self._lines)
+
+
+class _MarkerSink:
+    """Explicit caller-provided sink; must never be augmented or replaced."""
+
+    def __init__(self) -> None:
+        self.risks: list = []
+
+    def emit(self, risk) -> None:
+        self.risks.append(risk)
+
+
+def _snagline_records(caplog) -> list:
+    return [r for r in caplog.records if r.name == "snagline"]
+
+
+# ---------------------------------------------------------------------------
+# config validation (loud failure, never silent no-op)
+# ---------------------------------------------------------------------------
 
 
 def test_log_format_defaults_to_text():
@@ -44,3 +107,137 @@ def test_invalid_values_are_rejected_everywhere(value, tmp_path):
 def test_resolve_env_layering_still_applies_valid_json():
     cfg = Config.resolve(environ={"SNAGLINE_LOG_FORMAT": " json "})
     assert cfg.log_format == "json"
+
+
+# ---------------------------------------------------------------------------
+# Monitor.default() composition (issues #99/#119)
+# ---------------------------------------------------------------------------
+
+
+def test_default_monitor_with_text_installs_console_only(monkeypatch):
+    monkeypatch.delenv("SNAGLINE_LOG_FORMAT", raising=False)
+    monitor = Monitor.default(Config())
+    assert [type(s).__name__ for s in monitor._sinks] == ["ConsoleSink"]
+
+
+def test_default_monitor_with_json_adds_logging_next_to_console():
+    monitor = Monitor.default(Config(log_format="json"))
+    # Order matters: LoggingSink sits NEXT TO ConsoleSink ("alongside
+    # console"), it does not replace it.
+    assert [type(s).__name__ for s in monitor._sinks] == [
+        "ConsoleSink",
+        "LoggingSink",
+    ]
+
+
+def test_default_monitor_never_augments_explicit_sinks_even_for_json():
+    marker = _MarkerSink()
+    monitor = Monitor.default(Config(log_format="json"), sinks=[marker])
+    assert monitor._sinks == [marker]
+
+
+def test_bare_default_monitor_resolves_env_for_json(monkeypatch):
+    """Acceptance path: no config object, zero code changes, env only."""
+    monkeypatch.setenv("SNAGLINE_LOG_FORMAT", "json")
+    monitor = Monitor.default()
+    assert [type(s).__name__ for s in monitor._sinks] == [
+        "ConsoleSink",
+        "LoggingSink",
+    ]
+
+
+def test_bare_default_monitor_stays_console_only_without_the_env(monkeypatch):
+    monkeypatch.delenv("SNAGLINE_LOG_FORMAT", raising=False)
+    monitor = Monitor.default()
+    assert [type(s).__name__ for s in monitor._sinks] == ["ConsoleSink"]
+
+
+# ---------------------------------------------------------------------------
+# CLI sink selection honors the knob through Config.resolve()
+# ---------------------------------------------------------------------------
+
+
+def test_cli_watch_sink_selection_text_vs_json(monkeypatch):
+    args = _build_parser().parse_args(["watch"])
+    monkeypatch.delenv("SNAGLINE_LOG_FORMAT", raising=False)
+    assert [type(s).__name__ for s in _build_sinks(args, Config())] == ["ConsoleSink"]
+    assert [
+        type(s).__name__ for s in _build_sinks(args, Config(log_format="json"))
+    ] == ["ConsoleSink", "LoggingSink"]
+
+
+def test_cli_serve_sink_selection_honors_json():
+    args = _build_parser().parse_args(["serve"])
+    assert [
+        type(s).__name__ for s in _build_sinks(args, Config(log_format="json"))
+    ] == ["ConsoleSink", "LoggingSink"]
+
+
+# ---------------------------------------------------------------------------
+# end-to-end: SNAGLINE_LOG_FORMAT=json with zero code changes
+# ---------------------------------------------------------------------------
+
+_JSON_KEYS = {"ts", "episode_id", "step_id", "trigger", "severity", "score", "detail"}
+
+
+def test_replay_with_json_env_emits_parseable_json_lines(tmp_path, caplog, monkeypatch):
+    monkeypatch.setenv("SNAGLINE_LOG_FORMAT", "json")
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        rc = main(["replay", str(_trajectory(tmp_path))])
+    assert rc == 0
+    records = _snagline_records(caplog)
+    # Fire side: the injected loop surfaces as structured lines on the logger.
+    assert records, "expected at least one risk record on the snagline logger"
+    parsed = [json.loads(r.getMessage()) for r in records]
+    for obj in parsed:
+        assert set(obj) == _JSON_KEYS
+    assert any(obj["trigger"] == "loop" for obj in parsed)
+
+
+def test_replay_with_text_keeps_the_logging_channel_silent(
+    tmp_path, caplog, capsys, monkeypatch
+):
+    monkeypatch.delenv("SNAGLINE_LOG_FORMAT", raising=False)
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        rc = main(["replay", str(_trajectory(tmp_path))])
+    assert rc == 0
+    # Silence side: no logging records at all in text mode...
+    assert _snagline_records(caplog) == []
+    # ...but humans still see the risk on stderr through the console sink.
+    err = capsys.readouterr().err
+    assert '"trigger": "loop"' in err
+
+
+def test_watch_with_json_env_emits_json_lines_without_code_changes(monkeypatch, caplog):
+    monkeypatch.setenv("SNAGLINE_LOG_FORMAT", "json")
+    events = [_event(i) for i in range(2)]
+    events += [_event(50 + i, sig="watch-loop-sig") for i in range(3)]
+    monkeypatch.setattr("sys.stdin", _FakeStdin([json.dumps(e) for e in events]))
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        rc = main(["watch"])
+    assert rc == 0
+    records = _snagline_records(caplog)
+    assert records, "expected the injected loop to reach the logging channel"
+    parsed = [json.loads(r.getMessage()) for r in records]
+    assert {set(obj) == _JSON_KEYS for obj in parsed} == {True}
+    assert any(obj["trigger"] == "loop" for obj in parsed)
+
+
+def test_watch_text_mode_logs_nothing(monkeypatch, caplog):
+    monkeypatch.delenv("SNAGLINE_LOG_FORMAT", raising=False)
+    events = [_event(i) for i in range(2)]
+    events += [_event(50 + i, sig="watch-loop-sig") for i in range(3)]
+    monkeypatch.setattr("sys.stdin", _FakeStdin([json.dumps(e) for e in events]))
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        rc = main(["watch"])
+    assert rc == 0
+    assert _snagline_records(caplog) == []
+
+
+def test_healthy_unique_steps_fire_nothing_on_a_default_monitor():
+    """No-false-positive side: 20 unique-signature steps stay silent."""
+    marker = _MarkerSink()
+    monitor = Monitor.default(Config(), sinks=[marker])
+    for i in range(20):
+        monitor.ingest(StepEvent(**_event(i)))
+    assert marker.risks == []


### PR DESCRIPTION
## Summary

Makes `SNAGLINE_LOG_FORMAT` / `Config.log_format` operational end to end (issue #119). The knob was documented by #99/#111 but consumed nowhere in core: `Monitor.default()` always installed ConsoleSink alone, and every CLI path appended ConsoleSink directly, so setting the env var changed nothing unless a user constructed LoggingSink manually.

What changed:

- **Loud validation** (`config.py`): values outside {"text", "json"} now raise ValueError at construction and again after env layering in `Config.resolve()` (setattr bypasses `__post_init__`, so resolve re-validates). Case and surrounding whitespace are normalized (" JSON " means "json") so operators are not punished for spelling; genuinely invalid values fail with the allowed set in the message. Previously any other string was silently accepted and undefined.
- **Monitor.default() composition** (`monitor.py`, default() only): with an effective `log_format == "json"`, LoggingSink is installed NEXT TO ConsoleSink, per the "alongside console" wording agreed in #99. Explicitly passed `sinks` lists are honored verbatim (never augmented). Bare `Monitor.default()` callers now get their Config through `Config.resolve()` so the env var works with zero code changes; passing an explicit `Config` pins behavior exactly as before.
- **CLI** (`cli.py`): `watch`, `serve`, and `replay` share a `_console_sinks()` helper pairing ConsoleSink with LoggingSink under json, so config file -> env layering behaves identically on every run path. Explicit non-console `--sink` selections replace the console pair entirely and stay untouched. `_build_sinks` gained a required `cfg` parameter; the four existing call sites in tests/test_cli.py were updated for the signature with zero assertion changes.
- **README**: the consolidated environment-variable/config-key table #111 deferred, generated from the dataclass itself so names/defaults cannot drift (47 scalar keys), plus the three component-specific variables outside Config (`SNAGLINE_SERVE_AUTH_TOKEN`, `SNAGLINE_STATE_BACKEND`, `SNAGLINE_STATE_REDIS_URL`) and the layering rules.

Scope note: monitor.py changes are confined to `default()` (diff hunks at lines 409-500); `ingest()` is untouched.

## Verification

Acceptance criterion from the issue, run against an untouched example:

```
$ SNAGLINE_LOG_FORMAT=json PYTHONPATH=src python examples/raw_loop_example.py
logging-channel JSON lines: 8
['detail', 'episode_id', 'score', 'severity', 'step_id', 'trigger', 'ts'] loop
['detail', 'episode_id', 'score', 'severity', 'step_id', 'trigger', 'ts'] error_cascade
['detail', 'episode_id', 'score', 'severity', 'step_id', 'trigger', 'ts'] latency_anomaly

$ SNAGLINE_LOG_FORMAT=json PYTHONPATH=src python examples/raw_loop_example.py --healthy
JSON lines on healthy run (expect 0): 0
```

Full gate on the tip commit (macOS, CPython 3.14):

```
$ python -m pytest tests/ -q -o addopts=""
407 passed, 1 skipped in 30.60s
$ ruff check src tests && ruff format --check src tests
All checks passed!
98 files already formatted
$ mypy src
Success: no issues found in 47 source files
```

CI-parity coverage leg:

```
$ python -m pytest tests/ -q
Required test coverage of 80% reached. Total coverage: 86.22%
407 passed, 1 skipped in 31.05s
```

Mutation check (anti-cheat, per repo rules): I inverted the validation comparison in `_validated_log_format` (`not in` -> `in`) on purpose and reran pytest: 20 tests of mine went red (`test_constructor_rejects_invalid_log_format`, the parametrized reject-everywhere cases, and the downstream wiring tests). Reverted the mutation; full suite green again (407 passed). Every test can fail; no assertion was weakened to get green, nothing was skipped or deleted, and no expected value is computed by calling the function under test.

Both sides are covered for each contract: json fires parseable lines with exactly the seven keys (ts, episode_id, step_id, trigger, severity, score, detail) through replay AND watch; text keeps the logging channel silent while risks still reach stderr via console; explicit sinks stay untouched even under json; healthy sequences fire nothing.

Fixes #119
Board: #106
Refs #99, #111
