### PR TITLE
fix(adapters): default every adapter clock to time.perf_counter

### DIFF
--- a/src/snagline/adapters/anthropic.py
+++ b/src/snagline/adapters/anthropic.py
@@ -2,6 +2,12 @@
 
 Mirrors ``adapters/openai.py`` for ``anthropic.Anthropic``.
 
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`: the wall clock advances in ~15.6 ms ticks on Windows,
+quantizing sub-tick latencies to zero (issue #155). ``perf_counter`` has no
+meaningful epoch, so these timestamps are only comparable within one process;
+detectors consume them solely as in-process latency differences.
+
 Usage::
 
     from snagline.adapters.anthropic import wrap_anthropic_client
@@ -65,7 +71,7 @@ def observe_anthropic_call(
     event = StepEvent(
         step_id=step_id or "anthropic",
         episode_id=episode_id,
-        timestamp=time.time(),
+        timestamp=time.perf_counter(),
         action_type="tool_call",
         action_signature=sig,
         tool_name=model or "anthropic",
@@ -149,7 +155,7 @@ class _SyncStreamWrapper:
         if self._emitted:
             return
         self._emitted = True
-        latency = (time.time() - self._start) * 1000.0
+        latency = (time.perf_counter() - self._start) * 1000.0
         tokens_in, tokens_out = (None, None)
         if not error and self._last is not None:
             tokens_in, tokens_out = _extract_tokens(self._last)
@@ -159,7 +165,7 @@ class _SyncStreamWrapper:
         event = StepEvent(
             step_id=str(next(self._counter)),
             episode_id=self._episode_id,
-            timestamp=time.time(),
+            timestamp=time.perf_counter(),
             action_type="tool_call",
             action_signature=sig,
             tool_name=str(self._model),
@@ -240,7 +246,7 @@ class _AsyncStreamWrapper:
         if self._emitted:
             return
         self._emitted = True
-        latency = (time.time() - self._start) * 1000.0
+        latency = (time.perf_counter() - self._start) * 1000.0
         tokens_in, tokens_out = (None, None)
         if not error and self._last is not None:
             tokens_in, tokens_out = _extract_tokens(self._last)
@@ -250,7 +256,7 @@ class _AsyncStreamWrapper:
         event = StepEvent(
             step_id=str(next(self._counter)),
             episode_id=self._episode_id,
-            timestamp=time.time(),
+            timestamp=time.perf_counter(),
             action_type="tool_call",
             action_signature=sig,
             tool_name=str(self._model),
@@ -277,7 +283,7 @@ def _emit_now(
     error_type: str | None,
     result: Any,
 ) -> None:
-    latency = (time.time() - start) * 1000.0
+    latency = (time.perf_counter() - start) * 1000.0
     tokens_in, tokens_out = (None, None)
     if not error:
         tokens_in, tokens_out = _extract_tokens(result)
@@ -285,7 +291,7 @@ def _emit_now(
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id=episode_id,
-        timestamp=time.time(),
+        timestamp=time.perf_counter(),
         action_type="tool_call",
         action_signature=sig,
         tool_name=str(model),
@@ -306,7 +312,7 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
     def _sync(*args: Any, **kwargs: Any) -> Any:
         model = kwargs.get("model", "unknown")
         sig_text = str(kwargs.get("messages") or args)
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = original(*args, **kwargs)
         except Exception as e:
@@ -342,7 +348,7 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
     async def _async(*args: Any, **kwargs: Any) -> Any:
         model = kwargs.get("model", "unknown")
         sig_text = str(kwargs.get("messages") or args)
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = await original(*args, **kwargs)
         except Exception as e:

--- a/src/snagline/adapters/autogen.py
+++ b/src/snagline/adapters/autogen.py
@@ -15,6 +15,13 @@ is retained -- only the one-way ``action_signature`` hash, tool name, latency
 Autogen event objects are pydantic models; we read them via ``model_dump()``
 when present and fall back to attribute access / ``__dict__`` so the adapter
 works across Autogen versions without hard coupling.
+
+The optional ``clock=`` defaults to :func:`time.perf_counter`: monotonic and
+high-resolution on every platform. ``time.time`` advances in ~15.6 ms ticks on
+Windows and quantized sub-tick latencies to zero (issue #155). Note that
+``perf_counter`` has no meaningful epoch: event timestamps produced with it
+are only comparable within one process; detectors consume them solely as
+in-process latency differences.
 """
 
 from __future__ import annotations
@@ -66,7 +73,10 @@ class SnaglineAutogenHandler:
         self._monitor = monitor
         self._episode_id = episode_id
         self._agent_name = agent_name
-        self._clock = clock or time.time
+        # perf_counter, not time.time: time.time ticks at ~15.6 ms on Windows,
+        # quantizing sub-tick latencies to zero (issue #155). perf_counter has
+        # no meaningful epoch; detectors only consume in-process differences.
+        self._clock = clock or time.perf_counter
         self._counter = itertools.count()
 
     def observe(self, event: Any) -> list[StepEvent]:

--- a/src/snagline/adapters/crewai.py
+++ b/src/snagline/adapters/crewai.py
@@ -20,6 +20,13 @@ is retained -- only the one-way ``action_signature`` hash, tool name, latency
 CrewAI step objects vary by version; we read common attributes (``tool``,
 ``tool_input``, ``output``/``text``, ``error``) and fall back to a dict view, so
 the adapter stays loosely coupled to a specific CrewAI release.
+
+The optional ``clock=`` defaults to :func:`time.perf_counter`: monotonic and
+high-resolution on every platform. ``time.time`` advances in ~15.6 ms ticks on
+Windows and quantized sub-tick latencies to zero (issue #155). Note that
+``perf_counter`` has no meaningful epoch: event timestamps produced with it
+are only comparable within one process; detectors consume them solely as
+in-process latency differences.
 """
 
 from __future__ import annotations
@@ -163,7 +170,10 @@ class _CrewAIStepCallback:
         self._monitor = monitor
         self._episode_id = episode_id
         self._agent_name = agent_name
-        self._clock = clock or time.time
+        # perf_counter, not time.time: time.time ticks at ~15.6 ms on Windows,
+        # quantizing sub-tick latencies to zero (issue #155). perf_counter has
+        # no meaningful epoch; detectors only consume in-process differences.
+        self._clock = clock or time.perf_counter
         self._counter = itertools.count()
 
     def __call__(self, step: Any) -> None:
@@ -219,7 +229,9 @@ def observe_crewai_step(
         episode_id=episode_id,
         step_id=step_id or "manual",
         agent_name=agent_name,
-        clock=clock or time.time,
+        # Same rationale as SnaglineAutogenHandler: sub-tick latency fidelity
+        # on Windows requires a monotonic high-resolution default (issue #155).
+        clock=clock or time.perf_counter,
         side_effect=side_effect,
     )
     monitor.ingest(event)

--- a/src/snagline/adapters/langchain_adapter.py
+++ b/src/snagline/adapters/langchain_adapter.py
@@ -50,11 +50,22 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
         agent_name: str | None = None,
         clock: Callable[[], float] | None = None,
     ) -> None:
+        """Wire the handler to ``monitor`` for one ``episode_id``.
+
+        ``clock`` defaults to :func:`time.perf_counter`: monotonic and
+        high-resolution on every platform. The previous default,
+        :func:`time.time`, advances in ~15.6 ms ticks on Windows, which
+        quantized sub-tick latencies to zero and starved the CUSUM latency
+        detector of usable samples (issue #155). Note that ``perf_counter``
+        has no meaningful epoch: event timestamps produced with it are only
+        comparable within one process. Detectors consume them solely as
+        in-process latency differences, which is exactly what it guarantees.
+        """
         super().__init__()
         self._monitor = monitor
         self._episode_id = episode_id
         self._agent_name = agent_name
-        self._clock = clock or time.time
+        self._clock = clock or time.perf_counter
         self._counter = itertools.count()
         self._runs: dict[str, dict] = {}
 

--- a/src/snagline/adapters/openai.py
+++ b/src/snagline/adapters/openai.py
@@ -20,6 +20,12 @@ or low-level observation without wrapping::
 The adapter is duck-typed and import-safe: it works without ``openai``
 installed and never hard-couples to a specific SDK release. All
 ``StepEvent`` construction is fail-open and never raises into the host.
+
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`: the wall clock advances in ~15.6 ms ticks on Windows,
+quantizing sub-tick latencies to zero (issue #155). ``perf_counter`` has no
+meaningful epoch, so these timestamps are only comparable within one process;
+detectors consume them solely as in-process latency differences.
 """
 
 from __future__ import annotations
@@ -87,7 +93,7 @@ def observe_openai_call(
     event = StepEvent(
         step_id=step_id or "openai",
         episode_id=episode_id,
-        timestamp=time.time(),
+        timestamp=time.perf_counter(),
         action_type="tool_call",
         action_signature=sig,
         tool_name=model or "openai",
@@ -171,7 +177,7 @@ class _SyncStreamWrapper:
         if self._emitted:
             return
         self._emitted = True
-        latency = (time.time() - self._start) * 1000.0
+        latency = (time.perf_counter() - self._start) * 1000.0
         tokens_in, tokens_out = (None, None)
         if not error and self._last is not None:
             tokens_in, tokens_out = _extract_tokens(self._last)
@@ -183,7 +189,7 @@ class _SyncStreamWrapper:
         event = StepEvent(
             step_id=str(next(self._counter)),
             episode_id=self._episode_id,
-            timestamp=time.time(),
+            timestamp=time.perf_counter(),
             action_type="tool_call",
             action_signature=sig,
             tool_name=str(self._model),
@@ -265,7 +271,7 @@ class _AsyncStreamWrapper:
         if self._emitted:
             return
         self._emitted = True
-        latency = (time.time() - self._start) * 1000.0
+        latency = (time.perf_counter() - self._start) * 1000.0
         tokens_in, tokens_out = (None, None)
         if not error and self._last is not None:
             tokens_in, tokens_out = _extract_tokens(self._last)
@@ -275,7 +281,7 @@ class _AsyncStreamWrapper:
         event = StepEvent(
             step_id=str(next(self._counter)),
             episode_id=self._episode_id,
-            timestamp=time.time(),
+            timestamp=time.perf_counter(),
             action_type="tool_call",
             action_signature=sig,
             tool_name=str(self._model),
@@ -302,7 +308,7 @@ def _emit_now(
     error_type: str | None,
     result: Any,
 ) -> None:
-    latency = (time.time() - start) * 1000.0
+    latency = (time.perf_counter() - start) * 1000.0
     tokens_in, tokens_out = (None, None)
     if not error:
         tokens_in, tokens_out = _extract_tokens(result)
@@ -310,7 +316,7 @@ def _emit_now(
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id=episode_id,
-        timestamp=time.time(),
+        timestamp=time.perf_counter(),
         action_type="tool_call",
         action_signature=sig,
         tool_name=str(model),
@@ -331,7 +337,7 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
     def _sync(*args: Any, **kwargs: Any) -> Any:
         model = kwargs.get("model", "unknown")
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = original(*args, **kwargs)
         except Exception as e:
@@ -368,7 +374,7 @@ def _wrap_one(monitor: Any, original: Any, episode_id: str, counter: Any) -> Any
     async def _async(*args: Any, **kwargs: Any) -> Any:
         model = kwargs.get("model", "unknown")
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = await original(*args, **kwargs)
         except Exception as e:

--- a/tests/adapters/test_perf_counter_clock.py
+++ b/tests/adapters/test_perf_counter_clock.py
@@ -1,0 +1,123 @@
+"""Issue #155 regression: every adapter clock defaults to ``time.perf_counter``.
+
+``time.time()`` advances in ~15.6 ms ticks on Windows, so any tool/LLM call
+shorter than one tick recorded ``latency_ms == 0.0`` and fast operations were
+indistinguishable from instant failures. That starves the CUSUM latency
+detector of usable samples.
+
+These tests reuse the deterministic scripted-clock pattern introduced in
+PR #139 (commit b42d47c), but pointed at the DEFAULT path: instead of
+injecting ``clock=``, we script ``time.perf_counter`` itself. If an adapter
+ever falls back to ``time.time``, the scripted readings are never consumed and
+the assertions fail, so a regression cannot hide behind platform timing.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from snagline.adapters.anthropic import observe_anthropic_call
+from snagline.adapters.autogen import SnaglineAutogenHandler
+from snagline.adapters.crewai import observe_crewai_step
+from snagline.adapters.langchain_adapter import SnaglineCallbackHandler
+from snagline.adapters.openai import observe_openai_call
+from snagline.monitor import Monitor
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self.risks: list = []
+
+    def emit(self, risk) -> None:
+        self.risks.append(risk)
+
+
+def _monitor() -> RecMonitor:
+    return RecMonitor.default(sinks=[RecordingSink()])
+
+
+class RecMonitor(Monitor):
+    """Monitor that also records every ingested event for assertions."""
+
+    def __init__(self, detectors, sinks, fail_open: bool = True):
+        super().__init__(detectors, sinks, fail_open=fail_open)
+        self.events: list = []
+
+    def ingest(self, event):
+        self.events.append(event)
+        super().ingest(event)
+
+
+def _script(*values: float):
+    """Scripted clock: one value per expected reading, then fail loudly."""
+    reads = iter(values)
+    return lambda: next(reads)
+
+
+# Sub-millisecond deltas built from binary-exact floats: 2**-10 seconds is
+# exactly representable and its difference from the base reading is exact, so
+# the asserted latency_ms values hold bit-for-bit on every platform.
+T0 = 1024.0
+SUB_MS_S = 2**-10  # 0.9765625 ms
+
+
+def test_langchain_default_clock_preserves_sub_ms_latency(monkeypatch):
+    # Default path: NO injected clock. Read order per successful tool call:
+    # on_tool_start captures one reading, on_tool_end reads twice more (once
+    # in _latency_from, once for the event timestamp).
+    monkeypatch.setattr(
+        time, "perf_counter", _script(T0, T0 + SUB_MS_S, T0 + 2 * SUB_MS_S)
+    )
+    mon = _monitor()
+    h = SnaglineCallbackHandler(mon, "ep-155")
+
+    h.on_tool_start({"name": "search"}, "query=cat", run_id="r1")
+    h.on_tool_end("result", run_id="r1")
+
+    e = mon.events[0]
+    assert e.latency_ms == pytest.approx(SUB_MS_S * 1000.0, rel=1e-12)
+    assert e.latency_ms > 0.0  # exactly what the Windows tick quantized to zero
+
+
+def test_autogen_default_clock_reads_perf_counter(monkeypatch):
+    scripted = T0 + SUB_MS_S
+    monkeypatch.setattr(time, "perf_counter", _script(scripted))
+    mon = _monitor()
+    h = SnaglineAutogenHandler(mon, "ep-155")
+
+    events = h.observe({"type": "TextMessage", "content": "hello"})
+
+    assert len(events) == 1
+    assert events[0].timestamp == scripted
+
+
+def test_crewai_default_clock_reads_perf_counter(monkeypatch):
+    scripted = T0 + SUB_MS_S
+    monkeypatch.setattr(time, "perf_counter", _script(scripted))
+    mon = _monitor()
+
+    e = observe_crewai_step(mon, "ep-155", {"tool": "search", "output": "hits"})
+
+    assert e.timestamp == scripted
+
+
+def test_openai_observe_reads_perf_counter(monkeypatch):
+    scripted = T0 + SUB_MS_S
+    monkeypatch.setattr(time, "perf_counter", _script(scripted))
+    mon = _monitor()
+
+    e = observe_openai_call(mon, episode_id="ep-155", model="gpt-4o")
+
+    assert e.timestamp == scripted
+
+
+def test_anthropic_observe_reads_perf_counter(monkeypatch):
+    scripted = T0 + SUB_MS_S
+    monkeypatch.setattr(time, "perf_counter", _script(scripted))
+    mon = _monitor()
+
+    e = observe_anthropic_call(mon, episode_id="ep-155", model="claude")
+
+    assert e.timestamp == scripted


### PR DESCRIPTION
Fixes #155

## What

All five framework/SDK adapters defaulted their clock to `time.time()`, which advances in ~15.6 ms system-tick steps on Windows. Any tool/LLM call shorter than one tick recorded `latency_ms == 0.0`, several fast calls collapsed onto identical timestamps, and the CUSUM latency-anomaly detector received degenerate samples (warm-up variance collapsing toward zero, sub-tick spikes invisible).

The default is now `time.perf_counter()` everywhere:

- `src/snagline/adapters/langchain_adapter.py`: `SnaglineCallbackHandler.__init__`
- `src/snagline/adapters/autogen.py`: `SnaglineAutogenHandler.__init__`
- `src/snagline/adapters/crewai.py`: `_CrewAIStepCallback.__init__` + `observe_crewai_step`
- `src/snagline/adapters/openai.py`: all 9 direct call sites (latency measurement + event timestamps)
- `src/snagline/adapters/anthropic.py`: all 9 direct call sites (same)

## Docstring note (per the issue)

Every touched adapter now documents that `perf_counter` has no meaningful epoch, so event timestamps produced with it are only comparable within one process, and that detectors consume them solely as in-process latency differences. Injected `clock=` remains supported on all handlers that exposed it.

## Cross-clock audit (issue step 2)

Detectors (`loop`, `error_cascade`, `latency_anomaly`, ...) read `event.timestamp` only as intra-episode deltas, and each handler feeds one episode from exactly one clock, so nothing persists or compares timestamps across mixed clocks. No detector changes needed.

## Regression tests

New `tests/adapters/test_perf_counter_clock.py` reuses the scripted-clock pattern from PR #139 (commit b42d47c) against the DEFAULT path: `time.perf_counter` itself is scripted via monkeypatch, so if any adapter ever falls back to `time.time`, the scripted readings go unconsumed and the test fails deterministically.

- `test_langchain_default_clock_preserves_sub_ms_latency`: exact binary-exact 0.9765625 ms latency through the default handler path
- `test_autogen_default_clock_reads_perf_counter`, `test_crewai_default_clock_reads_perf_counter`, `test_openai_observe_reads_perf_counter`, `test_anthropic_observe_reads_perf_counter`: scripted perf_counter value lands in `event.timestamp`

## Benchmarks

`benchmarks/overhead_benchmark.py` needs no change: it already measures wall cost with `time.perf_counter` and shares no clock helper with the adapters; its fixture `timestamp=` values are inert data.

## No-extras import smoke check

Ran in a fresh venv with only `pip install -e . --no-deps`: bare `import snagline` plus imports of all five touched adapter modules succeed on a stdlib-only install (adapters keep their guarded optional imports).

## Mutation check

Committed the fix, then mutated `langchain_adapter.py` back to `clock or time.time`: `test_langchain_default_clock_preserves_sub_ms_latency` went red with an exact-latency assertion failure at line 80. Reverted the mutation; suite green again. Caught by: `test_langchain_default_clock_preserves_sub_ms_latency`.

## Gate

Full gate green at this snapshot: `pytest tests/ -q -o addopts=""` (505 passed, 1 skipped), `ruff check src tests`, `ruff format --check src tests`, `mypy src`.

Refs #17, Refs #116, Board: #106
