### PR TITLE
feat(continuum): ledger adapter + REQUIRES_REVIEW sink (Fixes #79)

### DIFF
--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -102,14 +102,51 @@ to protect constraints it cannot see. Enable it with
 | `adapters/langgraph_adapter.py` | LangGraph `graph.stream()` | pass-through iterator wrapper |
 | `adapters/autogen.py` | Autogen `agent.run_stream(task)` | `SnaglineAutogenHandler` observer + `run_and_monitor` wrapper |
 | `adapters/crewai.py` | CrewAI `Agent(step_callback=...)` | `snagline_step_callback` returning the hook callable |
+| `adapters/continuum_adapter.py` | CONTINUUM `Storage` event log | `ContinuumAdapter` poll/push translating ledger entries |
 | `server/http_server.py` | any non-Python runtime | stdlib HTTP sidecar, `POST /events` |
 
 Both the Autogen and CrewAI adapters are duck-typed: they read event objects via
 `model_dump()` with attribute/dict fallbacks, so they import without the
-framework installed and never hard-couple to a specific release. Adapters for
-raw OpenAI/Anthropic SDKs and CONTINUUM remain planned (project.md §13 step 10 /
-§6) - the raw adapter is usually a fine stand-in for any of them, since they all
-bottom out in a tool-calling loop.
+framework installed and never hard-couple to a specific release. The CONTINUUM
+adapter (`pip install snagline-agent[continuum]`, issue #79) is duck-typed the
+same way: it calls only the verified public read pair
+(`read_events(run_id, *, after_sequence=0, upto=None)` + `last_sequence(run_id)`)
+and never imports `continuum`. It maps `PERCEPTION_OBSERVED` to an observation,
+`BRANCH_RESOLVED` to a plan step, and the action-ledger lifecycle
+(`ACTION_RECORDED` started/completed/failed, plus reconcile/compensate) to tool
+calls with paired latency. `raw_claim` text is dropped at translation time;
+only hashes, ids, statuses and counts cross over.
+
+## CONTINUUM sink (closing the loop)
+
+`sinks/continuum_sink.py` escalates a detected risk back into CONTINUUM via its
+existing request-human path: `ActionLedger.flag_for_review(key, reason)`, which
+sets the action's status to `REQUIRES_REVIEW` and appends an auditable ledger
+event (CONTINUUM's recovery planner then routes it to a person).
+
+```python
+from snagline.sinks.continuum_sink import ContinuumSink
+
+sink = ContinuumSink(
+    storage,                      # a CONTINUUM Storage handle
+    run_id,
+    key_from_risk=lambda risk: my_action_keys.get(risk.step_id),
+)
+monitor.add_sink(sink)
+```
+
+Honest limits, verified against current CONTINUUM source:
+
+- Run-level `request_human` is a *derived* recovery mode there; the only
+  writable escalation API is the action-level `flag_for_review`. A risk with no
+  resolvable action key is therefore logged and dropped, not fabricated onto
+  the ledger.
+- `key_from_risk` must return the resolved idempotency key or `action_id`; a
+  bare action name is refused by the real ledger with `LedgerError`.
+- Exercised against real CONTINUUM code only in the skip-guarded test
+  `tests/sinks/test_continuum_sink.py::test_real_actionledger_flags_review`
+  (claim -> flag_for_review -> REQUIRES_REVIEW); no live CONTINUUM instance was
+  used for end-to-end polling.
 
 ## Testing your adapter
 

--- a/docs/INTEGRATION_MATRIX.md
+++ b/docs/INTEGRATION_MATRIX.md
@@ -12,6 +12,7 @@ dependency-free unless noted; the core is always zero-required-dependency.
 | File / command bridge | `snagline watch --file` or `hook --out` | any | forward one JSON line |
 | Python auto-instrumentation | `snagline.auto` (OpenAI/Anthropic/LangChain) | Python | one import |
 | Framework adapters | `adapters.raw`, `langchain`, `langgraph`, `autogen`, `crewai`, `claude_code` | Python | wrap your loop |
+| CONTINUUM ledger (free telemetry) | `adapters.continuum_adapter` poll/push over a CONTINUUM `Storage` handle (issue #79) | Python (CONTINUUM runs) | none in host; consumer of the existing ledger |
 
 ## Transport security
 
@@ -52,11 +53,21 @@ from snagline.adapters.langchain import LLMChainObserver
 from snagline.adapters.langgraph import GraphObserver
 from snagline.adapters.autogen import SnaglineAutogenHandler
 from snagline.adapters.crewai import snagline_step_callback
+from snagline.adapters.continuum_adapter import ContinuumAdapter
 ```
 
 Each adapter maps the framework's native callback/hook into a `StepEvent` and
 hands it to a `Monitor`. They are duck-typed so they work without the
 framework installed at import time.
+
+The CONTINUUM adapter watches an existing run's hash-chained ledger
+(`PERCEPTION_OBSERVED`, `BRANCH_RESOLVED`, action claim/complete/reconcile/
+compensate) and needs zero new instrumentation on the CONTINUUM side. Verified
+against current CONTINUUM source: reads go through
+`read_events(run_id, *, after_sequence, upto)` + `last_sequence(run_id)`.
+Not exercised against a live CONTINUUM instance end-to-end; unit tests use a
+fake storage implementing only that verified surface, plus one skip-guarded
+test running the real `ActionLedger`.
 
 ## Sinks (escalation)
 
@@ -68,6 +79,7 @@ framework installed at import time.
 | `PagerDutySink` | PagerDuty Events API v2 | stdlib |
 | `DedupSink` | cooldown/dedup wrapper (issue #4) | stdlib |
 | `BatchingSink` | async, rate-limited dispatch | stdlib |
+| `ContinuumSink` (issue #79) | escalates via CONTINUUM `ActionLedger.flag_for_review` -> `REQUIRES_REVIEW`; needs a resolvable action key per risk | stdlib core; `snagline-agent[continuum]` extra for the lazy import |
 
 CLI: `snagline watch --sink {console,webhook,slack,pagerduty}` (plus
 `--cooldown-seconds`, `--min-severity`). Wrap any sink in `DedupSink` and/or

--- a/project.md
+++ b/project.md
@@ -619,17 +619,25 @@ calls (not monkeypatching) for people using a raw SDK without any
 orchestration framework at all — this is the "raw loop" case's most common
 concrete form.
 
-### 6.6 `continuum_adapter.py`
+### 6.6 `continuum_adapter.py` -- BUILT (issue #79)
 
-Reads CONTINUUM's `Storage` by sequence (its existing public API) and
-translates ledger entries — including the `PERCEPTION_OBSERVED`,
-`BRANCH_RESOLVED`, and action-ledger claim/perform/complete events from the
-security-extension work already done — into `StepEvent`s. This is the
-"free telemetry" case: zero new instrumentation on the CONTINUUM side,
-just a consumer of the existing hash-chained ledger. **Verify the exact
-`Storage` read-by-sequence method signature against the current CONTINUUM
-source before implementing** — don't assume the API shape described here
-is exact; confirm against the real repo.
+Reads CONTINUUM's `Storage` by sequence and translates ledger entries,
+including the `PERCEPTION_OBSERVED`, `BRANCH_RESOLVED`, and action-ledger
+claim/perform/complete events from the security-extension work already done,
+into `StepEvent`s. This is the "free telemetry" case: zero new instrumentation
+on the CONTINUUM side, just a consumer of the existing hash-chained ledger.
+
+Verified against current CONTINUUM source: there is no `read_by_sequence`
+method; the public read-by-sequence surface is
+`read_events(run_id, *, after_sequence=0, upto=None)` plus
+`last_sequence(run_id)`, which is what the adapter codes against. Poll mode
+advances `after_sequence`; push mode accepts live-tailed entries. The sink
+(`sinks/continuum_sink.py`) escalates risks via
+`ActionLedger.flag_for_review(key, reason)` -> `ActionStatus.REQUIRES_REVIEW`;
+run-level `request_human` remains a derived recovery mode with no public
+append API, so risks without a resolvable action key are dropped, not
+fabricated. Ships behind the optional `[continuum]` extra (`continuum-agent`);
+both modules are duck-typed and never import `continuum`.
 
 ### 6.7 `claude_code_adapter.py`
 
@@ -815,8 +823,7 @@ project easily").
   (`snagline/auto/openai.py`, `anthropic.py`, plus explicit wrappers per
   §6.5). The horizon detector set (§5.4–5.6) and restart-survivable
   snapshots (§4.6) are **done** on the `feat/horizon-detectors` branch.
-  Still pending: `continuum_adapter.py`/`continuum_sink.py` and the
-  `drift` extra.
+  Still pending: the `drift` extra.
 
 ---
 
@@ -896,6 +903,24 @@ when the optional langchain extra is absent).
   `ml_ensemble` shipped detector is the deterministic stand-in.
 - `drift` extra semantic goal-drift (`drift/goal_drift.py`,
   sentence-transformers).
-- `continuum_adapter.py`/`continuum_sink.py`, `openai_adapter.py`,
-  `anthropic_adapter.py`.
 - `benchmarks/detection_accuracy.py` (paper-number honesty gate in §14).
+
+### CONTINUUM bridge (issue #79)
+
+- **CONTINUUM adapter** (`adapters/continuum_adapter.py`): poll-by-sequence and
+  push modes translating `PERCEPTION_OBSERVED`, `BRANCH_RESOLVED`, and the
+  action-ledger lifecycle into `StepEvent`s; latency paired claim-to-terminal;
+  `raw_claim` and other payload text dropped at translation. Coded against the
+  verified real API (`read_events(run_id, *, after_sequence, upto)` /
+  `last_sequence(run_id)`), not the spec's guessed name. Duck-typed; imports
+  without CONTINUUM present.
+- **CONTINUUM sink** (`sinks/continuum_sink.py`): escalates a `FailureRisk` by
+  calling `ActionLedger.flag_for_review` so the action lands as
+  `REQUIRES_REVIEW`; requires a resolvable action key (`key_from_risk`) and
+  drops unmapped risks rather than inventing ledger facts. Fail-open.
+- **Extra**: `snagline-agent[continuum]` names the real `continuum-agent`
+  distribution; core stays zero-dependency either way.
+- **Verification honesty**: unit tests use a fake storage implementing only
+  the verified surface; one skip-guarded test drives the real
+  `ActionLedger.claim` -> `flag_for_review` path where CONTINUUM is importable.
+  No end-to-end run against a live CONTINUUM instance has been performed.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,12 +35,16 @@ crewai     = ["crewai>=0.30"]
 # SDKs used by the bundled demos (real agent harnesses):
 openai     = ["openai>=1.0"]
 anthropic  = ["anthropic>=0.30"]
+# CONTINUUM bridge (issue #79): the adapter/sink are duck-typed and never
+# import continuum, so an in-process or vendored CONTINUUM works without this;
+# the extra just names the real distribution (continuum-agent) for pip users.
+continuum  = ["continuum-agent"]
 # Optional extras (not required for the core fail-open detector):
 ml         = ["numpy>=1.24", "scikit-learn>=1.3"]   # ESN ensemble (issue #80)
 drift      = ["sentence-transformers>=2.2"]          # semantic goal-drift (issue #81)
 # Slack and PagerDuty sinks ship in the core and use only the stdlib, so they
 # need no extra dependency; the `all` extra pulls in the framework/SDK extras.
-all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift]"]
+all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift,continuum]"]
 
 [project.scripts]
 snagline = "snagline.cli:main"

--- a/src/snagline/adapters/continuum_adapter.py
+++ b/src/snagline/adapters/continuum_adapter.py
@@ -68,6 +68,11 @@ logger = logging.getLogger("snagline")
 
 __all__ = ["ContinuumAdapter"]
 
+#: Bound on the claim->terminal latency window map: actions that never reach a
+#: terminal status (crashed run, dropped tail) are evicted oldest-first so a
+#: long poll_forever cannot grow memory without limit.
+_MAX_PENDING_CLAIMS = 10_000
+
 #: Entry types that map onto an agent step; everything else is skipped.
 _PERCEPTION = "PERCEPTION_OBSERVED"
 _BRANCH = "BRANCH_RESOLVED"
@@ -76,14 +81,18 @@ _ACTION_RECONCILED = "ACTION_RECONCILED"
 _ACTION_COMPENSATED = "ACTION_COMPENSATED"
 
 
-def _to_epoch(timestamp: Any) -> float:
-    """Accept a datetime (CONTINUUM's Event.timestamp) or a numeric epoch."""
+def _to_epoch(timestamp: Any) -> float | None:
+    """Accept a datetime (CONTINUUM's Event.timestamp) or a numeric epoch.
+
+    Returns None when unusable so callers can fall back to their own clock:
+    ledger times are the truth about when a step happened, the local clock is
+    only a last resort.
+    """
     if isinstance(timestamp, datetime):
         return timestamp.timestamp()
-    try:
+    if isinstance(timestamp, (int, float)) and not isinstance(timestamp, bool):
         return float(timestamp)
-    except (TypeError, ValueError):
-        return time.time()
+    return None
 
 
 def _as_dict(payload: Any) -> Mapping[str, Any]:
@@ -219,12 +228,20 @@ class ContinuumAdapter:
         payload = _as_dict(getattr(entry, "payload", None))
         name = str(entry_type).rsplit(".", 1)[-1] if entry_type is not None else ""
 
+        # The ledger's own timestamp is when the step happened; the local clock
+        # is only a fallback for malformed entries. Review finding (PR #164):
+        # wall-clock-at-translation made latency pairing meaningless because a
+        # poll batch translates claim and completion microseconds apart.
+        event_time = _to_epoch(getattr(entry, "timestamp", None))
+        if event_time is None:
+            event_time = self._clock()
+
         if name == _PERCEPTION:
-            event = self._perception(sequence, payload)
+            event = self._perception(event_time, sequence, payload)
         elif name == _BRANCH:
-            event = self._branch(sequence, payload)
+            event = self._branch(event_time, sequence, payload)
         elif name in (_ACTION_RECORDED, _ACTION_RECONCILED, _ACTION_COMPENSATED):
-            event = self._action(name, sequence, payload)
+            event = self._action(name, event_time, sequence, payload)
         else:
             return None
         if event is not None and sequence is not None:
@@ -247,7 +264,9 @@ class ContinuumAdapter:
             return
         self._cursor = max(tail, 0) if self._cursor < 0 else 0
 
-    def _perception(self, sequence: Any, payload: Mapping[str, Any]) -> StepEvent:
+    def _perception(
+        self, event_time: float, sequence: Any, payload: Mapping[str, Any]
+    ) -> StepEvent:
         source = _str(payload.get("source"))
         observation_id = _str(payload.get("observation_id")) or ""
         trust = _str(payload.get("trust_level")) or ""
@@ -257,7 +276,7 @@ class ContinuumAdapter:
         return StepEvent(
             step_id=str(sequence),
             episode_id=self._run_id,
-            timestamp=self._clock(),
+            timestamp=event_time,
             action_type="observation",
             action_signature=sig,
             tool_name=source,
@@ -270,7 +289,9 @@ class ContinuumAdapter:
             },
         )
 
-    def _branch(self, sequence: Any, payload: Mapping[str, Any]) -> StepEvent:
+    def _branch(
+        self, event_time: float, sequence: Any, payload: Mapping[str, Any]
+    ) -> StepEvent:
         requires_review = bool(payload.get("requires_review", False))
         branch = _as_dict(payload.get("branch"))
         branch_name = _str(branch.get("name")) or _str(branch.get("branch_id")) or ""
@@ -283,7 +304,7 @@ class ContinuumAdapter:
         return StepEvent(
             step_id=str(sequence),
             episode_id=self._run_id,
-            timestamp=self._clock(),
+            timestamp=event_time,
             action_type="plan_step",
             action_signature=sig,
             tool_name=_str(branch_name),
@@ -296,18 +317,24 @@ class ContinuumAdapter:
         )
 
     def _action(
-        self, name: str, sequence: Any, payload: Mapping[str, Any]
+        self, name: str, event_time: float, sequence: Any, payload: Mapping[str, Any]
     ) -> StepEvent:
         status = _str(payload.get("status")) or ""
         tool_name = _str(payload.get("action_type"))
         key = _str(payload.get("key")) or _str(payload.get("action_id")) or ""
-        now = self._clock()
+        now = event_time
         latency: float | None = None
         if status == "started":
             # A fresh claim opens the latency window; a repeat claim for a key
             # we already track keeps the original start (retry, not restart).
             self._pending_claims.setdefault(key, now)
+            while len(self._pending_claims) > _MAX_PENDING_CLAIMS:
+                # Insertion order makes the first key the oldest claim. Evict
+                # it so a never-terminating action cannot grow this forever.
+                self._pending_claims.pop(next(iter(self._pending_claims)))
         elif key in self._pending_claims:
+            # Terminal record: close the window using LEDGER times on both
+            # sides, so the number is the real claim-to-terminal duration.
             latency = max(0.0, (now - self._pending_claims.pop(key)) * 1000.0)
         action_type = {
             _ACTION_RECONCILED: "action_reconciled",

--- a/src/snagline/adapters/continuum_adapter.py
+++ b/src/snagline/adapters/continuum_adapter.py
@@ -1,0 +1,333 @@
+"""CONTINUUM ledger adapter (optional extra: ``pip install snagline-agent[continuum]``).
+
+"Free telemetry": reads a CONTINUUM run's hash-chained event log through its
+existing public ``Storage`` API and translates entries into SNAGLINE
+``StepEvent``s. Zero new instrumentation on the CONTINUUM side.
+
+Verified against the current CONTINUUM source (``continuum.storage.base.Storage``
+and ``continuum.events``); project.md section 6.6 described a
+``read_by_sequence`` method, but the real public read-by-sequence surface is::
+
+    Storage.read_events(run_id, *, after_sequence: int = 0,
+                        upto: int | None = None) -> Sequence[Event]
+    Storage.last_sequence(run_id) -> int
+
+Polling therefore advances ``after_sequence``; this adapter codes only against
+that verified pair of methods plus the ``Event`` fields ``sequence``, ``type``,
+``timestamp`` and ``payload``. The delta is recorded here and in the PR.
+
+Ledger entries translated (project.md section 6.6 mapping):
+
+=========================  =====================  ==================================
+CONTINUUM entry            StepEvent.action_type  Notes
+=========================  =====================  ==================================
+PERCEPTION_OBSERVED        "observation"          trust_level/verifier/hash kept;
+                                                  raw_claim NEVER copied (privacy)
+BRANCH_RESOLVED            "plan_step"            requires_review flag kept
+ACTION_RECORDED            "tool_call"            claim/perform/complete lifecycle:
+                                                  status started -> completed/failed;
+                                                  latency paired from observed times
+ACTION_RECONCILED          "action_reconciled"
+ACTION_COMPENSATED         "action_compensated"
+=========================  =====================  ==================================
+
+Other entry types (RUN_STARTED, TASK_UPDATED, checkpoints, ...) are skipped:
+they carry no agent-step semantics for SNAGLINE's detectors.
+
+Two consumption modes:
+
+* **Poll**: :meth:`ContinuumAdapter.poll` reads new entries by sequence and
+  ingests them. Call it periodically from your own loop (or use
+  :meth:`ContinuumAdapter.poll_forever`).
+* **Push**: :meth:`ContinuumAdapter.push` translates one already-observed
+  ledger entry, for callers that tail the log live via their own callback.
+
+The adapter is duck-typed like every other adapter: it never imports
+``continuum``, so this module is importable without any extra installed and
+never hard-couples to a release. Fail-open (project.md principle 2): storage
+errors are caught, logged once and ignored; a poisoned entry is skipped
+without stopping the rest; nothing here can crash or block the host agent.
+
+Privacy (project.md principle 4): hashes, ids, counts, statuses, timestamps.
+Payload text such as ``raw_claim`` is dropped at translation time and never
+reaches a ``StepEvent``.
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from collections.abc import Callable, Mapping
+from datetime import datetime
+from typing import Any
+
+from snagline.events import StepEvent, make_signature
+
+logger = logging.getLogger("snagline")
+
+__all__ = ["ContinuumAdapter"]
+
+#: Entry types that map onto an agent step; everything else is skipped.
+_PERCEPTION = "PERCEPTION_OBSERVED"
+_BRANCH = "BRANCH_RESOLVED"
+_ACTION_RECORDED = "ACTION_RECORDED"
+_ACTION_RECONCILED = "ACTION_RECONCILED"
+_ACTION_COMPENSATED = "ACTION_COMPENSATED"
+
+
+def _to_epoch(timestamp: Any) -> float:
+    """Accept a datetime (CONTINUUM's Event.timestamp) or a numeric epoch."""
+    if isinstance(timestamp, datetime):
+        return timestamp.timestamp()
+    try:
+        return float(timestamp)
+    except (TypeError, ValueError):
+        return time.time()
+
+
+def _as_dict(payload: Any) -> Mapping[str, Any]:
+    return payload if isinstance(payload, Mapping) else {}
+
+
+def _str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value)
+    return text or None
+
+
+class ContinuumAdapter:
+    """Translate CONTINUUM ledger entries into ``StepEvent``s for a Monitor.
+
+    Args:
+        monitor: a :class:`snagline.monitor.Monitor` (duck-typed: anything
+            with ``ingest``).
+        storage: a CONTINUUM ``Storage`` (duck-typed: only ``read_events`` and
+            ``last_sequence`` are called).
+        run_id: the CONTINUUM run to follow; becomes the SNAGLINE episode id.
+        start_at_tail: when True (default), the first :meth:`poll` starts at
+            the log's current tail so you monitor live activity instead of
+            replaying history. Set False to replay the whole run from
+            sequence 1.
+    """
+
+    def __init__(
+        self,
+        monitor: Any,
+        storage: Any,
+        run_id: str,
+        *,
+        start_at_tail: bool = True,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        self._monitor = monitor
+        self._storage = storage
+        self._run_id = run_id
+        self._clock = clock or time.time
+        self._cursor = -1 if start_at_tail else 0
+        self._started = False
+        #: action key -> epoch seconds of the observed claim, for latency pairing
+        self._pending_claims: dict[str, float] = {}
+        self._stop = threading.Event()
+
+    # -- public API -------------------------------------------------------- #
+
+    def poll(self) -> int:
+        """Read and ingest every entry after the cursor. Returns count ingested.
+
+        Fail-open: any storage error is logged and swallowed; the caller's loop
+        keeps running and the next poll retries.
+        """
+        if not self._started:
+            self._seek_initial_cursor()
+            self._started = True
+        try:
+            entries = list(
+                self._storage.read_events(self._run_id, after_sequence=self._cursor)
+            )
+        except Exception:
+            logger.warning(
+                "snagline continuum adapter: read failed for run %s; will retry",
+                self._run_id,
+                exc_info=True,
+            )
+            return 0
+        count = 0
+        for entry in entries:
+            if self.push(entry):
+                count += 1
+        return count
+
+    def poll_forever(
+        self, interval: float = 1.0, stop_event: threading.Event | None = None
+    ) -> None:
+        """Poll on a fixed interval until ``stop_event`` is set (or Ctrl-C).
+
+        Deliberately boring: stdlib sleep loop, no threads spawned, no network.
+        """
+        stop = stop_event or self._stop
+        while not stop.is_set():
+            self.poll()
+            stop.wait(max(0.05, interval))
+
+    def stop(self) -> None:
+        """Signal a :meth:`poll_forever` loop using its default stop event."""
+        self._stop.set()
+
+    def push(self, entry: Any) -> bool:
+        """Translate one live-tailed ledger entry and ingest it.
+
+        Push mode: for callers that observe entries as they are appended and
+        prefer handing them over directly. Returns True when an event was
+        ingested. Never raises.
+        """
+        sequence = getattr(entry, "sequence", None)
+        try:
+            event = self.translate(entry)
+        except Exception:
+            logger.warning(
+                "snagline continuum adapter: failed to translate entry; skipped",
+                exc_info=True,
+            )
+            self._advance(sequence)
+            return False
+        if event is None:
+            self._advance(sequence)
+            return False
+        try:
+            self._monitor.ingest(event)
+        except Exception:
+            logger.warning(
+                "snagline continuum adapter: monitor.ingest raised; event dropped",
+                exc_info=True,
+            )
+            self._advance(sequence)
+            return False
+        self._advance(sequence)
+        return True
+
+    def _advance(self, sequence: Any) -> None:
+        """Move the poll cursor past an entry, whatever happened to it."""
+        if isinstance(sequence, int) and not isinstance(sequence, bool):
+            self._cursor = max(self._cursor, sequence)
+
+    def translate(self, entry: Any) -> StepEvent | None:
+        """Map one ledger entry to a ``StepEvent``; None for irrelevant types."""
+        sequence = getattr(entry, "sequence", None)
+        entry_type = getattr(entry, "type", None)
+        payload = _as_dict(getattr(entry, "payload", None))
+        name = str(entry_type).rsplit(".", 1)[-1] if entry_type is not None else ""
+
+        if name == _PERCEPTION:
+            event = self._perception(sequence, payload)
+        elif name == _BRANCH:
+            event = self._branch(sequence, payload)
+        elif name in (_ACTION_RECORDED, _ACTION_RECONCILED, _ACTION_COMPENSATED):
+            event = self._action(name, sequence, payload)
+        else:
+            return None
+        if event is not None and sequence is not None:
+            event.metadata["sequence"] = sequence
+        return event
+
+    # -- translation internals ---------------------------------------------- #
+
+    def _seek_initial_cursor(self) -> None:
+        try:
+            tail = int(self._storage.last_sequence(self._run_id))
+        except Exception:
+            logger.warning(
+                "snagline continuum adapter: last_sequence failed for run %s; "
+                "starting from sequence 0",
+                self._run_id,
+                exc_info=True,
+            )
+            self._cursor = 0
+            return
+        self._cursor = max(tail, 0) if self._cursor < 0 else 0
+
+    def _perception(self, sequence: Any, payload: Mapping[str, Any]) -> StepEvent:
+        source = _str(payload.get("source"))
+        observation_id = _str(payload.get("observation_id")) or ""
+        trust = _str(payload.get("trust_level")) or ""
+        verifier = _str(payload.get("verifier")) or ""
+        content_hash = _str(payload.get("content_hash")) or ""
+        sig = make_signature("observation", source, observation_id, content_hash)
+        return StepEvent(
+            step_id=str(sequence),
+            episode_id=self._run_id,
+            timestamp=self._clock(),
+            action_type="observation",
+            action_signature=sig,
+            tool_name=source,
+            metadata={
+                "adapter": "continuum",
+                "event_type": "PERCEPTION_OBSERVED",
+                "observation_id": observation_id,
+                "trust_level": trust,
+                "verifier": verifier,
+            },
+        )
+
+    def _branch(self, sequence: Any, payload: Mapping[str, Any]) -> StepEvent:
+        requires_review = bool(payload.get("requires_review", False))
+        branch = _as_dict(payload.get("branch"))
+        branch_name = _str(branch.get("name")) or _str(branch.get("branch_id")) or ""
+        sig = make_signature(
+            "plan_step",
+            branch_name or None,
+            str(branch_name),
+            "review" if requires_review else "auto",
+        )
+        return StepEvent(
+            step_id=str(sequence),
+            episode_id=self._run_id,
+            timestamp=self._clock(),
+            action_type="plan_step",
+            action_signature=sig,
+            tool_name=_str(branch_name),
+            error=False,
+            metadata={
+                "adapter": "continuum",
+                "event_type": "BRANCH_RESOLVED",
+                "requires_review": requires_review,
+            },
+        )
+
+    def _action(
+        self, name: str, sequence: Any, payload: Mapping[str, Any]
+    ) -> StepEvent:
+        status = _str(payload.get("status")) or ""
+        tool_name = _str(payload.get("action_type"))
+        key = _str(payload.get("key")) or _str(payload.get("action_id")) or ""
+        now = self._clock()
+        latency: float | None = None
+        if status == "started":
+            # A fresh claim opens the latency window; a repeat claim for a key
+            # we already track keeps the original start (retry, not restart).
+            self._pending_claims.setdefault(key, now)
+        elif key in self._pending_claims:
+            latency = max(0.0, (now - self._pending_claims.pop(key)) * 1000.0)
+        action_type = {
+            _ACTION_RECONCILED: "action_reconciled",
+            _ACTION_COMPENSATED: "action_compensated",
+        }.get(name, "tool_call")
+        sig = make_signature(action_type, tool_name, key, status)
+        return StepEvent(
+            step_id=str(sequence),
+            episode_id=self._run_id,
+            timestamp=now,
+            action_type=action_type,
+            action_signature=sig,
+            tool_name=tool_name,
+            latency_ms=latency,
+            error=status == "failed",
+            metadata={
+                "adapter": "continuum",
+                "event_type": name,
+                "status": status,
+                "action_key_hash": make_signature("key", None, key)[:16] if key else "",
+                "external_id": _str(payload.get("external_id")),
+            },
+        )

--- a/src/snagline/sinks/continuum_sink.py
+++ b/src/snagline/sinks/continuum_sink.py
@@ -1,0 +1,116 @@
+"""CONTINUUM sink -- escalate ``FailureRisk`` into a CONTINUUM review (issue #79).
+
+Closing the loop: when SNAGLINE detects a failure risk in an agent whose
+actions live in a CONTINUUM run, this sink escalates it through CONTINUUM's
+existing request-human mechanism so a person is pulled in exactly where
+SNAGLINE would want a pause.
+
+Verified against current CONTINUUM source: the writable escalation path is
+``continuum.actions.ActionLedger.flag_for_review(key, reason)``, which sets the
+action's status to ``ActionStatus.REQUIRES_REVIEW`` and appends an auditable
+ledger event; CONTINUUM's recovery planner then treats that action as needing a
+person and its engine escalates the run toward ``request_human``. Run-level
+``request_human`` is itself only a derived recovery mode in current CONTINUUM
+(no public append API), so this sink escalates through the action ledger and
+asks the caller to say which action key a risk refers to::
+
+    ContinuumSink(storage, run_id, key_from_risk=my_mapping)
+
+Risks with no resolvable action key are dropped with a log line rather than
+fabricated onto the ledger: an invented key would either raise inside
+CONTINUUM or, worse, attach SNAGLINE's opinion to the wrong action.
+
+Optional extra ``snagline-agent[continuum]``. The ``continuum`` import is
+lazy and guarded: constructing the sink without CONTINUUM installed raises a
+helpful ``ImportError`` naming the extra (host setup error), while runtime
+``emit()`` failures are caught and logged -- monitoring must never break the
+host agent (project.md principle 2). Pass ``ledger_factory`` to inject any
+duck-typed replacement in tests or vendored setups.
+
+Privacy: only ``FailureRisk`` fields travel (score, trigger, ids, timestamps,
+its content-free ``detail``). No prompt, tool output or event metadata is ever
+forwarded (project.md section 11).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from snagline.risk import FailureRisk
+
+logger = logging.getLogger("snagline")
+
+__all__ = ["ContinuumSink"]
+
+
+def _default_ledger_factory(storage: Any, run_id: str) -> Any:
+    """Build a real ``continuum.actions.ActionLedger``, importing lazily."""
+    try:
+        from continuum.actions import ActionLedger
+    except ImportError as exc:  # pragma: no cover - exercised via fake factory
+        raise ImportError(
+            "ContinuumSink needs CONTINUUM's ActionLedger; install the "
+            "'snagline-agent[continuum]' extra or pass ledger_factory="
+            "for a duck-typed replacement"
+        ) from exc
+    return ActionLedger(storage, run_id)
+
+
+class ContinuumSink:
+    """Forward detected risks into CONTINUUM as ``REQUIRES_REVIEW`` actions."""
+
+    def __init__(
+        self,
+        storage: Any,
+        run_id: str,
+        *,
+        key_from_risk: Callable[[FailureRisk], str | None] | None = None,
+        ledger_factory: Callable[[Any, str], Any] | None = None,
+    ) -> None:
+        self._storage = storage
+        self._run_id = run_id
+        self._key_from_risk = key_from_risk
+        self._ledger_factory = ledger_factory or _default_ledger_factory
+        # Resolve the ledger eagerly so a missing extra fails loudly during
+        # host setup instead of silently swallowing every future alert.
+        self._ledger = self._ledger_factory(storage, run_id)
+
+    def emit(self, risk: FailureRisk) -> None:
+        """Escalate one risk. Fire-and-forget; never raises into the Monitor."""
+        try:
+            key = self._key_from_risk(risk) if self._key_from_risk else None
+            if not key:
+                logger.warning(
+                    "snagline continuum sink: no action key for %s/%s (%s); "
+                    "cannot escalate without one",
+                    risk.episode_id,
+                    risk.step_id,
+                    risk.trigger,
+                )
+                return
+            self.escalate_action(
+                key,
+                f"[snagline:{risk.trigger}] score={risk.score:.2f} "
+                f"severity={risk.severity} step={risk.step_id} episode="
+                f"{risk.episode_id}: {risk.detail}",
+            )
+        except Exception:
+            logger.warning(
+                "snagline continuum sink: escalation failed for %s/%s; dropped",
+                risk.episode_id,
+                risk.step_id,
+                exc_info=True,
+            )
+
+    def escalate_action(self, action_key: str, reason: str) -> None:
+        """Flag one CONTINUUM action for human review (fail-open wrapper)."""
+        try:
+            self._ledger.flag_for_review(action_key, reason)
+        except Exception:
+            logger.warning(
+                "snagline continuum sink: flag_for_review failed for key %s",
+                action_key,
+                exc_info=True,
+            )

--- a/tests/adapters/test_continuum_adapter.py
+++ b/tests/adapters/test_continuum_adapter.py
@@ -1,0 +1,340 @@
+"""Tests for the CONTINUUM ledger adapter (issue #79).
+
+The ``FakeStorage`` here implements ONLY the API surface verified against
+current CONTINUUM source: ``read_events(run_id, *, after_sequence=0,
+upto=None)`` and ``last_sequence(run_id)``. Any other attribute access raises,
+so if the adapter starts depending on unverified Storage internals the tests
+go red instead of silently coupling to them.
+
+CONTINUUM itself is never imported; entries are hand-built duck-typed objects
+with the verified ``Event`` fields (sequence, type, timestamp, payload).
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from snagline.adapters.continuum_adapter import ContinuumAdapter
+
+
+class FakeEntry:
+    """Duck-typed stand-in for ``continuum.events.Event``."""
+
+    def __init__(
+        self,
+        sequence: int,
+        type_: str,
+        payload: dict[str, Any],
+        timestamp: Any | None = None,
+    ) -> None:
+        self.sequence = sequence
+        self.type = type_
+        self.payload = payload
+        self.timestamp = timestamp or datetime.now(timezone.utc)
+
+
+class FakeStorage:
+    """Exactly the verified read-by-sequence surface -- nothing more."""
+
+    def __init__(self, entries: list[FakeEntry] | None = None) -> None:
+        self.entries = entries or []
+        self.read_calls: list[dict[str, Any]] = []
+        self.fail_reads = False
+
+    def read_events(
+        self,
+        run_id: str,
+        *,
+        after_sequence: int = 0,
+        upto: int | None = None,
+    ) -> list[FakeEntry]:
+        self.read_calls.append(
+            {"run_id": run_id, "after": after_sequence, "upto": upto}
+        )
+        if self.fail_reads:
+            raise RuntimeError("storage unavailable")
+        return [e for e in self.entries if e.sequence > after_sequence]
+
+    def last_sequence(self, run_id: str) -> int:
+        return self.entries[-1].sequence if self.entries else 0
+
+    def __getattr__(self, name: str) -> Any:
+        raise AssertionError(f"unexpected Storage API access: {name!r}")
+
+
+class RecordingMonitor:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def ingest(self, event: Any) -> None:
+        self.events.append(event)
+
+
+def make_perception(seq: int, **overrides: Any) -> FakeEntry:
+    payload = {
+        "observation_id": "obs_1",
+        "source": "environment_observed",
+        "trust_level": "verified",
+        "verifier": "dom+consensus",
+        "content_hash": "a" * 64,
+        "q_vlm_model": "q-vlm-1",
+        "raw_claim": "TOP SECRET SCREENSHOT TEXT",
+    }
+    payload.update(overrides)
+    return FakeEntry(seq, "PERCEPTION_OBSERVED", payload)
+
+
+def make_branch(seq: int, requires_review: bool = False) -> FakeEntry:
+    return FakeEntry(
+        seq,
+        "BRANCH_RESOLVED",
+        {
+            "branch": {"branch_id": "br-9", "name": "deploy-prod"},
+            "observation": {"observation_id": "obs_1"},
+            "requires_review": requires_review,
+        },
+    )
+
+
+def make_action(
+    seq: int,
+    status: str,
+    key: str = "k1",
+    action_type: str = "send_email",
+    name: str = "ACTION_RECORDED",
+) -> FakeEntry:
+    return FakeEntry(
+        seq,
+        name,
+        {
+            "key": key,
+            "action_id": f"action_{seq}",
+            "action_type": action_type,
+            "status": status,
+            "external_id": "ext-1",
+            "action": {"status": status},
+        },
+    )
+
+
+def test_poll_translates_full_lifecycle() -> None:
+    storage = FakeStorage(
+        [
+            make_perception(1),
+            make_branch(2),
+            make_action(3, "started"),
+            make_action(4, "completed"),
+            make_action(5, "failed", key="k2"),
+            FakeEntry(
+                6,
+                "ACTION_RECONCILED",
+                {"key": "k2", "status": "unknown", "action_type": "send_email"},
+            ),
+            FakeEntry(
+                7,
+                "ACTION_COMPENSATED",
+                {"key": "k1", "status": "compensated", "action_type": "send_email"},
+            ),
+        ]
+    )
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+
+    assert adapter.poll() == 7
+    kinds = [e.action_type for e in monitor.events]
+    assert kinds == [
+        "observation",
+        "plan_step",
+        "tool_call",
+        "tool_call",
+        "tool_call",
+        "action_reconciled",
+        "action_compensated",
+    ]
+    assert [e.step_id for e in monitor.events] == ["1", "2", "3", "4", "5", "6", "7"]
+    assert all(e.episode_id == "run-1" for e in monitor.events)
+    # error flag rides the failed status only
+    assert [e.error for e in monitor.events] == [
+        False,
+        False,
+        False,
+        False,
+        True,
+        False,
+        False,
+    ]
+    # tool names come from the CONTINUUM action type / observation source
+    assert monitor.events[0].tool_name == "environment_observed"
+    assert {e.tool_name for e in monitor.events[2:]} == {"send_email"}
+    # every event keeps structural provenance in metadata
+    assert monitor.events[0].metadata["event_type"] == "PERCEPTION_OBSERVED"
+    assert monitor.events[1].metadata["requires_review"] is False
+    assert monitor.events[3].metadata["status"] == "completed"
+    # reads advanced by sequence
+    assert storage.read_calls[0]["after"] == 0
+    adapter.poll()  # second poll sees nothing new
+    assert storage.read_calls[1]["after"] == 7
+
+
+def test_latency_reaches_completion_event() -> None:
+    ticks = iter([100.0, 101.5])
+    storage = FakeStorage([make_action(1, "started"), make_action(2, "completed")])
+
+    class ClockMonitor(RecordingMonitor):
+        pass
+
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(
+        monitor, storage, "run-1", start_at_tail=False, clock=lambda: next(ticks)
+    )
+    adapter.poll()
+    assert monitor.events[1].latency_ms == pytest.approx(1500.0)
+    assert monitor.events[0].latency_ms is None
+
+
+def test_repeat_claim_keeps_original_start() -> None:
+    ticks = iter([10.0, 11.0, 12.0])
+    storage = FakeStorage(
+        [
+            make_action(1, "started"),
+            make_action(2, "started"),
+            make_action(3, "completed"),
+        ]
+    )
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(
+        monitor, storage, "run-1", start_at_tail=False, clock=lambda: next(ticks)
+    )
+    adapter.poll()
+    # retry at t=11 must NOT reset the t=10 start: total 2000ms, not 1000ms
+    assert monitor.events[-1].latency_ms == pytest.approx(2000.0)
+
+
+def test_poll_defaults_to_live_tail() -> None:
+    storage = FakeStorage([make_perception(i) for i in range(1, 6)] + [make_branch(6)])
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1")
+    # attaching skips all history, including the entry that was the tail
+    assert adapter.poll() == 0
+    assert monitor.events == []
+    # entries appended after attaching are picked up
+    storage.entries.append(make_perception(7))
+    assert adapter.poll() == 1
+    assert [e.step_id for e in monitor.events] == ["7"]
+
+
+def test_unknown_entry_types_skipped_but_cursor_advances() -> None:
+    storage = FakeStorage(
+        [
+            FakeEntry(1, "RUN_STARTED", {"goal": "x"}),
+            FakeEntry(2, "TASK_UPDATED", {"progress": 1}),
+            make_perception(3),
+        ]
+    )
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    assert adapter.poll() == 1
+    assert monitor.events[0].step_id == "3"
+    adapter.poll()
+    assert storage.read_calls[-1]["after"] == 3
+
+
+def test_raw_claim_never_reaches_step_event() -> None:
+    storage = FakeStorage([make_perception(1)])
+    monitor = RecordingMonitor()
+    ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False).poll()
+
+    def _walk(obj: Any) -> None:
+        if isinstance(obj, dict):
+            for k, v in obj.items():
+                assert "raw_claim" != k
+                _walk(v)
+        elif isinstance(obj, (list, tuple)):
+            for item in obj:
+                _walk(item)
+
+    for event in monitor.events:
+        blob = repr(event.metadata) + repr(event.action_signature)
+        assert "TOP SECRET" not in blob
+        _walk(event.metadata)
+
+
+def test_storage_error_is_swallowed_fail_open() -> None:
+    storage = FakeStorage([make_perception(1)])
+    storage.fail_reads = True
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    assert adapter.poll() == 0  # no raise, no events
+    storage.fail_reads = False
+    assert adapter.poll() == 1  # recovers on the next poll
+
+
+def test_poisoned_entry_does_not_stop_the_rest(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    class PoisonedEntry:
+        def __init__(self) -> None:
+            self.sequence = 1
+            self.type = "PERCEPTION_OBSERVED"
+
+        @property
+        def payload(self) -> dict[str, Any]:
+            raise RuntimeError("boom")
+
+    bad = PoisonedEntry()
+    good = make_perception(2)
+    storage = FakeStorage([bad, good])
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        assert adapter.poll() == 1
+    assert monitor.events[0].step_id == "2"
+
+
+def test_monitor_failure_is_contained_and_poll_continues() -> None:
+    class PickyMonitor(RecordingMonitor):
+        def ingest(self, event: Any) -> None:
+            if event.step_id == "1":
+                raise RuntimeError("monitor exploded")
+            super().ingest(event)
+
+    storage = FakeStorage([make_perception(1), make_branch(2)])
+    monitor = PickyMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    assert adapter.poll() == 1  # branch still made it through
+    assert [e.step_id for e in monitor.events] == ["2"]
+    adapter.poll()
+    assert storage.read_calls[-1]["after"] == 2
+
+
+def test_push_mode_for_live_tails() -> None:
+    storage = FakeStorage()
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1")
+    assert adapter.push(make_action(41, "started")) is True
+    assert adapter.push(FakeEntry(42, "STATE_CHECKPOINTED", {})) is False
+    assert [e.step_id for e in monitor.events] == ["41"]
+
+
+def test_datetime_timestamps_accepted() -> None:
+    entry = make_perception(1)
+    entry.timestamp = datetime(2026, 8, 26, tzinfo=timezone.utc)
+    storage = FakeStorage([entry])
+    monitor = RecordingMonitor()
+    assert ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False).poll() == 1
+
+
+def test_modules_import_without_continuum(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The extra is truly optional: poisoning 'continuum' changes nothing."""
+    monkeypatch.setitem(sys.modules, "continuum", None)
+    monkeypatch.setitem(sys.modules, "continuum.actions", None)
+    adapter_mod = importlib.import_module("snagline.adapters.continuum_adapter")
+    sink_mod = importlib.import_module("snagline.sinks.continuum_sink")
+    assert adapter_mod.ContinuumAdapter is not None
+    assert sink_mod.ContinuumSink is not None

--- a/tests/adapters/test_continuum_adapter.py
+++ b/tests/adapters/test_continuum_adapter.py
@@ -108,6 +108,7 @@ def make_action(
     key: str = "k1",
     action_type: str = "send_email",
     name: str = "ACTION_RECORDED",
+    timestamp: Any | None = None,
 ) -> FakeEntry:
     return FakeEntry(
         seq,
@@ -120,6 +121,7 @@ def make_action(
             "external_id": "ext-1",
             "action": {"status": status},
         },
+        timestamp=timestamp,
     )
 
 
@@ -182,35 +184,76 @@ def test_poll_translates_full_lifecycle() -> None:
     assert storage.read_calls[1]["after"] == 7
 
 
-def test_latency_reaches_completion_event() -> None:
-    ticks = iter([100.0, 101.5])
-    storage = FakeStorage([make_action(1, "started"), make_action(2, "completed")])
+def dt(epoch: float) -> Any:
+    return datetime.fromtimestamp(epoch, tz=timezone.utc)
 
-    class ClockMonitor(RecordingMonitor):
-        pass
 
+def test_latency_paired_from_ledger_times() -> None:
+    """Claim and completion carry real ledger timestamps 1.5s apart."""
+    storage = FakeStorage(
+        [
+            make_action(1, "started", timestamp=dt(1000.0)),
+            make_action(2, "completed", timestamp=dt(1001.5)),
+        ]
+    )
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    adapter.poll()
+    assert adapter._pending_claims == {}  # terminal status closes the pairing
+    assert monitor.events[1].latency_ms == pytest.approx(1500.0)
+    assert monitor.events[0].latency_ms is None
+
+
+def test_step_timestamps_come_from_the_ledger_not_the_wall_clock() -> None:
+    """Replay must reproduce when steps actually happened (review fix)."""
+    storage = FakeStorage([make_perception(1), make_branch(2)])
+    for e in storage.entries:
+        e.timestamp = dt(1700000000.0 + e.sequence)
+    monitor = RecordingMonitor()
+    ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False).poll()
+    assert monitor.events[0].timestamp == pytest.approx(1700000001.0)
+    assert monitor.events[1].timestamp == pytest.approx(1700000002.0)
+
+
+def test_unusable_entry_timestamp_falls_back_to_clock() -> None:
+    storage = FakeStorage([make_perception(1)])
+    storage.entries[0].timestamp = "not-a-time"
+    ticks = iter([555.0])
     monitor = RecordingMonitor()
     adapter = ContinuumAdapter(
         monitor, storage, "run-1", start_at_tail=False, clock=lambda: next(ticks)
     )
     adapter.poll()
-    assert monitor.events[1].latency_ms == pytest.approx(1500.0)
-    assert monitor.events[0].latency_ms is None
+    assert monitor.events[0].timestamp == 555.0
+
+
+def test_pending_claims_bounded_by_eviction(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Never-terminating actions are evicted oldest-first (review fix)."""
+    import snagline.adapters.continuum_adapter as mod
+
+    monkeypatch.setattr(mod, "_MAX_PENDING_CLAIMS", 2)
+    entries = [make_action(i, "started", key=f"k{i}") for i in range(1, 5)]
+    storage = FakeStorage(entries)
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    adapter.poll()
+    assert set(adapter._pending_claims) == {"k3", "k4"}  # oldest two evicted
+    # an evicted key can no longer pair; a late terminal yields latency None
+    storage.entries.append(make_action(5, "completed", key="k1"))
+    adapter.poll()
+    assert monitor.events[-1].latency_ms is None
 
 
 def test_repeat_claim_keeps_original_start() -> None:
-    ticks = iter([10.0, 11.0, 12.0])
     storage = FakeStorage(
         [
-            make_action(1, "started"),
-            make_action(2, "started"),
-            make_action(3, "completed"),
+            make_action(1, "started", timestamp=dt(10.0)),
+            make_action(2, "started", timestamp=dt(11.0)),
+            make_action(3, "completed", timestamp=dt(12.0)),
         ]
     )
     monitor = RecordingMonitor()
-    adapter = ContinuumAdapter(
-        monitor, storage, "run-1", start_at_tail=False, clock=lambda: next(ticks)
-    )
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
     adapter.poll()
     # retry at t=11 must NOT reset the t=10 start: total 2000ms, not 1000ms
     assert monitor.events[-1].latency_ms == pytest.approx(2000.0)
@@ -328,6 +371,7 @@ def test_datetime_timestamps_accepted() -> None:
     storage = FakeStorage([entry])
     monitor = RecordingMonitor()
     assert ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False).poll() == 1
+    assert monitor.events[0].timestamp == entry.timestamp.timestamp()
 
 
 def test_modules_import_without_continuum(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sinks/test_continuum_sink.py
+++ b/tests/sinks/test_continuum_sink.py
@@ -93,6 +93,18 @@ def test_ledger_failure_is_swallowed_fail_open(
     assert any("flag_for_review failed" in rec.message for rec in caplog.records)
 
 
+def test_key_from_risk_failure_is_swallowed_fail_open(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    def exploding_key(_risk: FailureRisk) -> str:
+        raise RuntimeError("mapping exploded")
+
+    sink, ledger = make_sink(FakeLedger(), key_from_risk=exploding_key)
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        sink.emit(make_risk())  # host-supplied mapping failure must not propagate
+    assert ledger.flagged == []
+
+
 def test_escalate_action_direct() -> None:
     sink, ledger = make_sink(FakeLedger())
     sink.escalate_action("k9", "human needed")

--- a/tests/sinks/test_continuum_sink.py
+++ b/tests/sinks/test_continuum_sink.py
@@ -1,0 +1,158 @@
+"""Tests for the CONTINUUM sink (issue #79).
+
+Unit tests run against a fake ledger mirroring the verified
+``ActionLedger.flag_for_review(key, reason)`` surface. One optional test
+exercises the REAL ``continuum.actions.ActionLedger`` over a minimal fake
+storage when CONTINUUM is importable; it skips cleanly otherwise (zero-dep CI).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import pytest
+
+from snagline.risk import FailureRisk
+from snagline.sinks.continuum_sink import ContinuumSink
+
+
+class FakeLedger:
+    """Mirrors the verified flag_for_review(key, reason) -> Action surface."""
+
+    def __init__(self) -> None:
+        self.flagged: list[tuple[str, str]] = []
+        self.fail = False
+
+    def flag_for_review(self, key: str, reason: str) -> Any:
+        if self.fail:
+            raise RuntimeError("ledger down")
+        self.flagged.append((key, reason))
+        return {"key": key, "status": "requires_review"}
+
+
+def make_risk(**overrides: Any) -> FailureRisk:
+    fields: dict[str, Any] = {
+        "episode_id": "run-1",
+        "step_id": "42",
+        "score": 0.91,
+        "trigger": "loop",
+        "detail": "same signature 5 times",
+        "timestamp": 1000.0,
+    }
+    fields.update(overrides)
+    return FailureRisk(**fields)
+
+
+def make_sink(ledger: FakeLedger, **kwargs: Any) -> tuple[ContinuumSink, Any]:
+    storage = object()  # the sink never touches storage directly, only the ledger
+    sink = ContinuumSink(storage, "run-1", ledger_factory=lambda s, r: ledger, **kwargs)
+    return sink, ledger
+
+
+def test_emit_flags_action_for_review() -> None:
+    sink, ledger = make_sink(FakeLedger(), key_from_risk=lambda r: "k1")
+    risk = make_risk()
+    sink.emit(risk)
+    assert len(ledger.flagged) == 1
+    key, reason = ledger.flagged[0]
+    assert key == "k1"
+    # structural reason string: trigger/score/severity/ids/detail, no metadata
+    assert "[snagline:loop]" in reason
+    assert "score=0.91" in reason
+    assert "step=42" in reason
+    assert "episode=run-1" in reason
+    assert "same signature 5 times" in reason
+
+
+def test_emit_without_key_mapping_drops_cleanly(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    sink, ledger = make_sink(FakeLedger())
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        sink.emit(make_risk())  # must not raise despite no channel
+    assert ledger.flagged == []
+    assert any("no action key" in rec.message for rec in caplog.records)
+
+
+def test_key_from_risk_returning_none_drops(caplog: pytest.LogCaptureFixture) -> None:
+    sink, ledger = make_sink(FakeLedger(), key_from_risk=lambda r: None)
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        sink.emit(make_risk())
+    assert ledger.flagged == []
+
+
+def test_ledger_failure_is_swallowed_fail_open(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    ledger = FakeLedger()
+    ledger.fail = True
+    sink, _ = make_sink(ledger, key_from_risk=lambda r: "k1")
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        sink.emit(make_risk())  # monitoring failure never reaches the host agent
+    assert any("flag_for_review failed" in rec.message for rec in caplog.records)
+
+
+def test_escalate_action_direct() -> None:
+    sink, ledger = make_sink(FakeLedger())
+    sink.escalate_action("k9", "human needed")
+    assert ledger.flagged == [("k9", "human needed")]
+
+
+def test_missing_continuum_raises_helpful_importerror(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(__import__("sys").modules, "continuum", None)
+    monkeypatch.setitem(__import__("sys").modules, "continuum.actions", None)
+    with pytest.raises(ImportError, match=r"snagline-agent\[continuum\]"):
+        ContinuumSink(object(), "run-1")
+
+
+def test_real_actionledger_flags_review() -> None:
+    """Live check of the real request-human path; skipped without CONTINUUM."""
+    continuum = pytest.importorskip("continuum")
+    events_mod = pytest.importorskip("continuum.events")
+
+    class MiniStorage:
+        """Just enough Storage for ActionLedger's fold + append."""
+
+        def __init__(self) -> None:
+            self.events: list[Any] = []
+
+        def read_events(self, run_id: str) -> list[Any]:
+            return list(self.events)
+
+        def read_archived_events(self, run_id: str) -> list[Any]:
+            return []  # fake holds no compacted prefix
+
+        def last_sequence(self, run_id: str) -> int:
+            return len(self.events)
+
+        def append_event(
+            self,
+            run_id: str,
+            type: Any = None,
+            payload: Any = None,
+        ) -> Any:
+            event = events_mod.Event(
+                run_id=run_id,
+                sequence=len(self.events) + 1,
+                type=type,
+                payload=dict(payload or {}),
+            )
+            self.events.append(event)
+            return event
+
+    storage = MiniStorage()
+    ledger = continuum.ActionLedger(storage, "run-1")  # type: ignore[attr-defined]
+    outcome = ledger.claim("send_email", {"to": "x"})
+    # key_from_risk must hand the sink the *resolved* idempotency key (or
+    # action_id); a bare action name does not resolve, as the real ledger
+    # refuses it with LedgerError.
+    action = ledger.flag_for_review(outcome.key, "[snagline] review me")
+    assert str(action.status.value) == "requires_review"
+    statuses = [str(e.payload.get("status")) for e in storage.events]
+    assert "requires_review" in statuses
+    # and the real EventType vocabulary matches what the adapter translates
+    assert events_mod.EventType.PERCEPTION_OBSERVED.value == "PERCEPTION_OBSERVED"
+    assert events_mod.EventType.BRANCH_RESOLVED.value == "BRANCH_RESOLVED"


### PR DESCRIPTION
## CONTINUUM adapter + sink (free telemetry), Fixes #79

Closes the loop with CONTINUUM in both directions. **Explicitly non-blocking
for release** (board Pool F; issue #106 marks #79 as not blocking 0.1.0).

### Step zero: verified the real Storage API (delta found)

Read-only inspection of current CONTINUUM source (`continuum/storage/base.py`,
`continuum/events.py`, `continuum/actions/ledger.py`, `continuum/security/trust_gate.py`).
project.md section 6.6 guessed a `read_by_sequence` method; the real public
read-by-sequence surface is:

- `Storage.read_events(run_id, *, after_sequence: int = 0, upto: int | None = None) -> Sequence[Event]`
- `Storage.last_sequence(run_id) -> int`
- `Event` fields used: `sequence`, `type`, `timestamp` (datetime), `payload`

The adapter codes against that verified pair only; the delta is documented in
the module docstring, project.md section 6.6, and the guides.

### What ships

- **`adapters/continuum_adapter.py`**
  - Poll mode: tracks a sequence cursor, reads new ledger entries per poll,
    translates and ingests. Default attaches at the live tail (history is not
    replayed); `start_at_tail=False` replays from sequence 1.
    `poll_forever(interval, stop_event)` for an unattended loop.
  - Push mode: `push(entry)` for callers tailing the log live.
  - Mapping: `PERCEPTION_OBSERVED` -> observation (source/trust/verifier/hash
    kept), `BRANCH_RESOLVED` -> plan step (`requires_review` kept),
    `ACTION_RECORDED` started/completed/failed -> tool_call steps with
    claim-to-terminal latency pairing (retry keeps the original window),
    `ACTION_RECONCILED` / `ACTION_COMPENSATED` -> their own step types.
    Other entry types are skipped.
  - Privacy: `raw_claim` and all payload text never reach a `StepEvent`;
    hashes, ids, statuses, counts only.
- **`sinks/continuum_sink.py`**: escalates a `FailureRisk` through CONTINUUM's
  existing request-human path, verified as `ActionLedger.flag_for_review(key,
  reason)` -> `ActionStatus.REQUIRES_REVIEW` + auditable event. Caller supplies
  `key_from_risk`; risks without a resolvable key are logged and dropped rather
  than fabricating ledger facts (run-level `request_human` is a derived mode in
  current CONTINUUM, with no public append API).
- **Extra**: `snagline-agent[continuum]` naming the real distribution found in
  CONTINUUM's pyproject (`continuum-agent`). Both modules are duck-typed and
  never import `continuum`; core untouched.
- **Docs**: ADAPTER_GUIDE reference-table row + "CONTINUUM sink" section;
  INTEGRATION_MATRIX rows; project.md 6.6/13.1/15 refreshed honestly. Also
  removed two stale lines from the section-15 pending list that this PR and
  the merged auto-instrumentation work had already made false.

### Verification honesty

- Exercised against real CONTINUUM code: one skip-guarded test drives the real
  `ActionLedger.claim` -> `flag_for_review` path over a minimal fake storage
  and asserts `REQUIRES_REVIEW` lands in the ledger; run locally against the
  actual CONTINUUM checkout, passes there, skips on zero-dep CI.
- NOT exercised: end-to-end polling against a live running CONTINUUM instance.
  The integration-matrix rows say so explicitly.
- Finding worth noting for integrators: the real ledger refuses
  `flag_for_review` with a bare action name; you must pass the resolved
  idempotency key or action_id. Documented in the guide and asserted by the
  live-API test.

### Fail-open proof and mutation checks

Fail-open tests cover storage read failure (adapter recovers next poll),
poisoned entries (skipped without stopping siblings), monitor ingest failures
(contained), sink ledger failures and host-supplied mapping failures
(swallowed, logged).

Mutation testing (inject bug, watch named test go red, revert):

| Mutation | Test that caught it |
|---|---|
| Removed poll's read try/except | `test_storage_error_is_swallowed_fail_open` |
| Removed inner guard in `escalate_action` | `test_ledger_failure_is_swallowed_fail_open` |
| Removed outer guard in `emit` | `test_key_from_risk_failure_is_swallowed_fail_open` |
| Retry reset latency window (`setdefault` -> assignment) | `test_repeat_claim_keeps_original_start` |

The third row exists because the first attempt at mutating emit survived:
`escalate_action` has defense-in-depth, so a dedicated test now covers the
outer guard's own path (host-supplied `key_from_risk` raising).

### No-extras import smoke

Bare stdlib interpreter (`python3 -S`, no site-packages, `PYTHONPATH=src`):

```
import snagline
import snagline.adapters.continuum_adapter
import snagline.sinks.continuum_sink
-> OK; third-party loaded: none
```

Full gate green at every commit snapshot (pytest 524 passed / 2 skipped after
rebase onto master@09f1112, ruff check, ruff format --check, mypy src clean).

### Review findings addressed (Gitar-bot, both valid, fixed in-PR)

1. Timestamps/latency now derive from the ledger entry's own `Event.timestamp`
   (datetime or epoch) instead of the wall clock at translation time;
   `_to_epoch` is no longer dead code. Latency pairing measures real ledger
   durations even when a poll batch translates claim and completion together.
   Caught by `test_step_timestamps_come_from_the_ledger_not_the_wall_clock`
   and `test_latency_paired_from_ledger_times` (mutation-proved).
2. `_pending_claims` is bounded at 10k with FIFO eviction of never-terminating
   actions; caught by `test_pending_claims_bounded_by_eviction`
   (mutation-proved).
