### PR TITLE
feat(server): end-of-episode signal expires the episodes-active gauge

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -136,6 +136,26 @@ enterprise-grade alerting. Concretely:
     or `SNAGLINE_METRICS_FORMAT=classic`. Scrape config: point Prometheus at
     the sidecar with `metrics_path: /metrics` (same port and auth token as
     the event endpoints). Structured logging remains.
+
+    **End-of-episode signal (#123):** `snagline_episodes_active` counts
+    distinct episode ids seen through the sidecar since process start
+    (capped at 10,000, least-recently-seen eviction). A host that knows an
+    episode is finished should tell the sidecar so the gauge drops the id
+    immediately instead of waiting for cap eviction:
+
+    ```bash
+    curl -X POST http://127.0.0.1:8787/episodes/end \
+      -H "Authorization: Bearer $SNAGLINE_SERVE_AUTH_TOKEN" \
+      -H "Content-Type: application/json" \
+      -d '{"episode_id": "run-42"}'
+    # -> {"status": "ended", "episode_id": "run-42"}
+    ```
+
+    The endpoint runs behind the same auth token as every other POST,
+    forwards to `Monitor.end_episode()` (running detector finalizers and
+    releasing per-episode detector state), and answers `400` on malformed
+    bodies without crashing or retaining anything beyond the id itself.
+    Ending an unknown id is an idempotent no-op.
 11. Integration matrix document plus a prominent "10-line custom adapter"
     path. **Done:** `docs/INTEGRATION_MATRIX.md` (#49).
 

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -6,8 +6,15 @@ shell script, a Claude Code hook) can POST ``StepEvent`` JSON to:
     POST /events             body: a StepEvent as a JSON object      -> monitor.ingest()
                                or a JSON array of StepEvent objects     (batched)
     POST /hooks/claude-code  body: a native Claude Code hook payload -> mapped + ingested
+    POST /episodes/end       body: {"episode_id": "<id>"}            -> monitor.end_episode()
     GET  /health                                                     -> 200 OK
     GET  /metrics                                                    -> Prometheus text exposition (v0.0.4)
+
+A host that knows an episode is over can signal it with ``POST
+/episodes/end`` carrying ``{"episode_id": "..."}`` (issue #123): the sidecar
+forwards to ``Monitor.end_episode()`` and drops the id from the
+``snagline_episodes_active`` gauge immediately, so long-lived processes stop
+counting finished episodes without waiting for cap eviction.
 
 POST bodies are capped at ``max_body_bytes`` (default 1 MB); larger payloads
 get 413. This keeps the sidecar safe to expose and able to absorb buffered
@@ -202,6 +209,23 @@ class SidecarMetricsCollector:
         except Exception:
             logger.debug("snagline: metrics record failed", exc_info=True)
 
+    def end_episode(self, episode_id: str) -> None:
+        """Forget one episode id so the gauge reflects completion at once.
+
+        Without this an ended episode keeps occupying a table slot until cap
+        eviction forgets it (issue #123). Idempotent by design: ending an
+        unknown or already-ended id is a no-op, never an error. Guarded like
+        every other entry point: bookkeeping must never take serving down.
+        """
+        try:
+            key = str(episode_id)
+            with self._lock:
+                self._episodes.pop(key, None)
+        except Exception:
+            logger.debug(
+                "snagline: metrics collector end_episode failed", exc_info=True
+            )
+
     def snapshot(self) -> dict[str, Any]:
         """Return a consistent copy of the counters for rendering."""
         with self._lock:
@@ -238,7 +262,8 @@ class SidecarMetricsCollector:
                 f'severity="{_escape_label(severity)}"}} {count}'
             )
         lines.append(
-            "# HELP snagline_episodes_active Distinct episode ids seen since start."
+            "# HELP snagline_episodes_active Distinct episode ids seen since start;"
+            " ids removed again on POST /episodes/end."
         )
         lines.append("# TYPE snagline_episodes_active gauge")
         lines.append(f"snagline_episodes_active {snap['episodes_active']}")
@@ -397,6 +422,8 @@ def make_handler(
                 self._post_events()
             elif self.path == "/hooks/claude-code":
                 self._post_claude_hook()
+            elif self.path == "/episodes/end":
+                self._post_episodes_end()
             elif self.path == "/risks":
                 self._post_risks()
             else:
@@ -468,6 +495,43 @@ def make_handler(
             # above is the only client-visible error.
             self._ingest_recorded(event)
             self._respond(202, {"status": "ingested", "step_id": event.step_id})
+
+        def _post_episodes_end(self) -> None:
+            """Accept an end-of-episode signal (issue #123).
+
+            Body is ``{"episode_id": "<id>"}``. The id is forwarded to
+            ``Monitor.end_episode`` (detector finalization plus state
+            teardown) and removed from the metrics episodes table so the
+            gauge stops counting it immediately. Ids only: the body is never
+            logged or retained. Fail-open end to end -- malformed bodies get
+            400, monitor failures are logged and swallowed, and the client
+            always gets a clean response because this endpoint must never be
+            the one that takes the sidecar down.
+            """
+            body = self._read_body()
+            try:
+                payload = json.loads(body.decode("utf-8"))
+            except (ValueError, json.JSONDecodeError):
+                self._respond(400, {"error": "invalid end-episode JSON"})
+                return
+            episode_id = (
+                payload.get("episode_id") if isinstance(payload, dict) else None
+            )
+            if not isinstance(episode_id, str) or not episode_id:
+                self._respond(400, {"error": "episode_id must be a non-empty string"})
+                return
+            try:
+                self.snagline_monitor.end_episode(episode_id)
+            except Exception:
+                # Monitor dispatch is fail-open internally already; this guard
+                # covers misconfigured monitors (fail_open=False) so a bad
+                # signal can still never escape into the server plumbing.
+                logger.exception("snagline: end_episode dispatch failed")
+            finally:
+                collector = self.snagline_collector
+                if collector is not None:
+                    collector.end_episode(episode_id)
+            self._respond(200, {"status": "ended", "episode_id": episode_id})
 
         def _ingest_recorded(self, event: StepEvent) -> None:
             """Ingest one event while recording sidecar metrics around it.

--- a/tests/server/test_episodes_end.py
+++ b/tests/server/test_episodes_end.py
@@ -35,24 +35,30 @@ class _RecordingMonitor:
         self.ended: list[str] = []
 
     def add_sink(self, sink: object) -> None:
+        """Accept a sink registration without doing anything."""
         pass
 
     def ingest(self, event: object) -> None:
+        """Accept an event without detecting anything."""
         pass
 
     def end_episode(self, episode_id: str) -> None:
+        """Record that this id was ended."""
         self.ended.append(str(episode_id))
 
     def metrics(self) -> dict:
+        """Return an empty counter snapshot."""
         return {}
 
 
 class _ExplodingMonitor(_RecordingMonitor):
     def end_episode(self, episode_id: str) -> None:
+        """Always raises: simulates a misconfigured Monitor."""
         raise RuntimeError("boom: monitor misconfigured")
 
 
 def _start(monitor: object | None = None, auth_token: str | None = None):
+    """Start a sidecar on an ephemeral port; returns (server, port)."""
     server = make_server(
         monitor or Monitor([], []),  # type: ignore[arg-type]
         host="127.0.0.1",
@@ -93,6 +99,7 @@ def _request(
 
 
 def _post_event(port: int, episode_id: str) -> bytes:
+    """POST one minimal StepEvent with the given episode id."""
     event = {"step_id": "0", "episode_id": episode_id, **_EVENT_FIELDS}
     return _request(port, "POST", "/events", json.dumps(event).encode())
 

--- a/tests/server/test_episodes_end.py
+++ b/tests/server/test_episodes_end.py
@@ -1,0 +1,222 @@
+"""End-of-episode signal: POST /episodes/end expires the gauge entry (#123).
+
+The wire format previously had no way to say "this episode is over", so
+``snagline_episodes_active`` could only shrink via least-recently-seen cap
+eviction. These tests pin the remedy: the signal forwards to
+``Monitor.end_episode``, removes the id from the metrics table immediately,
+applies auth like every POST, and treats malformed signals as 400 -- never
+a crash, never retained content (ids only).
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+
+from snagline.monitor import Monitor
+from snagline.server.http_server import (
+    SidecarMetricsCollector,
+    make_server,
+)
+
+_EVENT_FIELDS = {
+    "timestamp": 1718300000.0,
+    "action_type": "tool_call",
+    "action_signature": "aaaa1111bbbb2222",
+    "metadata": {},
+}
+
+
+class _RecordingMonitor:
+    """Duck-typed Monitor stand-in that records end_episode calls."""
+
+    def __init__(self) -> None:
+        self.ended: list[str] = []
+
+    def add_sink(self, sink: object) -> None:
+        pass
+
+    def ingest(self, event: object) -> None:
+        pass
+
+    def end_episode(self, episode_id: str) -> None:
+        self.ended.append(str(episode_id))
+
+    def metrics(self) -> dict:
+        return {}
+
+
+class _ExplodingMonitor(_RecordingMonitor):
+    def end_episode(self, episode_id: str) -> None:
+        raise RuntimeError("boom: monitor misconfigured")
+
+
+def _start(monitor: object | None = None, auth_token: str | None = None):
+    server = make_server(
+        monitor or Monitor([], []),  # type: ignore[arg-type]
+        host="127.0.0.1",
+        port=0,
+        auth_token=auth_token,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def _request(
+    port: int,
+    method: str,
+    path: str,
+    body: bytes = b"",
+    token: str | None = None,
+) -> bytes:
+    """One raw-socket HTTP/1.0 request; returns the full wire response."""
+    sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+    try:
+        lines = [f"{method} {path} HTTP/1.0", "Host: localhost"]
+        if token:
+            lines.append(f"Authorization: Bearer {token}")
+        if body:
+            lines.append(f"Content-Length: {len(body)}")
+        lines.append("")
+        sock.sendall(("\r\n".join(lines) + "\r\n").encode() + body)
+        chunks: list[bytes] = []
+        while True:
+            data = sock.recv(65536)
+            if not data:
+                break
+            chunks.append(data)
+        return b"".join(chunks)
+    finally:
+        sock.close()
+
+
+def _post_event(port: int, episode_id: str) -> bytes:
+    event = {"step_id": "0", "episode_id": episode_id, **_EVENT_FIELDS}
+    return _request(port, "POST", "/events", json.dumps(event).encode())
+
+
+def test_end_signal_drops_episode_from_gauge_immediately():
+    """Full raw-socket flow: ingest -> gauge 1, end -> gauge 0, no eviction."""
+    server, port = _start()
+    try:
+        response = _post_event(port, "ep-gauge")
+        assert response.startswith(b"HTTP/1.0 202"), response[:120]
+        scrape = _request(port, "GET", "/metrics")
+        assert b"snagline_episodes_active 1\n" in scrape
+
+        end = _request(port, "POST", "/episodes/end", b'{"episode_id": "ep-gauge"}')
+        assert end.startswith(b"HTTP/1.0 200"), end[:120]
+        assert b'"status": "ended"' in end
+        assert b'"episode_id": "ep-gauge"' in end
+
+        scrape_after = _request(port, "GET", "/metrics")
+        assert b"snagline_episodes_active 0\n" in scrape_after
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_end_forwards_to_monitor_end_episode():
+    monitor = _RecordingMonitor()
+    server, port = _start(monitor)
+    try:
+        response = _request(port, "POST", "/episodes/end", b'{"episode_id": "run-42"}')
+        assert response.startswith(b"HTTP/1.0 200"), response[:120]
+        assert monitor.ended == ["run-42"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_auth_applies_to_end_endpoint_like_every_post():
+    monitor = _RecordingMonitor()
+    server, port = _start(monitor, auth_token="s3cr3t")
+    try:
+        denied = _request(port, "POST", "/episodes/end", b'{"episode_id": "run-42"}')
+        assert denied.startswith(b"HTTP/1.0 401"), denied[:120]
+        assert monitor.ended == []
+
+        allowed = _request(
+            port,
+            "POST",
+            "/episodes/end",
+            b'{"episode_id": "run-42"}',
+            token="s3cr3t",
+        )
+        assert allowed.startswith(b"HTTP/1.0 200"), allowed[:120]
+        assert monitor.ended == ["run-42"]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_malformed_signals_get_400_and_sidecar_stays_up():
+    """Bad bodies are rejected with 400; the sidecar keeps serving."""
+    bad_bodies = [
+        b"not json at all",
+        b"[1, 2, 3]",
+        b'"just a string"',
+        b'{"step_id": "no-episode-id"}',
+        b'{"episode_id": ""}',
+        b'{"episode_id": 42}',
+    ]
+    server, port = _start()
+    try:
+        for bad in bad_bodies:
+            response = _request(port, "POST", "/episodes/end", bad)
+            assert response.startswith(b"HTTP/1.0 400"), (bad, response[:120])
+        # No Content-Length at all: body silently empty -> invalid JSON -> 400.
+        response = _request(port, "POST", "/episodes/end")
+        assert response.startswith(b"HTTP/1.0 400"), response[:120]
+        # Still alive and serving afterwards.
+        health = _request(port, "GET", "/health")
+        assert health.startswith(b"HTTP/1.0 200"), health[:120]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_monitor_failure_never_breaks_the_endpoint():
+    """A raising Monitor is swallowed; the client still gets a clean reply."""
+    monitor = _ExplodingMonitor()
+    server, port = _start(monitor)
+    try:
+        response = _request(port, "POST", "/episodes/end", b'{"episode_id": "run-7"}')
+        assert response.startswith(b"HTTP/1.0 200"), response[:120]
+        assert b'"status": "ended"' in response
+        health = _request(port, "GET", "/health")
+        assert health.startswith(b"HTTP/1.0 200"), health[:120]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_end_is_idempotent_and_ids_only():
+    """Ending twice is a no-op the second time; ids never become content."""
+    collector = SidecarMetricsCollector()
+    collector.record_ingest("ep-a", 0.001)
+    assert collector.snapshot()["episodes_active"] == 1
+    collector.end_episode("ep-a")
+    assert collector.snapshot()["episodes_active"] == 0
+    collector.end_episode("ep-a")  # second end: still zero, never raises
+    collector.end_episode("never-seen")  # unknown id: no-op, never raises
+    assert collector.snapshot()["episodes_active"] == 0
+
+
+def test_collector_expiry_does_not_wait_for_cap_eviction():
+    """The freed slot is reusable: the quietest old id survives because the
+    explicit end made room, where cap eviction would have forgotten it."""
+    collector = SidecarMetricsCollector(max_episodes=2)
+    collector.record_ingest("ep-a", 0.001)
+    collector.record_ingest("ep-b", 0.001)
+    assert collector.snapshot()["episodes_active"] == 2
+    collector.end_episode("ep-a")
+    assert collector.snapshot()["episodes_active"] == 1
+    collector.record_ingest("ep-c", 0.001)
+    # Had the end signal not freed a slot, adding c at cap would have evicted
+    # b (the least-recently-seen); instead b and c are both still tracked.
+    assert list(collector._episodes) == ["ep-b", "ep-c"]
+    collector.record_ingest("ep-a", 0.001)  # ended ids can be recounted later
+    assert list(collector._episodes) == ["ep-c", "ep-a"]


### PR DESCRIPTION
Closes #123

## What

New endpoint on the sidecar:

    POST /episodes/end        body: {"episode_id": "<id>"}     -> 200 {"status": "ended", ...}

It forwards the id to `Monitor.end_episode(episode_id)` (running detector
finalizers plus per-episode state teardown) AND removes the id from the
`SidecarMetricsCollector` episodes table, so `snagline_episodes_active`
stops counting a finished episode immediately instead of waiting for
least-recently-seen cap eviction.

## Why

The gauge had no deterministic expiry: the wire format had no end-of-run
signal, so long-lived processes seeing more than 10k episodes under-counted
old-but-still-running ones. This gives hosts an explicit signal (issue
#123).

## Design decisions

- Dedicated `POST /episodes/end` chosen over the `{"type": "end_episode"}`
  control-event variant on `/events`: one unambiguous endpoint, no risk of
  colliding with batched StepEvent arrays on the ingest path.
- **TTL expiry not implemented**, deliberately: it needs per-id wall-clock
  tracking plus sweep timing and replay-traffic caveats. Not trivial, and
  the issue says to skip it in that case. The explicit signal covers the
  deterministic case; the LRU cap still bounds memory when hosts never
  send the signal.
- Auth applies exactly like every other POST (the shared `_authorized`
  check at the top of `do_POST`; `/health` stays the only open route).
- Fail-open end to end: malformed bodies get 400, a raising
  `Monitor.end_episode` is logged and swallowed (covers misconfigured
  monitors with `fail_open=False`), collector bookkeeping is guarded, and
  the client always gets a clean JSON response.
- No content retention: ids only, bodies are never logged or stored.
  Ending an unknown or already-ended id is an idempotent no-op.
- Gauge HELP text updated to mention the removal behavior.

## Docs

`docs/ATTACH_ANY_SYSTEM.md`, directly after the Prometheus scrape config
sentence: what the signal does, auth note, idempotency note, and a curl
example against the default port.

## Acceptance evidence

- Ended episodes stop being counted without waiting for cap eviction:
  raw-socket flow `test_end_signal_drops_episode_from_gauge_immediately`
  (ingest -> gauge 1, POST /episodes/end -> gauge 0), unit-level
  `test_collector_expiry_does_not_wait_for_cap_eviction`,
  `test_end_is_idempotent_and_ids_only`.
- Forwarding to Monitor.end_episode: `test_end_forwards_to_monitor_end_episode`.
- Auth like every POST: `test_auth_applies_to_end_endpoint_like_every_post`.
- Malformed signals: 400, never crash, never retain:
  `test_malformed_signals_get_400_and_sidecar_stays_up` (bad JSON,
  non-dict body, missing/empty/non-string id, missing Content-Length).
- Monitor failure cannot break serving: `test_monitor_failure_never_breaks_the_endpoint`.
- Bounded memory preserved: table cap unchanged (`_MAX_TRACKED_EPISODES`),
  eviction tests from #98 still pass.
- Full gate at this commit: 505 passed, 2 skipped (coverage 87.89%),
  `ruff check src tests`, `ruff format --check src tests`,
  `mypy src` all clean.

## Mutation checks (fix committed first, then mutated, then reverted)

- Disabled the 400 responses in `_post_episodes_end` ->
  `test_malformed_signals_get_400_and_sidecar_stays_up` went red.
- Disabled the table pop in `SidecarMetricsCollector.end_episode` ->
  `test_end_signal_drops_episode_from_gauge_immediately` went red.

Refs #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authenticated endpoint to mark episodes as ended.
  * Ended episodes are finalized promptly and removed from active episode metrics.
  * The endpoint safely handles repeated requests and unknown episode IDs.
  * Added validation for malformed requests with clear client error responses.

* **Documentation**
  * Documented the new episode-ending endpoint and its behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->