### PR TITLE
fix(cli): single DedupSink choke point; watch composes like serve (Fixes #152)

### DIFF
--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -453,7 +453,10 @@ def _cmd_watch(args: argparse.Namespace) -> int:
         return int(exc.code or 2)
     monitor = Monitor.default(
         config=cfg,
-        sinks=_maybe_dedup(sinks, args.cooldown_seconds),
+        # _build_sinks is the single DedupSink choke point (issue #152):
+        # re-wrapping here composed DedupSink(DedupSink(inner)) and made watch
+        # diverge from serve, which passes _build_sinks through untouched.
+        sinks=sinks,
     )
     episode = args.episode_id or (args.file or "stdin")
     steps = 0

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -69,6 +69,40 @@ def test_build_sinks_cooldown_wraps():
     assert isinstance(sinks[0], DedupSink)
 
 
+def test_watch_composes_single_dedup_layer(monkeypatch, tmp_path):
+    """Regression for #152: ``watch`` must not re-wrap ``_build_sinks`` output
+    in a second DedupSink. The builder is the single wrap choke point, so
+    watch and serve compose identically: exactly one layer around the console
+    sink."""
+    import snagline.cli as cli
+
+    traj = tmp_path / "t.jsonl"
+    _write_healthy_trajectory(traj)
+
+    captured = {}
+    real_default = cli.Monitor.default
+
+    class SpyMonitor(cli.Monitor):
+        @classmethod
+        def default(cls, *a, **kw):
+            captured["sinks"] = kw.get("sinks")
+            return real_default(*a, **kw)
+
+    monkeypatch.setattr(cli, "Monitor", SpyMonitor)
+
+    assert main(["watch", "--file", str(traj), "--cooldown-seconds", "60"]) == 0
+
+    sinks = captured["sinks"]
+    assert sinks is not None, "watch must construct its Monitor with explicit sinks"
+    assert len(sinks) == 1
+    assert isinstance(sinks[0], DedupSink)
+    # Exactly ONE layer: the wrapped sink is the console escalation itself,
+    # not another DedupSink.
+    from snagline.sinks.console import ConsoleSink
+
+    assert isinstance(sinks[0]._sink, ConsoleSink)
+
+
 def test_main_watch_slack_missing_url_exits_2():
     assert main(["watch", "--sink", "slack"]) == 2
 


### PR DESCRIPTION
Closes #152.

`_cmd_watch` re-wrapped `_build_sinks()` output in `_maybe_dedup(...)` even though the builder already wraps at its return — composing `DedupSink(DedupSink(inner))` on `snagline watch`, while `snagline serve` composes a single layer. With one shared cooldown the outer wrapper never suppresses anything extra (inner already gates the window), but:

- the run paths composed inconsistently for the same job,
- every extra layer doubles the cooldown-table state that snapshots must round-trip (#136 territory),
- the composition misled readers about how many suppression layers exist.

## Change
- `_build_sinks` remains the single choke point; `_cmd_watch` passes its result straight through (comment in place explains why).
- Regression test: `test_watch_composes_single_dedup_layer` runs `main(["watch", ...])` with a Monitor spy and asserts exactly one `DedupSink` around `ConsoleSink`.

## Verification
- Mutation check performed: re-introducing the second wrap turns the new test red (observed), reverted.
- Full gate: 498 passed / 2 skipped · coverage 88.44% · ruff clean · format clean · mypy clean (51 files)

Board: #106
