### PR TITLE
fix(sinks): stop DedupSink cooldown snapshots over-suppressing after reboot

### DIFF
--- a/src/snagline/sinks/dedup.py
+++ b/src/snagline/sinks/dedup.py
@@ -18,6 +18,15 @@ Elapsed time is measured on the monotonic clock. Wall-clock time can step
 stretch a cooldown into an indefinite silence -- the one failure mode an
 alert-suppression wrapper must not have.
 
+Snapshots (``dump_state``/``load_state``, issue #91) record a wall-clock
+companion alongside every monotonic timestamp so restore can tell a same-boot
+process restart (monotonic continuous, suppression continues seamlessly) from
+a host reboot (monotonic reset; restored values would sit in the fresh clock's
+future and silently suppress alerts for roughly the previous uptime -- issue
+#136). Entries that are provably stale or of unverifiable provenance are
+dropped at load with one log line and never restored: an alert-suppression
+wrapper fails by delivering too much, never by staying silent.
+
 A non-positive ``cooldown_seconds`` disables suppression: ``emit`` becomes a
 pass-through that never touches the table. Wrapping is normally avoided
 upstream in that case (``cli._maybe_dedup``), but the sink is public API and
@@ -27,6 +36,8 @@ must behave sanely when constructed directly.
 from __future__ import annotations
 
 import contextlib
+import logging
+import math
 import threading
 import time
 from collections.abc import Callable
@@ -34,6 +45,8 @@ from typing import Any
 
 from snagline.risk import FailureRisk
 from snagline.sinks.base import AlertSink
+
+logger = logging.getLogger("snagline")
 
 
 def _default_key(risk: FailureRisk) -> tuple[Any, ...]:
@@ -135,21 +148,97 @@ class DedupSink:
         key function is in use; a custom ``key_fn`` is an opaque callable, so
         this returns ``None`` and snapshot/restore skip it (a restored dedup
         sink then starts with empty cooldowns rather than failing setup).
+
+        Each entry carries its monotonic timestamp plus a wall-clock companion
+        derived at dump time (``now_wall - (now_mono - t)``), so ``load_state``
+        can judge entry age across a host reboot without any extra per-emit
+        bookkeeping on this sink's hot path. The derivation assumes both clocks
+        advanced together since the emit, which holds within one boot; across a
+        reboot the companion is exactly what exposes the discontinuity.
         """
         if self._key_fn is not _default_key:
             return None
         with self._lock:
+            now_mono = time.monotonic()
+            now_wall = time.time()
+            entries = sorted(self._last.items(), key=lambda kv: repr(kv[0]))
             return {
                 "cooldown_seconds": self._cooldown,
                 # Tuples become lists on JSON round-trip; load_state converts back.
-                "last": [
-                    [list(k), v]
-                    for k, v in sorted(self._last.items(), key=lambda kv: repr(kv[0]))
-                ],
+                "last": [[list(k), t] for k, t in entries],
+                # Wall-clock moment of each entry's last emit (issue #136).
+                "wall": [[list(k), now_wall - (now_mono - t)] for k, t in entries],
             }
 
     def load_state(self, state: dict[str, Any]) -> None:
+        """Restore cooldowns from :meth:`dump_state` (setup-time only, #91).
+
+        A snapshot may have crossed a host reboot since it was written: the
+        fresh clock then starts near zero while restored monotonic timestamps
+        still hold previous-uptime values, so trusting them suppresses every
+        restored key until ``now`` catches up with roughly the old uptime
+        (#136). Restore therefore drops, with one warning and no exception:
+
+        - entries whose wall-clock age already exceeds ``cooldown_seconds``;
+        - entries sitting in the future of the current monotonic clock (proof
+          of a clock reset, whatever the wall clock claims);
+        - entries without a finite wall companion (snapshots from older
+          versions carry no provenance, so they cannot be trusted either way);
+        - anything malformed (fail open to delivery, never raise into setup).
+
+        Surviving entries keep their stored monotonic value: they only survive
+        when the monotonic clock is demonstrably continuous, which is exactly
+        the same-boot restart scenario #91 shipped for.
+        """
         if self._key_fn is not _default_key:
             return
+        if not isinstance(state, dict):
+            logger.warning(
+                "snagline: dedup snapshot malformed (%r); starting with "
+                "empty cooldowns",
+                type(state).__name__,
+            )
+            return
+        try:
+            last_entries: list[Any] = state.get("last", []) or []
+            wall_map = {
+                tuple(k): w
+                for k, w in (state.get("wall") or [])
+                if isinstance(w, (int, float))
+            }
+            now_mono = time.monotonic()
+            now_wall = time.time()
+            restored: dict[Any, float] = {}
+            dropped = 0
+            for k, ts in last_entries:
+                key = tuple(k)
+                wall = wall_map.get(key)
+                if (
+                    not isinstance(ts, (int, float))
+                    or not math.isfinite(float(ts))
+                    or wall is None
+                    or not math.isfinite(wall)
+                    or (now_wall - wall) >= self._cooldown
+                    or float(ts) > now_mono
+                ):
+                    dropped += 1
+                    continue
+                restored[key] = float(ts)
+        except Exception:
+            # Fail open: an unreadable snapshot must not break setup, let alone
+            # surface later inside ingest (#91 contract). Delivering duplicates
+            # beats silently suppressing fresh alerts for hours.
+            logger.warning(
+                "snagline: dedup snapshot unreadable; starting with empty cooldowns",
+                exc_info=True,
+            )
+            return
+        if dropped:
+            logger.warning(
+                "snagline: dedup snapshot carried %d stale or clock-reset "
+                "cooldown entrie(s); dropped them so affected alerts "
+                "re-deliver",
+                dropped,
+            )
         with self._lock:
-            self._last = {tuple(k): float(ts) for k, ts in state.get("last", [])}
+            self._last = restored

--- a/tests/test_sinks_dedup.py
+++ b/tests/test_sinks_dedup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import time
 
 from snagline.risk import (
@@ -172,6 +173,118 @@ class _SweepCountingDedup(DedupSink):
     def _sweep(self, now: float) -> None:
         self.sweeps += 1
         super()._sweep(now)
+
+
+# --- snapshot restore across a host reboot (issue #136) ----------------------
+
+
+def _dumped_snapshot(cooldown: float = 300.0):
+    inner = _RecordingSink()
+    sink = DedupSink(inner, cooldown_seconds=cooldown)
+    sink.emit(_risk(0.9))
+    sink.emit(_risk(0.9))
+    assert len(inner.emitted) == 1, "second immediate emit must be suppressed"
+    dumped = sink.dump_state()
+    assert dumped is not None
+    assert dumped["wall"], "wall-clock companion must be recorded"
+    return dumped
+
+
+def test_dedup_snapshot_restored_after_reboot_delivers(monkeypatch, caplog):
+    """Issue #136 verification sketch: restored monotonic timestamps from before
+    a reboot sit in the fresh clock's future; the duplicate risk emitted after
+    the simulated reboot must be DELIVERED, not suppressed for roughly the
+    previous uptime.
+    """
+    dumped = _dumped_snapshot()
+    # Simulate the reboot: fresh monotonic clock starts near zero. Wall time is
+    # untouched, exactly as on real hardware.
+    monkeypatch.setattr(time, "monotonic", lambda: 5.0)
+    inner_b = _RecordingSink()
+    s2 = DedupSink(inner_b, cooldown_seconds=300.0)
+    with caplog.at_level("WARNING", logger="snagline"):
+        s2.load_state(dumped)
+    assert any("clock-reset" in r.message for r in caplog.records), "drop must log once"
+    s2.emit(_risk(0.9))
+    assert len(inner_b.emitted) == 1, "duplicate after reboot must be delivered"
+
+
+def test_dedup_snapshot_same_boot_restart_still_suppresses(monkeypatch):
+    """The fix must not throw away what #91 shipped: within one boot the
+    monotonic clock is continuous, so a process restart mid-window keeps
+    suppressing for the remainder of the cooldown."""
+    dumped = _dumped_snapshot()
+    stored_mono = dumped["last"][0][1]
+    monkeypatch.setattr(time, "monotonic", lambda: stored_mono + 10.0)
+    inner_b = _RecordingSink()
+    s2 = DedupSink(inner_b, cooldown_seconds=300.0)
+    s2.load_state(dumped)
+    assert len(s2._last) == 1, "same-boot entry must survive restore"
+    s2.emit(_risk(0.9))
+    assert len(inner_b.emitted) == 0, "cooldown continues across same-boot restart"
+
+
+def test_dedup_snapshot_wall_stale_entries_dropped(monkeypatch, caplog):
+    """An entry older than the cooldown by wall clock (long shutdown) is dead
+    weight even when its monotonic value happens to still be in the fresh
+    clock's past; it must be dropped so the alert re-delivers."""
+    dumped = _dumped_snapshot()
+    stored_mono = dumped["last"][0][1]
+    # Monotonic continuous and ahead of the entry, but a day has passed by wall.
+    monkeypatch.setattr(time, "monotonic", lambda: stored_mono + 10.0)
+    real_wall = time.time()
+    monkeypatch.setattr(time, "time", lambda: real_wall + 86_400.0)
+    inner_b = _RecordingSink()
+    s2 = DedupSink(inner_b, cooldown_seconds=300.0)
+    with caplog.at_level("WARNING", logger="snagline"):
+        s2.load_state(dumped)
+    assert len(s2._last) == 0, "wall-stale entry must not be restored"
+    assert any("stale" in r.message for r in caplog.records)
+    s2.emit(_risk(0.9))
+    assert len(inner_b.emitted) == 1
+
+
+def test_dedup_legacy_snapshot_without_wall_fails_open(caplog):
+    """Snapshots written before the wall companion (#136) carry no provenance;
+    they cannot prove same-boot continuity, so their entries are dropped with
+    one warning instead of risking silent over-suppression."""
+    legacy = {
+        "cooldown_seconds": 300.0,
+        "last": [[["ep", "loop", "critical"], time.monotonic()]],
+    }
+    inner = _RecordingSink()
+    s = DedupSink(inner, cooldown_seconds=300.0)
+    with caplog.at_level("WARNING", logger="snagline"):
+        s.load_state(legacy)
+    assert len(s._last) == 0
+    s.emit(_risk(0.9))
+    assert len(inner.emitted) == 1, "unprovenanced entries fail open to delivery"
+
+
+def test_dedup_malformed_snapshot_does_not_raise_and_delivers(caplog):
+    inner = _RecordingSink()
+    s = DedupSink(inner, cooldown_seconds=300.0)
+    garbage = {
+        "cooldown_seconds": 300.0,
+        "last": [["ep", "loop", "critical"]],  # missing timestamp element
+        "wall": [["ep", "loop", "critical", None]],  # wrong shape entirely
+    }
+    with caplog.at_level("WARNING", logger="snagline"):
+        s.load_state(garbage)
+    assert len(s._last) == 0
+    s.emit(_risk(0.9))
+    assert len(inner.emitted) == 1, "garbage snapshot never breaks setup or ingest"
+
+
+def test_dedup_snapshot_survives_json_round_trip():
+    dumped = _dumped_snapshot()
+    round_tripped = json.loads(json.dumps(dumped))
+    inner_b = _RecordingSink()
+    s2 = DedupSink(inner_b, cooldown_seconds=300.0)
+    s2.load_state(round_tripped)
+    assert len(s2._last) == 1, "JSON-compatible state restores cleanly"
+    s2.emit(_risk(0.9))
+    assert len(inner_b.emitted) == 0, "restored suppression still works"
 
 
 def test_dedup_non_positive_cooldown_is_pass_through():


### PR DESCRIPTION
Fixes #136

## What

`DedupSink.dump_state()` persisted raw `time.monotonic()` timestamps. That is correct for the same-boot process restarts #91 targeted, but restoring a snapshot written before a host reboot left every restored key far in the fresh clock's future: old uptime (say 30 days) against `now` near zero, so `(now - last) < cooldown` held and alerts were silently suppressed for roughly the previous uptime. Days-to-weeks of silent alert loss for every restored key.

## Chosen option: wall-clock companion (options 1+2 hybrid), justified

Implemented the wall-clock-companion option rather than the documented same-boot minimum-viable variant:

- **Zero hot-path cost.** `dump_state()` derives each entry's wall-clock moment at dump time as `now_wall - (now_mono - t)`; no extra `time.time()` call per emit, no second dict to maintain. The derivation is valid whenever both clocks advanced together since the emit, which holds within one boot.
- **load_state drop policy.** Entries are dropped (one warning, no exception) when: wall-clock age exceeds `cooldown_seconds`; they sit in the future of the current monotonic clock (proof of a clock reset, whatever the wall clock claims); they lack a finite wall companion (pre-#136 snapshots carry no provenance); or they are malformed. Survivors keep their stored monotonic value, because survival requires demonstrable monotonic continuity, which is exactly the same-boot case.
- **Why not minimum-viable:** the same-boot-only documentation variant leaves cross-reboot restores silently over-suppressing forever. The companion costs a few lines more, keeps same-boot semantics identical to what #91 shipped, makes short cross-reboot windows continue seamlessly by wall age, and turns every unverifiable or provably-stale entry into delivery instead of silence. Fail-open toward delivery is this wrapper's stated correct way to fail.

## Contract compliance (#91)

Restore remains setup-time only. No load path can raise: malformed state logs once and degrades to an empty table, so nothing can ever surface inside `ingest`. A dropped snapshot means duplicates get delivered, never that fresh alerts go missing.

## Tests (`tests/test_sinks_dedup.py`)

- `test_dedup_snapshot_restored_after_reboot_delivers`: the issue's verification sketch verbatim (patch `time.monotonic` low simulating reboot, restore, emit duplicate risk, assert DELIVERED not suppressed) plus assert the one-time warning
- `test_dedup_snapshot_same_boot_restart_still_suppresses`: #91 behavior preserved across a mid-window restart
- `test_dedup_snapshot_wall_stale_entries_dropped`: long-shutdown entries dropped even when monotonic happens to be ahead
- `test_dedup_legacy_snapshot_without_wall_fails_open`, `test_dedup_malformed_snapshot_does_not_raise_and_delivers`
- `test_dedup_snapshot_survives_json_round_trip`

## Mutation check

Committed the fix, then mutated the committed file to disable the future-monotonic guard (`or float(ts) > now_mono` -> `or False`): `test_dedup_snapshot_restored_after_reboot_delivers` went red (duplicate was suppressed). Reverted via `git checkout --`; suite green again. Caught by: `test_dedup_snapshot_restored_after_reboot_delivers`.

## Gate

Full gate green at this snapshot: `pytest tests/ -q -o addopts=""` (511 passed, 1 skipped), `ruff check src tests`, `ruff format --check src tests`, `mypy src`. Bare `import snagline` verified against `src/` on a dependency-free interpreter.

Refs #91. Board: #106
