### PR TITLE
ci: wire detection_accuracy harness as healthy-control false-positive gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,3 +101,46 @@ jobs:
         run: |
           . .venv/bin/activate
           python -m pytest tests/ -q
+
+  benchmark-accuracy:
+    # False-positive gate (issue #148): replays the committed deterministic
+    # 76-episode corpus through benchmarks/detection_accuracy.py on every
+    # push/PR. The harness exits 1 when any healthy control fires, so its
+    # exit code is consumed directly as the gate -- a red job here means a
+    # detector regressed onto healthy traffic and must not merge. Stdlib-only
+    # (imports snagline + stdlib), runs in well under a second.
+    name: Accuracy gate (healthy-control false positives)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.12"
+
+      - name: Install (stdlib-only core, zero extras)
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Accuracy false-positive gate (table format)
+        run: |
+          . .venv/bin/activate
+          python benchmarks/detection_accuracy.py --fixtures benchmarks/fixtures --format table
+
+      - name: Accuracy report JSON (for audit, even when the gate is red)
+        if: always()
+        run: |
+          . .venv/bin/activate
+          python benchmarks/detection_accuracy.py --fixtures benchmarks/fixtures --format json > accuracy-report.json || true
+
+      - name: Upload accuracy report artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: accuracy-report
+          path: accuracy-report.json
+          if-no-files-found: ignore


### PR DESCRIPTION
Fixes #148

## What

Adds a dedicated `benchmark-accuracy` job to `.github/workflows/ci.yml` that replays the committed deterministic corpus through the detection harness on every push to master and every PR:

```bash
python benchmarks/detection_accuracy.py --fixtures benchmarks/fixtures --format table
```

The harness already exits 1 when any healthy control fires (documented contract from #82), so CI consumes its exit code directly as a false-positive gate. No parsing, no new deps.

## Design notes

- **Dedicated job, not a matrix step**: the corpus replay is stdlib-only (`import snagline` + stdlib), needs no langchain-core or ml extras, and adds ~0.2s locally, so running it once on ubuntu-latest parallel to the test matrix is cheaper than 6x inside the matrix. This satisfies "after mypy, before/parallel to tests": the job starts immediately, gated by nothing.
- **Zero-dep install**: `pip install -e .` only; core declares `dependencies = []`. Verified in a fresh stdlib-only venv inside an isolated worktree: bare `import snagline` works with no extras installed.
- **JSON audit artifact**: `--format json > accuracy-report.json` uploaded via `actions/upload-artifact@v4` under `if: always()`, so the report exists even (and especially) when the gate is red. The table exit code remains the sole gate; the JSON is informational only.
- **No threshold drift**: the step passes no config overrides, so it uses exactly `harness_config()` defaults from `src/snagline/config.py`, same as the README table published in #142. Same committed fixtures, same thresholds, so README numbers and CI replay can never diverge.

## Gate proof: red IS the gate working

Per the issue's verification requirement ("a PR that introduces a healthy-control regression must turn the job red"), proved on this branch before cleaning history:

1. Temporary commit flipped near-threshold healthy control `healthy-15`: events s11/s12 given event s10's action signature, creating three identical consecutive calls inside the loop window.
2. Local harness on the flip: `healthy -> loop: 1`, `healthy controls that fired: 1`, exit code 1.
3. Pushed; the accuracy job went RED exactly as intended, printing the same confusion line and failing with `Process completed with exit code 1`: https://github.com/Cyrax321/SNAGLINE/actions/runs/32965152910/job/98165909820 . The regular test jobs also went red on that push since `tests/test_detection_accuracy.py::test_committed_corpus_separates_cleanly` (`healthy-15: expected [], got ['loop']`) and `tests/test_calibration.py::test_auto_is_never_worse_than_manual` independently assert controls stay silent. Two independent layers catching one regression is the desired defense in depth.
4. Reverted the fixture byte-for-byte; the same accuracy job went GREEN on the next run: https://github.com/Cyrax321/SNAGLINE/actions/runs/32965540496/job/98167093692 , full matrix green alongside it.
5. Branch history was then rewritten to drop the flip+revert pair, leaving only the ci.yml change (this diff); head run re-verified green below.

The gate was never loosened, skipped, or allowed to pass while red.

## Local verification (worktree, fresh stdlib venv)

```
$ python benchmarks/detection_accuracy.py --fixtures benchmarks/fixtures --format table
...
episodes: 76 (40 labeled, 36 healthy controls)
confusion (firings on other data):
  (none)
healthy controls that fired: 0    (exit 0)
real 0m0.208s
```

Full gate at the tip commit: pytest 498 passed / 2 skipped, coverage 87.86% (>= 80% gate), ruff check clean, ruff format --check clean, mypy src clean.

Refs #117, #141, #142, #82, board #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an automated detection-accuracy benchmark to validate false-positive rates.
  * Accuracy results are now generated in JSON format and retained as downloadable build artifacts, including when validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->