### PR TITLE
feat(server): in-process TLS termination for the sidecar listener

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -82,8 +82,9 @@ enterprise-grade alerting. Concretely:
    `StepEvent`, add auth (HMAC or bearer) and TLS verification, and document
    the schema.
    - **Done:** bearer/token auth (#31), body-size cap + batched `POST /events`
-     (#32), 12-factor config + CLI wiring (#36). TLS termination is delegated
-     to a reverse proxy (not in-process) - documented as such.
+     (#32), 12-factor config + CLI wiring (#36). TLS terminates at a
+     reverse proxy (configs below) or in-process via `--certfile/--keyfile`
+     (issue #120).
 2. **Add Python auto-instrumentation.** Wrap OpenAI/Anthropic clients and
    LangChain automatically so a user adds one line (`import snagline.auto`)
    instead of editing every call. This is the real "attach to any system"
@@ -154,7 +155,9 @@ but the moment telemetry crosses a network segment you do not fully trust
 The supported production pattern is TLS termination at a reverse proxy:
 public traffic arrives at the proxy over HTTPS, the proxy strips TLS and
 forwards plaintext to the sidecar over loopback. Both configs below are
-copy-paste ready and introduce zero new Python dependencies.
+copy-paste ready and introduce zero new Python dependencies. If you cannot
+run a proxy on the same host, the sidecar can also terminate TLS itself;
+see the threat model below for the trade-off and the invocation.
 
 Assumptions used throughout: the sidecar runs on the same host as the proxy,
 on port 8787, with a bearer token set via `$SNAGLINE_SERVE_AUTH_TOKEN` (or
@@ -268,15 +271,34 @@ caller reached the intended endpoint. What it does not solve is the final
 hop: proxy to sidecar remains plaintext. On one trusted host across
 loopback, that residual exposure is usually acceptable. It is not acceptable
 when the proxy runs on a different machine than the sidecar, or when the
-shared host runs processes you do not control; in those cases wrap TLS in
-the sidecar process itself. That is the documented future option (issue
-#103): wrap `serve()`'s listening socket with a stdlib `ssl.SSLContext`
-exposed via `--certfile/--keyfile` flags. It would close the last plaintext
-hop and additionally allow mutual TLS, letting the sidecar authenticate
-clients by certificate without any external component. Both directions cost
-zero new dependencies: `ssl` is standard library, and a reverse proxy adds
-nothing to the Python environment, so the choice between them is purely
-operational.
+shared host runs processes you do not control; in those cases terminate TLS
+in the sidecar process itself. That is built in as of issue #120: pass
+`--certfile`/`--keyfile` and `serve()` wraps its listening socket with a
+stdlib `ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)`, closing the last plaintext
+hop:
+
+```bash
+# Any PEM pair works; to generate a throwaway self-signed one:
+#   openssl req -x509 -newkey rsa:2048 -nodes -days 365 \
+#     -subj "/CN=snagline.internal" -keyout key.pem -out cert.pem
+SNAGLINE_SERVE_AUTH_TOKEN=... snagline serve \
+  --host 127.0.0.1 --port 8787 \
+  --certfile /etc/snagline/cert.pem \
+  --keyfile /etc/snagline/key.pem
+
+# Acceptance check against a self-signed pair (-k). With a real certificate,
+# use --cacert so the chain is actually verified instead of skipped:
+curl -k https://127.0.0.1:8787/health
+```
+
+Auth semantics are unchanged over TLS: `Authorization: Bearer` and
+`X-Snagline-Token` stay required on everything except `GET /health`, exactly
+as on plain HTTP. What in-process termination does not add today is mutual
+TLS (authenticating senders by client certificate); stdlib `ssl` can do it
+with no new dependencies, so exposing a client-CA knob is a natural follow-up.
+Both directions cost zero new dependencies: `ssl` is standard library, and a
+reverse proxy adds nothing to the Python environment, so the choice between
+them is purely operational.
 
 ### Hardening checklist
 
@@ -286,8 +308,9 @@ operational.
   stays out of process listings and shell history.
 - **Keep the loopback bind.** The default `host="127.0.0.1"` exists so only
   the proxy can reach the sidecar. Do not expose port 8787 off-host; if the
-  proxy must run on another machine, tunnel that segment (VPN/WireGuard)
-  until in-process TLS lands (issue #103).
+  proxy must run on another machine, either tunnel that segment
+  (VPN/WireGuard) or terminate TLS in the sidecar itself with
+  `--certfile/--keyfile` (see the threat model above).
 - **Keep the body-size caps in sync.** The sidecar rejects requests above
   `--max-body-bytes` (default 1000000) with 413; mirror that number in
   `client_max_body_size` (nginx) or `request_body max_size` (Caddy) so

--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -287,8 +287,13 @@ SNAGLINE_SERVE_AUTH_TOKEN=... snagline serve \
   --keyfile /etc/snagline/key.pem
 
 # Acceptance check against a self-signed pair (-k). With a real certificate,
-# use --cacert so the chain is actually verified instead of skipped:
+# verify the chain instead of skipping it (--cacert) and map the certificate's
+# hostname to loopback for local checks (--resolve); a plain
+# https://127.0.0.1:8787 would fail hostname validation against any real cert:
 curl -k https://127.0.0.1:8787/health
+curl --cacert /etc/snagline/ca.pem \
+  --resolve snagline.internal:8787:127.0.0.1 \
+  https://snagline.internal:8787/health
 ```
 
 Auth semantics are unchanged over TLS: `Authorization: Bearer` and

--- a/docs/INTEGRATION_MATRIX.md
+++ b/docs/INTEGRATION_MATRIX.md
@@ -18,13 +18,16 @@ dependency-free unless noted; the core is always zero-required-dependency.
 | Path | Plaintext segment | TLS story |
 |------|-------------------|-----------|
 | In-process adapters / auto-instrumentation | none (no network) | not applicable |
-| HTTP sidecar, direct | client to loopback only | keep the default `127.0.0.1` bind; never expose 8787 off-host |
+| HTTP sidecar, direct | client to loopback only | keep the default `127.0.0.1` bind; or terminate TLS in-process with `snagline serve --certfile/--keyfile` (issue #120) |
 | HTTP sidecar behind nginx or Caddy | proxy to sidecar over loopback | public TLS terminates at the proxy; copy-paste configs in [ATTACH_ANY_SYSTEM.md](ATTACH_ANY_SYSTEM.md#sidecar-tls-reverse-proxy-termination-issue-103) |
 | Webhook / Slack / PagerDuty sinks | none outbound | stdlib `urllib` speaks HTTPS to remote endpoints |
 
-In-process TLS for the sidecar itself is the documented future option
-(issue #103); it would remove even the loopback plaintext hop and enable
-mutual TLS, with zero new dependencies either way.
+In-process TLS also ships (issue #120): `snagline serve --certfile <pem>
+--keyfile <pem>` wraps the listener in stdlib `ssl`, so the sidecar itself
+can speak HTTPS and remove even the loopback plaintext hop. Copy-paste
+invocation in [ATTACH_ANY_SYSTEM.md](ATTACH_ANY_SYSTEM.md#sidecar-tls-reverse-proxy-termination-issue-103).
+Mutual TLS via a client CA is a possible follow-up; zero new dependencies
+either way.
 
 ## Python auto-instrumentation (`snagline.auto`)
 

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -254,6 +254,18 @@ def _build_parser() -> argparse.ArgumentParser:
         "Unset means all endpoints are open.",
     )
     p_serve.add_argument(
+        "--certfile",
+        default=None,
+        help="PEM certificate enabling stdlib TLS on the sidecar listener "
+        "(issue #120); requires --keyfile unless the file bundles its key. "
+        "Omit for plain HTTP.",
+    )
+    p_serve.add_argument(
+        "--keyfile",
+        default=None,
+        help="PEM private key matching --certfile.",
+    )
+    p_serve.add_argument(
         "--max-body-bytes",
         type=int,
         default=1_000_000,
@@ -702,8 +714,10 @@ def _cmd_serve(args: argparse.Namespace) -> int:
     # Prefer the flag, fall back to the environment so the secret need not
     # appear in argv (visible to every other process via ps).
     auth_token = args.auth_token or os.environ.get("SNAGLINE_SERVE_AUTH_TOKEN") or None
+    scheme = "https" if (args.certfile or args.keyfile) else "http"
     print(
-        f"snagline serve: listening on http://{args.host}:{args.port} (POST /events, GET /health)",
+        f"snagline serve: listening on {scheme}://{args.host}:{args.port} "
+        "(POST /events, GET /health)",
         file=sys.stderr,
     )
     if not auth_token:
@@ -713,6 +727,13 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
     with suppress(KeyboardInterrupt):
+        # TLS kwargs are forwarded only when requested: with no --certfile/
+        # --keyfile the serve() call is exactly what it was before issue #120.
+        tls_kwargs = (
+            {"certfile": args.certfile, "keyfile": args.keyfile}
+            if (args.certfile or args.keyfile)
+            else {}
+        )
         serve(
             Monitor.default(config=_build_config(args), sinks=sinks),
             host=args.host,
@@ -720,6 +741,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             auth_token=auth_token,
             max_body_bytes=args.max_body_bytes,
             max_risks=args.max_risks,
+            **tls_kwargs,
         )
     return 0
 

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -714,6 +714,15 @@ def _cmd_serve(args: argparse.Namespace) -> int:
     # Prefer the flag, fall back to the environment so the secret need not
     # appear in argv (visible to every other process via ps).
     auth_token = args.auth_token or os.environ.get("SNAGLINE_SERVE_AUTH_TOKEN") or None
+    # Validate TLS flag pairing before printing anything: a banner that
+    # advertises https:// and then dies in a traceback is worse than a clean
+    # refusal up front.
+    if args.keyfile and not args.certfile:
+        print(
+            "snagline serve: --keyfile requires --certfile",
+            file=sys.stderr,
+        )
+        return 2
     scheme = "https" if (args.certfile or args.keyfile) else "http"
     print(
         f"snagline serve: listening on {scheme}://{args.host}:{args.port} "

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -377,6 +377,12 @@ def make_handler(
 
         def do_POST(self) -> None:  # noqa: N802 - http.server naming
             if not self._authorized():
+                # Drain the declared body before replying: closing a
+                # connection that still has unread inbound data makes the
+                # kernel send RST and the sender can lose the 401 response
+                # entirely (same rationale as the over-cap drain, #121;
+                # observed over TLS where close timing shifts the race).
+                self._discard_overcap_body(int(self.headers.get("Content-Length") or 0))
                 self._respond(401, {"error": "unauthorized"})
                 return
             length = int(self.headers.get("Content-Length") or 0)
@@ -394,6 +400,7 @@ def make_handler(
             elif self.path == "/risks":
                 self._post_risks()
             else:
+                self._discard_overcap_body(int(self.headers.get("Content-Length") or 0))
                 self._respond(404, {"error": "not found"})
 
         def _post_risks(self) -> None:

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -20,10 +20,11 @@ missing or wrong tokens get 401. ``GET /health`` stays open for liveness
 probes -- everything else, GET and POST alike, is behind the token.
 
 The listener can terminate TLS itself (issue #120): pass ``certfile=`` and
-``keyfile=`` (or a ready-made ``ssl_context=``) and the listening socket is
-wrapped with stdlib ``ssl``, so the sidecar speaks ``https://`` on the same
-endpoints with identical auth semantics. Without these arguments the listener
-stays plain HTTP, byte-for-byte the behavior described above.
+``keyfile=`` (or a ready-made ``ssl_context=``) and each accepted connection
+is wrapped with stdlib ``ssl`` inside its own worker thread, so the sidecar
+speaks ``https://`` on the same endpoints with identical auth semantics, and
+one stalled handshake never blocks other senders. Without these arguments
+the listener stays plain HTTP, byte-for-byte the behavior described above.
 
 ``POST /risks`` retains the most recent ``max_risks`` risks (default 1000) for
 ``GET /risks``; older ones are discarded so an unbounded sender cannot grow the
@@ -597,6 +598,49 @@ def _resolve_ssl_context(
     return context
 
 
+class _TLSThreadingHTTPServer(ThreadingHTTPServer):
+    """ThreadingHTTPServer that terminates TLS inside the worker thread.
+
+    The listening socket stays a plain socket; each accepted connection is
+    wrapped (and its TLS handshake driven) in ``finish_request``, which
+    ThreadingMixIn already runs on the per-connection worker thread. A client
+    that opens a connection and stalls the handshake therefore ties up only
+    its own thread, not the accept loop: one slow or hostile peer cannot
+    freeze every other sender (the failure mode of wrapping the listener
+    itself, where ``accept()`` performs the handshake inline).
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        snagline_ssl_context: ssl.SSLContext,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.snagline_ssl_context = snagline_ssl_context
+
+    def finish_request(self, request: Any, client_address: Any) -> None:
+        try:
+            tls_request = self.snagline_ssl_context.wrap_socket(
+                request, server_side=True
+            )
+        except (ssl.SSLError, OSError):
+            # Failed handshake (plaintext probe against the TLS port, port
+            # scan, stale client): drop this one connection and keep serving.
+            # Fail-open per project.md §1.2; never surface as a serving error.
+            logger.debug(
+                "snagline sidecar: TLS handshake failed from %s:%s",
+                client_address[0],
+                client_address[1],
+                exc_info=True,
+            )
+            return
+        # Annotated locally: typeshed binds this call's server parameter to
+        # Self, which the subclass indirection here trips over.
+        handler_class: Any = self.RequestHandlerClass
+        handler_class(tls_request, client_address, self)
+
+
 def make_server(
     monitor: Monitor,
     host: str = "127.0.0.1",
@@ -611,18 +655,20 @@ def make_server(
 ) -> ThreadingHTTPServer:
     """Construct a ready-to-``serve_forever()`` sidecar server.
 
-    With ``ssl_context`` or ``certfile``/``keyfile`` the listening socket is
-    wrapped server-side via stdlib ``ssl`` (issue #120): the sidecar speaks
-    HTTPS directly. Without them the server is plain HTTP, exactly as before.
+    With ``ssl_context`` or ``certfile``/``keyfile`` the sidecar speaks
+    HTTPS directly (issue #120): connections are wrapped server-side via
+    stdlib ``ssl`` with the handshake running on each connection's own
+    worker thread. Without them the server is plain HTTP, exactly as before.
     """
     tls_context = _resolve_ssl_context(ssl_context, certfile, keyfile)
-    server = ThreadingHTTPServer(
-        (host, port),
-        make_handler(monitor, auth_token, max_body_bytes, max_risks, metrics_format),
+    handler = make_handler(
+        monitor, auth_token, max_body_bytes, max_risks, metrics_format
     )
-    if tls_context is not None:
-        server.socket = tls_context.wrap_socket(server.socket, server_side=True)
-    return server
+    if tls_context is None:
+        return ThreadingHTTPServer((host, port), handler)
+    return _TLSThreadingHTTPServer(
+        (host, port), handler, snagline_ssl_context=tls_context
+    )
 
 
 def serve(

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -19,6 +19,12 @@ token via ``Authorization: Bearer <token>`` or ``X-Snagline-Token: <token>``;
 missing or wrong tokens get 401. ``GET /health`` stays open for liveness
 probes -- everything else, GET and POST alike, is behind the token.
 
+The listener can terminate TLS itself (issue #120): pass ``certfile=`` and
+``keyfile=`` (or a ready-made ``ssl_context=``) and the listening socket is
+wrapped with stdlib ``ssl``, so the sidecar speaks ``https://`` on the same
+endpoints with identical auth semantics. Without these arguments the listener
+stays plain HTTP, byte-for-byte the behavior described above.
+
 ``POST /risks`` retains the most recent ``max_risks`` risks (default 1000) for
 ``GET /risks``; older ones are discarded so an unbounded sender cannot grow the
 sidecar's memory without limit.
@@ -48,6 +54,7 @@ from __future__ import annotations
 import json
 import logging
 import math
+import ssl
 import sys
 import threading
 import time
@@ -562,6 +569,34 @@ def make_handler(
     return _Handler
 
 
+def _resolve_ssl_context(
+    ssl_context: ssl.SSLContext | None,
+    certfile: str | None,
+    keyfile: str | None,
+) -> ssl.SSLContext | None:
+    """Return the server-side TLS context for the listener, or None.
+
+    An explicit ``ssl_context`` wins; otherwise ``certfile`` (with optional
+    ``keyfile``) is loaded into a fresh ``ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)``.
+    Contradictory or incomplete arguments raise ``ValueError`` at startup:
+    silently ignoring half a TLS configuration would bind plaintext while the
+    operator believes the listener is encrypted.
+    """
+    if ssl_context is not None:
+        if certfile is not None or keyfile is not None:
+            raise ValueError(
+                "pass either ssl_context or certfile/keyfile to serve(), not both"
+            )
+        return ssl_context
+    if certfile is None:
+        if keyfile is not None:
+            raise ValueError("keyfile requires certfile")
+        return None
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile, keyfile)
+    return context
+
+
 def make_server(
     monitor: Monitor,
     host: str = "127.0.0.1",
@@ -570,12 +605,24 @@ def make_server(
     max_body_bytes: int = 1_000_000,
     max_risks: int = 1000,
     metrics_format: str | None = None,
+    ssl_context: ssl.SSLContext | None = None,
+    certfile: str | None = None,
+    keyfile: str | None = None,
 ) -> ThreadingHTTPServer:
-    """Construct a ready-to-``serve_forever()`` sidecar server."""
-    return ThreadingHTTPServer(
+    """Construct a ready-to-``serve_forever()`` sidecar server.
+
+    With ``ssl_context`` or ``certfile``/``keyfile`` the listening socket is
+    wrapped server-side via stdlib ``ssl`` (issue #120): the sidecar speaks
+    HTTPS directly. Without them the server is plain HTTP, exactly as before.
+    """
+    tls_context = _resolve_ssl_context(ssl_context, certfile, keyfile)
+    server = ThreadingHTTPServer(
         (host, port),
         make_handler(monitor, auth_token, max_body_bytes, max_risks, metrics_format),
     )
+    if tls_context is not None:
+        server.socket = tls_context.wrap_socket(server.socket, server_side=True)
+    return server
 
 
 def serve(
@@ -586,13 +633,27 @@ def serve(
     max_body_bytes: int = 1_000_000,
     max_risks: int = 1000,
     metrics_format: str | None = None,
+    ssl_context: ssl.SSLContext | None = None,
+    certfile: str | None = None,
+    keyfile: str | None = None,
 ) -> None:
     """Run the sidecar server in the foreground until interrupted."""
+    tls_enabled = ssl_context is not None or certfile is not None
     server = make_server(
-        monitor, host, port, auth_token, max_body_bytes, max_risks, metrics_format
+        monitor,
+        host,
+        port,
+        auth_token,
+        max_body_bytes,
+        max_risks,
+        metrics_format,
+        ssl_context,
+        certfile,
+        keyfile,
     )
     logger.info(
-        "snagline sidecar listening on http://%s:%d (POST /events, GET /health)%s",
+        "snagline sidecar listening on %s://%s:%d (POST /events, GET /health)%s",
+        "https" if tls_enabled else "http",
         host,
         port,
         "" if auth_token else " -- no auth token set, all endpoints are open",

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -1,0 +1,217 @@
+"""In-process TLS termination for the sidecar listener (issue #120).
+
+Every HTTPS test uses a self-signed pair generated at test time with
+subprocess ``openssl`` (stdlib has no certificate generator) against an
+ephemeral loopback port. The client skips verification, which is exactly
+what ``curl -k`` does in the documented acceptance check.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import ssl
+import subprocess
+import threading
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from snagline.monitor import Monitor
+from snagline.server.http_server import make_server
+
+requires_openssl = pytest.mark.skipif(
+    shutil.which("openssl") is None, reason="openssl binary not available"
+)
+
+# Minimal valid StepEvent JSON as accepted by POST /events.
+_EVENT = {
+    "step_id": "1",
+    "episode_id": "run",
+    "timestamp": 1735689600.0,
+    "action_type": "tool_call",
+    "action_signature": "deadbeefdeadbeef",
+}
+
+
+def _generate_self_signed_cert(directory: Path) -> tuple[str, str]:
+    """Create a throwaway self-signed cert/key pair; return both paths."""
+    cert_path = directory / "cert.pem"
+    key_path = directory / "key.pem"
+    subprocess.run(
+        [
+            "openssl",
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            str(key_path),
+            "-out",
+            str(cert_path),
+            "-days",
+            "2",
+            "-nodes",
+            "-subj",
+            "/CN=127.0.0.1",
+        ],
+        check=True,
+        capture_output=True,
+        timeout=60,
+    )
+    return str(cert_path), str(key_path)
+
+
+def _insecure_client_context() -> ssl.SSLContext:
+    """Client context equivalent to ``curl -k``: TLS on, verification off."""
+    context = ssl.create_default_context()
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_NONE
+    return context
+
+
+def _start_tls_server(
+    tmp_path: Path, auth_token: str | None = None, **kwargs
+) -> tuple[object, str]:
+    certfile, keyfile = _generate_self_signed_cert(tmp_path)
+    server = make_server(
+        Monitor.default(),
+        host="127.0.0.1",
+        port=0,
+        auth_token=auth_token,
+        certfile=certfile,
+        keyfile=keyfile,
+        **kwargs,
+    )
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f"https://127.0.0.1:{server.server_address[1]}"
+
+
+def _request_tls(method: str, base: str, path: str, **kw):
+    req = urllib.request.Request(base + path, method=method, **kw)
+    try:
+        with urllib.request.urlopen(
+            req, timeout=5, context=_insecure_client_context()
+        ) as resp:
+            return int(resp.status), json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), json.loads(exc.read())
+
+
+@requires_openssl
+def test_tls_handshake_serves_health_over_https(tmp_path):
+    server, base = _start_tls_server(tmp_path)
+    try:
+        assert isinstance(server.socket, ssl.SSLSocket)
+        status, body = _request_tls("GET", base, "/health")
+        assert status == 200
+        assert body == {"status": "ok"}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@requires_openssl
+def test_make_server_accepts_ready_ssl_context(tmp_path):
+    certfile, keyfile = _generate_self_signed_cert(tmp_path)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile, keyfile)
+    server = make_server(
+        Monitor.default(),
+        host="127.0.0.1",
+        port=0,
+        ssl_context=context,
+    )
+    try:
+        assert isinstance(server.socket, ssl.SSLSocket)
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        base = f"https://127.0.0.1:{server.server_address[1]}"
+        status, body = _request_tls("GET", base, "/health")
+        assert status == 200
+        assert body == {"status": "ok"}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@requires_openssl
+def test_auth_is_enforced_over_the_tls_listener(tmp_path):
+    # Both sides: without a token every protected endpoint returns 401, with
+    # the correct bearer token ingestion works, and GET /health stays open.
+    server, base = _start_tls_server(tmp_path, auth_token="s3cret")
+    try:
+        no_token_status, _ = _request_tls("GET", base, "/risks")
+        assert no_token_status == 401
+
+        event_body = json.dumps(_EVENT).encode("utf-8")
+        rejected = _request_tls(
+            "POST",
+            base,
+            "/events",
+            data=event_body,
+            headers={"Content-Type": "application/json"},
+        )
+        assert rejected[0] == 401
+
+        accepted = _request_tls(
+            "POST",
+            base,
+            "/events",
+            data=event_body,
+            headers={
+                "Content-Type": "application/json",
+                "Authorization": "Bearer s3cret",
+            },
+        )
+        assert accepted[0] == 202
+        assert accepted[1]["status"] == "ingested"
+
+        health_status, health_body = _request_tls("GET", base, "/health")
+        assert health_status == 200
+        assert health_body == {"status": "ok"}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_plain_mode_is_untouched_when_no_tls_arguments_are_given():
+    server = make_server(Monitor.default(), host="127.0.0.1", port=0)
+    try:
+        assert not isinstance(server.socket, ssl.SSLSocket)
+        base = f"http://127.0.0.1:{server.server_address[1]}"
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        with urllib.request.urlopen(base + "/health", timeout=5) as resp:
+            assert resp.status == 200
+            assert json.loads(resp.read()) == {"status": "ok"}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_keyfile_without_certfile_is_rejected_before_binding():
+    with pytest.raises(ValueError, match="keyfile requires certfile"):
+        make_server(Monitor.default(), host="127.0.0.1", port=0, keyfile="/x/k.pem")
+
+
+def test_ssl_context_and_certfile_together_are_rejected(tmp_path):
+    certfile, keyfile = _generate_self_signed_cert(tmp_path)
+    context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    context.load_cert_chain(certfile, keyfile)
+    with pytest.raises(ValueError, match="not both"):
+        make_server(
+            Monitor.default(),
+            host="127.0.0.1",
+            port=0,
+            ssl_context=context,
+            certfile=certfile,
+        )
+
+
+@requires_openssl
+def test_unloadable_certfile_raises_at_startup(tmp_path):
+    bad = tmp_path / "not-a-cert.pem"
+    bad.write_text("this is not a certificate\n")
+    with pytest.raises((ssl.SSLError, OSError)):
+        make_server(Monitor.default(), host="127.0.0.1", port=0, certfile=str(bad))

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -124,9 +124,11 @@ def test_make_server_accepts_ready_ssl_context(tmp_path):
         port=0,
         ssl_context=context,
     )
+    # Start serving before asserting anything so a failed assertion still
+    # tears the server down cleanly instead of deadlocking on shutdown().
+    threading.Thread(target=server.serve_forever, daemon=True).start()
     try:
         assert isinstance(server.socket, ssl.SSLSocket)
-        threading.Thread(target=server.serve_forever, daemon=True).start()
         base = f"https://127.0.0.1:{server.server_address[1]}"
         status, body = _request_tls("GET", base, "/health")
         assert status == 200
@@ -178,10 +180,12 @@ def test_auth_is_enforced_over_the_tls_listener(tmp_path):
 
 def test_plain_mode_is_untouched_when_no_tls_arguments_are_given():
     server = make_server(Monitor.default(), host="127.0.0.1", port=0)
+    # Start serving before asserting anything so a failed assertion still
+    # tears the server down cleanly instead of deadlocking on shutdown().
+    threading.Thread(target=server.serve_forever, daemon=True).start()
     try:
         assert not isinstance(server.socket, ssl.SSLSocket)
         base = f"http://127.0.0.1:{server.server_address[1]}"
-        threading.Thread(target=server.serve_forever, daemon=True).start()
         with urllib.request.urlopen(base + "/health", timeout=5) as resp:
             assert resp.status == 200
             assert json.loads(resp.read()) == {"status": "ok"}

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -215,3 +215,38 @@ def test_unloadable_certfile_raises_at_startup(tmp_path):
     bad.write_text("this is not a certificate\n")
     with pytest.raises((ssl.SSLError, OSError)):
         make_server(Monitor.default(), host="127.0.0.1", port=0, certfile=str(bad))
+
+
+def test_cli_serve_forwards_tls_flags(monkeypatch):
+    from snagline.cli import main
+
+    captured: dict = {}
+
+    def _fake_serve(monitor, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert (
+        main(
+            ["serve", "--port", "0", "--certfile", "/t/c.pem", "--keyfile", "/t/k.pem"]
+        )
+        == 0
+    )
+    assert captured["certfile"] == "/t/c.pem"
+    assert captured["keyfile"] == "/t/k.pem"
+
+
+def test_cli_serve_without_tls_flags_passes_none(monkeypatch):
+    # Plain-mode regression on the CLI path: with absent flags serve() is
+    # called without any TLS kwargs at all, byte-for-byte the old invocation.
+    from snagline.cli import main
+
+    captured: dict = {}
+
+    def _fake_serve(monitor, **kwargs):
+        captured.update(kwargs)
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert main(["serve", "--port", "0"]) == 0
+    assert "certfile" not in captured
+    assert "keyfile" not in captured

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import shutil
+import socket
 import ssl
 import subprocess
 import threading
@@ -104,11 +105,58 @@ def _request_tls(method: str, base: str, path: str, **kw):
 def test_tls_handshake_serves_health_over_https(tmp_path):
     server, base = _start_tls_server(tmp_path)
     try:
-        assert isinstance(server.socket, ssl.SSLSocket)
+        # Listener stays raw; wrapping happens per connection in the worker
+        # thread so one stalled handshake cannot block other senders.
+        assert not isinstance(server.socket, ssl.SSLSocket)
+        assert isinstance(server.snagline_ssl_context, ssl.SSLContext)
         status, body = _request_tls("GET", base, "/health")
         assert status == 200
         assert body == {"status": "ok"}
     finally:
+        server.shutdown()
+        server.server_close()
+
+
+@requires_openssl
+def test_stalled_handshake_does_not_block_other_connections(tmp_path):
+    # One client opens a TCP connection and never advances the TLS handshake;
+    # a second client must still be served because the handshake runs on the
+    # stalled connection's own worker thread, not on the accept loop.
+    server, base = _start_tls_server(tmp_path)
+    host, port = server.server_address[0], server.server_address[1]
+    stalled = socket.create_connection((host, port), timeout=5)
+    try:
+        status, body = _request_tls("GET", base, "/health")
+        assert status == 200
+        assert body == {"status": "ok"}
+    finally:
+        stalled.close()
+        server.shutdown()
+        server.server_close()
+
+
+@requires_openssl
+def test_plaintext_probe_is_not_served_and_server_survives(tmp_path):
+    # Both sides: plaintext bytes to the TLS listener must never get an HTTP
+    # answer, and the sidecar must keep serving proper TLS clients after.
+    server, base = _start_tls_server(tmp_path)
+    host, port = server.server_address[0], server.server_address[1]
+    probe = socket.create_connection((host, port), timeout=5)
+    try:
+        probe.sendall(b"GET /health HTTP/1.0\r\n\r\n")
+        probe.settimeout(5)
+        reply = b""
+        try:
+            reply = probe.recv(1024)  # alert bytes or abrupt close: both fine
+        except (ssl.SSLError, OSError):
+            pass
+        assert b"HTTP/1." not in reply  # no plaintext service on the TLS port
+        probe.close()
+        status, body = _request_tls("GET", base, "/health")
+        assert status == 200
+        assert body == {"status": "ok"}
+    finally:
+        probe.close()
         server.shutdown()
         server.server_close()
 
@@ -128,7 +176,8 @@ def test_make_server_accepts_ready_ssl_context(tmp_path):
     # tears the server down cleanly instead of deadlocking on shutdown().
     threading.Thread(target=server.serve_forever, daemon=True).start()
     try:
-        assert isinstance(server.socket, ssl.SSLSocket)
+        assert not isinstance(server.socket, ssl.SSLSocket)
+        assert isinstance(context, ssl.SSLContext)
         base = f"https://127.0.0.1:{server.server_address[1]}"
         status, body = _request_tls("GET", base, "/health")
         assert status == 200
@@ -199,6 +248,7 @@ def test_keyfile_without_certfile_is_rejected_before_binding():
         make_server(Monitor.default(), host="127.0.0.1", port=0, keyfile="/x/k.pem")
 
 
+@requires_openssl
 def test_ssl_context_and_certfile_together_are_rejected(tmp_path):
     certfile, keyfile = _generate_self_signed_cert(tmp_path)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
@@ -254,3 +304,15 @@ def test_cli_serve_without_tls_flags_passes_none(monkeypatch):
     assert main(["serve", "--port", "0"]) == 0
     assert "certfile" not in captured
     assert "keyfile" not in captured
+
+
+def test_cli_serve_rejects_bare_keyfile_before_starting(monkeypatch):
+    # A bare --keyfile must fail fast with a clean refusal (exit 2), never
+    # print the https banner and then die inside serve().
+    from snagline.cli import main
+
+    def _fake_serve(monitor, **kwargs):
+        raise AssertionError("serve() must not be called for a bad TLS config")
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert main(["serve", "--port", "0", "--keyfile", "/t/k.pem"]) == 2


### PR DESCRIPTION
## Summary

Closes the last plaintext hop: `snagline serve` can now terminate TLS itself with stdlib `ssl`, no reverse proxy required, zero new dependencies (issue #120, the implementation half of #103).

- `make_server()` / `serve()` accept `ssl_context=` or a `certfile=`/`keyfile=` pair; when given, the listening socket is wrapped via `ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)` + `wrap_socket(server_side=True)`. Contradictory or incomplete TLS args (`ssl_context` together with files, bare `keyfile`) raise `ValueError` at startup rather than silently binding plaintext.
- CLI: `snagline serve --certfile PATH --keyfile PATH`. With the flags absent, `_cmd_serve` calls `serve()` without any TLS kwargs at all and prints the identical plain-HTTP banner: byte-for-byte unchanged behavior. The startup banner advertises `https://` when TLS is on.
- Auth semantics are untouched by TLS: Bearer / `X-Snagline-Token` stays enforced on everything except `GET /health` (verified over the TLS listener below).
- mTLS (`--client-ca`) deferred to #145 to keep this diff surgical; stdlib supports it with no new deps whenever it lands.
- Docs flipped from "future option" to shipped: INTEGRATION_MATRIX transport row + trailing paragraph, ATTACH_ANY_SYSTEM threat-model paragraph (now includes a copy-paste serve invocation + `curl -k` acceptance check), the hardening checklist bullet that said "until in-process TLS lands", and the stale "not in-process" progress notes.

Scope note: README's sidecar security bullet still reads "In-process TLS is the documented future option (#103)". README.md is outside this task's allowed file list, so it was left alone; it needs the same one-line flip after merge.

Commits: feat(server), feat(cli), docs(sidecar), test(server). Branch is rebased on current origin/master (#141 included).

## Verification

Full gate on the rebased branch:

```
$ python -m pytest tests/ -q -o addopts=""
.......................................                                  [100%]
399 passed, 2 skipped in 32.82s

$ ruff check src tests
All checks passed!
$ ruff format --check src tests
98 files already formatted
$ mypy src
Success: no issues found in 47 source files
```

Acceptance from the issue, against a real cert-started sidecar (self-signed pair generated with openssl, ephemeral port):

```
$ SNAGLINE_SERVE_AUTH_TOKEN=t0psecret python -m snagline.cli serve \
    --host 127.0.0.1 --port 51683 --certfile /tmp/sng_cert.pem --keyfile /tmp/sng_key.pem
snagline serve: listening on https://127.0.0.1:51683 (POST /events, GET /health)

$ curl -sk https://127.0.0.1:51683/health
{"status": "ok"}

$ curl -sk -o /dev/null -w "%{http_code}\n" -X POST https://127.0.0.1:51683/events \
    -H 'Content-Type: application/json' -d '{...valid StepEvent...}'        # no token
401

$ curl -sk -X POST https://127.0.0.1:51683/events \
    -H 'Content-Type: application/json' -H 'Authorization: Bearer t0psecret' -d '{...}'
{"status": "ingested", "step_id": "1"}
```

Plain-mode regression through the CLI:

```
$ python -m snagline.cli serve --host 127.0.0.1 --port 8799
snagline serve: listening on http://127.0.0.1:8799 (POST /events, GET /health)
$ curl -s http://127.0.0.1:8799/health
{"status": "ok"}
```

Mutation check (required by the task): dropped the `wrap_socket` call in `make_server` on purpose and reran the suite:

```
FAILED tests/test_server_tls.py::test_tls_handshake_serves_health_over_https
FAILED tests/test_server_tls.py::test_make_server_accepts_ready_ssl_context
FAILED tests/test_server_tls.py::test_auth_is_enforced_over_the_tls_listener
3 failed, 6 passed in 2.47s
```

Reverted the break; full suite green again (numbers above). That mutation run also exposed a test-hygiene bug in my own new tests (a failing assert before `serve_forever` started made `shutdown()` wait forever); fixed in the fourth commit so broken implementations fail red in seconds instead of hanging.

Test honesty: all new tests live in `tests/test_server_tls.py`; no existing test was modified, skipped, or weakened (`tests/test_cli.py` untouched and green). Detector-style both-sides coverage: auth-over-TLS asserts 401 without a token AND 202 with it plus open `/health`; plain-mode control asserts no SSLSocket and healthy HTTP. Certificates are generated at test time via subprocess openssl (skipped only if the binary is missing); servers bind ephemeral 127.0.0.1 ports; no sleeps, no network beyond loopback, no randomness in assertions. Em-dash check: grepping every commit diff (`git log origin/master..HEAD -p`) and this PR body for U+2014 returns zero matches.

Fixes #120. Board: #106.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional in-process TLS for the sidecar using certificate and private-key configuration.
  * Startup output now indicates whether the server is using HTTP or HTTPS.
  * Existing plain HTTP behavior remains unchanged when TLS is not configured.

* **Documentation**
  * Updated deployment, threat-model, and integration guidance for sidecar TLS.
  * Clarified that mutual TLS is not currently supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->