### PR TITLE
feat(monitor): optional enforcement policy with callback and halt_webhook (fail-open preserved)

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ in [docs/RETRAIN_CADENCE.md](docs/RETRAIN_CADENCE.md)).
 | **No content retention** | Detectors reason about hashes, timings, counts, and booleans -- never prompt or response content. Adoption blocker if left ambiguous. |
 | **Streaming-first, batch-capable** | Primary use is live monitoring of a running agent. The same event schema and detectors also work over an exported trajectory file for offline analysis. |
 | **Pluggable sinks** | Console (default, zero dep), webhook (stdlib urllib, fire-and-forget), and extensible. Only `FailureRisk` fields are ever transmitted. |
+| **Optional enforcement** | `Monitor(policy=...)` adds a sanctioned escalation path after the sinks: `"callback"` wraps an in-process callable fail-open; `"halt_webhook"` POSTs the risk and lands its `{"action": "continue"|"pause"}` directive on `monitor.last_directive`. Timeout/error/dead endpoint always falls back to continue; default `policy="observe"` pays nothing (issue #93). |
 | **External agent bridges** | HTTP sidecar, command bridge, and file tail for non-Python agents (Claude Code, OpenClaw, Hermes). |
 | **Thread-safe** | Per-instance `threading.Lock` supports concurrent multi-episode monitoring. |
 
@@ -262,6 +263,10 @@ the path variant below.
 | `SNAGLINE_FAIL_OPEN` | `fail_open` | True | Swallow detector/sink exceptions instead of propagating |
 | `SNAGLINE_LOG_FORMAT` | `log_format` | text | text or json; json installs LoggingSink next to ConsoleSink |
 | `SNAGLINE_METRICS_FORMAT` | `metrics_format` | prometheus | Sidecar GET /metrics body: prometheus or classic |
+| `SNAGLINE_POLICY` | `policy` | observe | Enforcement layer: observe, callback (needs a code-supplied `on_risk`), or halt_webhook |
+| `SNAGLINE_HALT_URL` | `halt_url` | *(unset)* | Halt webhook endpoint; required when policy is halt_webhook |
+| `SNAGLINE_HALT_TIMEOUT_S` | `halt_timeout_s` | 0.25 | Halt webhook round-trip budget in seconds; timeout fails open to continue |
+| `SNAGLINE_MIN_SEVERITY_FOR_HALT` | `min_severity_for_halt` | 0.8 | Minimum risk score that pays the halt-webhook cost |
 
 A handful of variables sit outside `Config` because they are consumed
 directly by one component each:
@@ -285,11 +290,17 @@ SNAGLINE is verified not just with unit tests, but against real LLM agents, live
 ### Automated Test Suite and Benchmarks
 
 ```
-tests : 390 passed, 2 skipped  (pytest, Python 3.14, 2026-08-26;
+tests : 531 passed, 2 skipped  (pytest, Python 3.14, 2026-08-26;
 skip = langchain integrations without optional extras)
 bench : median 2.43 us/step, p99 27.71 us/step over 200,000 synthetic steps
         (measured 2026-08-26 on Apple M1, arm64, CPython 3.14.5;
          earlier 1.91 / 33.90 on same hardware 2026-08-15)
+enforcement (issue #93): added latency per halting step, halt_timeout_s=250ms,
+        Apple M1 / CPython 3.14 / 2026-08-26: responding localhost endpoint
+        median 264 us/step, refused (dead) endpoint median 57 us/step,
+        stalled endpoint median 252.7 ms/step = the full timeout envelope;
+        observe baseline unchanged at ~2 us/step. Reproduce with
+        python benchmarks/enforcement_benchmark.py
 ```
 
 Coverage spans:
@@ -303,6 +314,7 @@ Coverage spans:
 | **Adapters** | Raw adapter builds and ingests events. LangChain callbacks map correctly. LangGraph stream wrapper passes through unchanged. Claude Code payloads map correctly. |
 | **HTTP sidecar** | Health endpoint returns 200. Events endpoint ingests and fires detectors. Malformed body returns 400. Unknown paths return 404. |
 | **Webhook sink** | Emits correct payload with no metadata. Never raises on network failure. Never raises on HTTP 500. |
+| **Enforcement policy (#93)** | Callback exceptions don't propagate (parity with fail-open tests), are logged and counted. Halt webhook timeout/dead endpoint/malformed body/unknown action/HTTP error all fall back to continue. Ordering is detectors -> sinks -> policy; the webhook runs outside the episode lock. `last_directive` is thread-safe under concurrent ingest. Default `policy="observe"` construction is unchanged. |
 | **CLI** | Replay detects loops, cascades, and latency spikes. Watch ingests stdin. Malformed lines are skipped. Webhook requires URL. |
 | **Integration** | Full agent run triggers all three detectors. Clean run stays silent. |
 
@@ -464,6 +476,36 @@ class MySink:
         ...
 ```
 
+### Enforcement policy (issue #93)
+
+Detection-only is the right default, but production harnesses sometimes need teeth: pause the session on a confirmed loop, trip an in-process circuit breaker on a budget breach. `Monitor` supports two optional escalation policies that run AFTER the sinks on every dispatched risk (documented ordering: detectors -> sinks -> policy), outside every episode lock:
+
+```python
+from snagline import Monitor
+
+# In-process circuit breaker: your callback sets a flag your agent loop checks.
+# Exceptions in the callback are swallowed exactly like sink errors.
+monitor = Monitor([...], [...], policy="callback", on_risk=my_fn)
+
+# Halt webhook: every risk with score >= min_severity_for_halt (default 0.8)
+# is POSTed to halt_url; the response {"action": "continue"|"pause",
+# "reason": ...} is surfaced thread-safely as monitor.last_directive.
+monitor = Monitor(
+    [...],
+    [...],
+    policy="halt_webhook",
+    halt_url="http://127.0.0.1:9100/halt",
+    halt_timeout_s=0.25,
+)
+...
+if monitor.last_directive.action == "pause":
+    ...  # your host decides what pausing means; snagline never raises into your loop
+```
+
+Fail-open survives enforcement by construction: a callback exception is logged, counted under `metrics()["policy_errors"]`, and swallowed (unless `fail_open=False`); a webhook timeout, dead endpoint, malformed body, unknown action, or HTTP error leaves the directive at continue. Worst-case added latency per halting step is bounded by the explicit `halt_timeout_s` envelope (default 250ms) and is paid only by the dispatching thread -- other episodes keep ingesting. Measured numbers (Apple M1, CPython 3.14, 2026-08-26; run `python benchmarks/enforcement_benchmark.py`): observe baseline ~2 us/step, responding localhost endpoint ~264 us/step median, refused endpoint ~57 us/step, stalled endpoint ~252.7 ms/step, i.e. the full timeout budget plus a small epsilon.
+
+The equivalent for sidecar consumers: `snagline serve --halt-forward URL` runs the identical policy inside the HTTP sidecar (`--halt-timeout` and `--min-severity-for-halt` tune it). Configuration is 12-factor too: `SNAGLINE_POLICY`, `SNAGLINE_HALT_URL`, `SNAGLINE_HALT_TIMEOUT_S`, `SNAGLINE_MIN_SEVERITY_FOR_HALT`. Note `on_risk` is code-only: callables cannot arrive via env vars or config files.
+
 ## External Agent Bridges
 
 Claude Code, OpenClaw, and Hermes are processes, not Python libraries, so SNAGLINE bridges at the process level with three universal mechanisms, HTTP, command, and file, documented with copy-paste wiring for each framework in [docs/FRAMEWORK_BRIDGES.md](docs/FRAMEWORK_BRIDGES.md).
@@ -575,6 +617,7 @@ Detectors reason only about **hashes, timings, counts, and booleans** -- never r
 - **FailureRisk** deliberately carries no `metadata` field. An alerting channel (webhook, Slack) cannot become an accidental data-exfiltration path.
 - **The `metadata` dict** on `StepEvent` is the one place raw content could leak if an adapter author puts it there. Detectors never read `metadata`, and sinks should not forward it by default.
 - **The webhook sink** transmits only `FailureRisk` fields (ids, score, trigger, detail, timestamp) -- never `StepEvent.content` or `StepEvent.metadata`.
+- **The halt webhook (enforcement, issue #93)** deserves special respect: unlike the alerting webhook, its response holds CONTROL -- a `"pause"` directive can stop your agent. Treat that endpoint as privileged infrastructure: bind it to localhost or reach it through an authenticated reverse proxy (same guidance as the sidecar below, copy-paste configs in [docs/ATTACH_ANY_SYSTEM.md](docs/ATTACH_ANY_SYSTEM.md#sidecar-tls-reverse-proxy-termination-issue-103)), and never expose it to networks you do not control. The POST body carries only `FailureRisk` fields, but whoever can answer it can steer the host. The fail-open contract still applies to the client side: timeout or error defaults to continue, so a DOWNED halt endpoint degrades to detection-only rather than blocking the agent.
 - **The HTTP sidecar** serves plain HTTP and accepts arbitrary `StepEvent` JSON from any caller. For production use, front it with a reverse proxy that enforces authentication and terminates TLS; copy-paste nginx and Caddy configs are in [docs/ATTACH_ANY_SYSTEM.md](docs/ATTACH_ANY_SYSTEM.md#sidecar-tls-reverse-proxy-termination-issue-103). In-process TLS is the documented future option ([#103](https://github.com/Cyrax321/SNAGLINE/issues/103)).
 
 ## What SNAGLINE Is Not

--- a/benchmarks/enforcement_benchmark.py
+++ b/benchmarks/enforcement_benchmark.py
@@ -1,0 +1,232 @@
+"""Enforcement-policy latency benchmark (issue #93).
+
+Measures the real, reproducible added wall-clock latency per ingested step
+when an enforcement policy is configured, across three halt-endpoint
+behaviors:
+
+  * responding : localhost endpoint answering {"action": "continue"} at once
+  * refused    : dead endpoint (connection refused immediately)
+  * stalled    : endpoint accepts the connection but never answers within the
+                 timeout budget -- the true worst case, where each halting
+                 step pays the full halt_timeout_s on its own dispatch thread
+
+A policy="observe" baseline leg is included for reference. Each halt leg uses
+a stub detector that emits one score=0.99 risk per step, so every step pays
+the full enforcement cost; sinks are empty so ONLY policy work is measured.
+
+Run directly::
+
+    python benchmarks/enforcement_benchmark.py
+
+Stdlib-only; imports ``snagline``. Numbers this script prints are safe to
+publish (with hardware/date noted), matching how overhead_benchmark is used.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import statistics
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from snagline.events import StepEvent
+from snagline.monitor import Monitor
+from snagline.risk import FailureRisk
+
+
+class _RiskPerStepDetector:
+    """Emits one above-threshold synthetic risk on every observe() call."""
+
+    name = "bench_risk_per_step"
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            0.99,
+            "loop",
+            "bench risk",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        pass
+
+
+def _make_events(n: int) -> list[StepEvent]:
+    return [
+        StepEvent(
+            step_id=str(i),
+            episode_id="bench-halt",
+            timestamp=time.time(),
+            action_type="tool_call",
+            action_signature=f"halt-bench-{i}",
+            tool_name="tool",
+            latency_ms=100.0,
+        )
+        for i in range(n)
+    ]
+
+
+def _measure_us_per_step(monitor: Monitor, n: int, block: int = 200) -> dict:
+    # Adaptive block size so small legs (the expensive stalled case) still
+    # produce several timed blocks after a proportionally small warm-up.
+    block = max(1, min(block, n // 5))
+    events = _make_events(n)
+    for e in events[:block]:
+        monitor.ingest(e)
+    per_step_us: list[float] = []
+    start_at = block
+    while start_at < n:
+        chunk = events[start_at : start_at + block]
+        t0 = time.perf_counter()
+        for e in chunk:
+            monitor.ingest(e)
+        t1 = time.perf_counter()
+        per_step_us.append((t1 - t0) / len(chunk) * 1e6)
+        start_at += block
+    ordered = sorted(per_step_us)
+    p99_idx = min(len(ordered) - 1, int(0.99 * len(ordered)))
+    return {
+        "n": n,
+        "median_us": statistics.median(per_step_us),
+        "p99_us": ordered[p99_idx],
+        # Fail-open fallbacks that fired during the leg; published numbers
+        # should always state this count (it means some steps paid the error
+        # path instead of a real round trip).
+        "policy_errors": monitor.metrics()["policy_errors"],
+    }
+
+
+class _RespondingEndpoint:
+    def __init__(self) -> None:
+        class _Handler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(length)
+                data = json.dumps({"action": "continue", "reason": ""}).encode("utf-8")
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self._server.request_queue_size = 128
+        self.url = f"http://127.0.0.1:{self._server.server_port}/halt"
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2)
+
+
+class _StalledEndpoint:
+    """Accepts requests, then sleeps far past any sane timeout budget."""
+
+    def __init__(self, stall_seconds: float = 5.0) -> None:
+        class _Handler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("Content-Length") or 0)
+                self.rfile.read(length)
+                time.sleep(stall_seconds)
+                self.send_response(200)
+                self.send_header("Content-Length", "2")
+                self.end_headers()
+                self.wfile.write(b"{}")
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self._server.request_queue_size = 128
+        self.url = f"http://127.0.0.1:{self._server.server_port}/halt"
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2)
+
+
+def _dead_url() -> str:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return f"http://127.0.0.1:{port}/halt"
+
+
+def run_enforcement_benchmark(
+    n_fast: int = 2_000, n_stalled: int = 12, halt_timeout_s: float = 0.25
+) -> dict:
+    """Return per-leg median/p99 microseconds-per-step for the four setups."""
+    results: dict[str, dict] = {}
+
+    baseline_monitor = Monitor([_RiskPerStepDetector()], [], policy="observe")
+    results["observe"] = _measure_us_per_step(baseline_monitor, n_fast)
+
+    responding = _RespondingEndpoint()
+    try:
+        monitor = Monitor(
+            [_RiskPerStepDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=responding.url,
+            halt_timeout_s=halt_timeout_s,
+        )
+        results["responding"] = _measure_us_per_step(monitor, n_fast)
+    finally:
+        responding.stop()
+
+    monitor = Monitor(
+        [_RiskPerStepDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=_dead_url(),
+        halt_timeout_s=halt_timeout_s,
+    )
+    results["refused"] = _measure_us_per_step(monitor, n_fast)
+
+    stalled = _StalledEndpoint(stall_seconds=halt_timeout_s * 20)
+    try:
+        monitor = Monitor(
+            [_RiskPerStepDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=stalled.url,
+            halt_timeout_s=halt_timeout_s,
+        )
+        results["stalled"] = _measure_us_per_step(monitor, n_stalled)
+    finally:
+        stalled.stop()
+
+    return results
+
+
+def main() -> None:
+    halt_timeout_s = 0.25
+    stats = run_enforcement_benchmark(halt_timeout_s=halt_timeout_s)
+    print("snagline enforcement-policy latency benchmark (issue #93)")
+    print(f"  halt timeout budget : {halt_timeout_s * 1000:.0f} ms")
+    for leg in ("observe", "responding", "refused", "stalled"):
+        s = stats[leg]
+        print(
+            f"  {leg:<11}: median {s['median_us']:>12.2f} us/step, "
+            f"p99 {s['p99_us']:>12.2f} us/step (n={s['n']}, "
+            f"fail-open fallbacks: {s['policy_errors']})"
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -12,6 +12,7 @@ build step - and errors clearly rather than silently doing nothing.
 from __future__ import annotations
 
 import argparse
+import dataclasses
 import json
 import os
 import sys
@@ -333,6 +334,27 @@ def _build_parser() -> argparse.ArgumentParser:
         default=0.0,
         help="Suppress repeated alerts of the same key for this many seconds "
         "(issue #4). 0 disables (default).",
+    )
+    p_serve.add_argument(
+        "--halt-forward",
+        default=None,
+        help="Enable the halt_webhook enforcement policy (issue #93): risks "
+        "with score >= --min-severity-for-halt are POSTed to this URL and the "
+        'response {"action": "continue"|"pause", "reason": ...} is surfaced '
+        "as the sidecar monitor's last_directive. Timeout or error fails open "
+        "to continue. Hold this endpoint tight: it controls pause decisions.",
+    )
+    p_serve.add_argument(
+        "--halt-timeout",
+        type=float,
+        default=None,
+        help="Halt webhook round-trip budget in seconds [default: 0.25].",
+    )
+    p_serve.add_argument(
+        "--min-severity-for-halt",
+        type=float,
+        default=None,
+        help="Minimum risk score that pays the halt-webhook cost [default: 0.8].",
     )
 
     p_hook = sub.add_parser(
@@ -731,6 +753,17 @@ def _cmd_serve(args: argparse.Namespace) -> int:
     from snagline.server.http_server import serve
 
     cfg = _build_config(args)
+    # Enforcement wiring (issue #93): --halt-forward turns the resolved config
+    # into halt_webhook mode. dataclasses.replace re-runs Config.__post_init__,
+    # so an invalid value fails loudly here instead of at first ingest.
+    if args.halt_forward:
+        cfg = dataclasses.replace(
+            cfg, policy="halt_webhook", halt_url=args.halt_forward
+        )
+    if args.halt_timeout is not None:
+        cfg = dataclasses.replace(cfg, halt_timeout_s=args.halt_timeout)
+    if args.min_severity_for_halt is not None:
+        cfg = dataclasses.replace(cfg, min_severity_for_halt=args.min_severity_for_halt)
     try:
         sinks = _build_sinks(args, cfg)
     except SystemExit as exc:
@@ -753,6 +786,14 @@ def _cmd_serve(args: argparse.Namespace) -> int:
         "(POST /events, GET /health)",
         file=sys.stderr,
     )
+    if cfg.policy == "halt_webhook":
+        print(
+            f"snagline serve: halt forwarding enabled -> {cfg.halt_url} "
+            f"(timeout {cfg.halt_timeout_s}s, min severity "
+            f"{cfg.min_severity_for_halt}); directives land on "
+            "Monitor.last_directive (issue #93)",
+            file=sys.stderr,
+        )
     if not auth_token:
         print(
             "snagline serve: no --auth-token / $SNAGLINE_SERVE_AUTH_TOKEN set; "

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -93,6 +93,27 @@ def _validated_log_format(value: str) -> str:
     return normalized
 
 
+# Closed value set for ``Config.policy`` (issue #93). Like log_format, an
+# unknown policy is a configuration error and fails loudly at construction or
+# resolve time: a typo'd enforcement setting must not silently degrade to
+# observation at exactly the moment someone relies on it.
+ENFORCEMENT_POLICIES: tuple[str, ...] = ("observe", "callback", "halt_webhook")
+
+
+def validate_policy(value: str) -> str:
+    """Normalize and validate a ``policy`` value; raise when invalid.
+
+    Case and surrounding whitespace are forgiven; anything outside
+    ``ENFORCEMENT_POLICIES`` raises ``ValueError`` (same precedent as
+    log_format, issue #119).
+    """
+    normalized = value.strip().lower() if isinstance(value, str) else value
+    if normalized not in ENFORCEMENT_POLICIES:
+        allowed = ", ".join(repr(v) for v in ENFORCEMENT_POLICIES)
+        raise ValueError(f"policy must be one of {allowed}; got {value!r}")
+    return normalized
+
+
 @dataclass
 class Config:
     # Loop detector
@@ -278,10 +299,29 @@ class Config:
     # ?format=prometheus; environment override SNAGLINE_METRICS_FORMAT.
     metrics_format: str = "prometheus"
 
+    # --- Enforcement policy (issue #93) ---------------------------------------
+    # Optional escalation layer that runs AFTER the sinks on every dispatched
+    # risk (documented ordering: detectors -> sinks -> policy). "observe" (the
+    # default) is today's detection-only behavior with zero overhead;
+    # "callback" invokes a host-supplied callable wrapped fail-open; and
+    # "halt_webhook" POSTs the FailureRisk JSON to halt_url and surfaces the
+    # response directive as Monitor.last_directive, failing open to continue
+    # on timeout/error. The callable for callback mode cannot come from env
+    # vars or files; pass on_risk= to Monitor directly.
+    policy: str = "observe"
+    halt_url: str | None = None  # required when policy == "halt_webhook"
+    # Webhook budget: how long one halt consultation may delay its own thread
+    # before the directive defaults to continue. 250ms per issue #93.
+    halt_timeout_s: float = 0.25
+    # Only risks scoring at or above this pay the webhook cost; below it the
+    # risk still reaches sinks/callback as usual but no halt round-trip happens.
+    min_severity_for_halt: float = 0.8
+
     def __post_init__(self) -> None:
-        # Issue #119: an invalid log_format is a configuration error and must
-        # fail loudly here instead of being silently ignored downstream.
+        # Issue #119: invalid closed-set values are configuration errors and
+        # must fail loudly here instead of being silently ignored downstream.
         self.log_format = _validated_log_format(self.log_format)
+        self.policy = validate_policy(self.policy)
 
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
@@ -379,4 +419,5 @@ class Config:
         # setattr bypasses __post_init__, so re-validate the fields that carry
         # a closed value set after env layering (issue #119).
         cfg.log_format = _validated_log_format(cfg.log_format)
+        cfg.policy = validate_policy(cfg.policy)
         return cfg

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -18,6 +18,10 @@ import json
 import logging
 import os
 import threading
+import time
+import urllib.request
+from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Any
 
 from snagline.calibration import (
@@ -25,7 +29,7 @@ from snagline.calibration import (
     build_plan,
     resolve_baseline_profile,
 )
-from snagline.config import Config
+from snagline.config import Config, validate_policy
 from snagline.detectors.base import Detector
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
@@ -36,6 +40,46 @@ logger = logging.getLogger("snagline")
 
 # Bump when the snapshot payload shape changes incompatibly (issue #91).
 SNAPSHOT_FORMAT_VERSION = 1
+
+# --- Enforcement policy (issue #93) -----------------------------------------
+#
+# Optional escalation layer that runs AFTER the sinks on every dispatched risk
+# (documented ordering: detectors -> sinks -> policy), outside every episode
+# lock. Three policies:
+#
+#   "observe"      detection only; today's behavior, zero added work.
+#   "callback"     invoke a host-supplied callable wrapped fail-open.
+#   "halt_webhook" POST the FailureRisk JSON to halt_url and surface the
+#                  response directive as ``monitor.last_directive``.
+#
+# The halt webhook NEVER raises into the host loop and never blocks other
+# episodes' ingest: on timeout, error, or dead endpoint the directive simply
+# stays/defaults to "continue" (fail-open). We deliberately do not pause
+# anything ourselves; the host decides what its own loop does with the
+# directive (project.md §1.2).
+DEFAULT_POLICY = "observe"
+HALT_ACTION_CONTINUE = "continue"
+HALT_ACTION_PAUSE = "pause"
+VALID_HALT_ACTIONS = (HALT_ACTION_CONTINUE, HALT_ACTION_PAUSE)
+# Cap on how many response-body bytes one halt consultation will read: the
+# endpoint holds control, but a runaway body still cannot balloon memory.
+_MAX_HALT_RESPONSE_BYTES = 65_536
+
+
+@dataclass(frozen=True, slots=True)
+class HaltDirective:
+    """The latest control directive returned by the halt webhook (issue #93).
+
+    ``action`` is ``"continue"`` or ``"pause"``; ``reason`` is the short
+    string the endpoint supplied (structure only, no event content);
+    ``timestamp`` is when the directive was received. Immutable and swapped
+    atomically under a lock, so concurrent multi-episode use always reads a
+    complete directive.
+    """
+
+    action: str = HALT_ACTION_CONTINUE
+    reason: str = ""
+    timestamp: float = 0.0
 
 
 def _detector_key(index: int, detector: Any) -> str:
@@ -91,6 +135,9 @@ class MonitorMetrics:
         self.risks_emitted = 0
         self.detector_errors = 0
         self.sink_errors = 0
+        # Enforcement faults (issue #93): callback raises and halt-webhook
+        # timeouts/errors, counted separately from sink errors.
+        self.policy_errors = 0
 
     def as_dict(self) -> dict:
         return {
@@ -98,6 +145,7 @@ class MonitorMetrics:
             "risks_emitted": self.risks_emitted,
             "detector_errors": self.detector_errors,
             "sink_errors": self.sink_errors,
+            "policy_errors": self.policy_errors,
         }
 
 
@@ -112,6 +160,14 @@ class Monitor:
     distinct episodes can be observed concurrently, while a single episode's
     events serialize. This removes the single global ingest lock that would
     bottleneck a high-throughput service (P1, item 4).
+
+    Enforcement (issue #93): with ``policy="callback"`` an ``on_risk``
+    callable is invoked after the sinks, wrapped fail-open; with
+    ``policy="halt_webhook"`` every risk scoring at or above
+    ``min_severity_for_halt`` is POSTed to ``halt_url`` and the response
+    directive is surfaced thread-safely as :attr:`last_directive`. The
+    default ``policy="observe"`` keeps construction byte-identical to the
+    pre-#93 behavior: no callback, no network, zero overhead.
     """
 
     def __init__(
@@ -120,6 +176,11 @@ class Monitor:
         sinks: list[AlertSink],
         fail_open: bool = True,
         state_backend: StateBackend | None = None,
+        policy: str = DEFAULT_POLICY,
+        on_risk: Callable[[FailureRisk], None] | None = None,
+        halt_url: str | None = None,
+        halt_timeout_s: float = 0.25,
+        min_severity_for_halt: float = 0.8,
     ) -> None:
         self._detectors = list(detectors)
         self._sinks = list(sinks)
@@ -131,6 +192,70 @@ class Monitor:
         self._fault_logged: set[str] = set()
         self._metrics = MonitorMetrics()
         self._metrics_lock = threading.Lock()
+        self._configure_policy(
+            policy=policy,
+            on_risk=on_risk,
+            halt_url=halt_url,
+            halt_timeout_s=halt_timeout_s,
+            min_severity_for_halt=min_severity_for_halt,
+        )
+
+    def _configure_policy(
+        self,
+        *,
+        policy: str = DEFAULT_POLICY,
+        on_risk: Callable[[FailureRisk], None] | None = None,
+        halt_url: str | None = None,
+        halt_timeout_s: float = 0.25,
+        min_severity_for_halt: float = 0.8,
+    ) -> None:
+        """Validate and install the enforcement configuration (issue #93).
+
+        Called from ``__init__`` and re-callable from ``Monitor.default`` so
+        subclasses with a fixed ``__init__`` signature keep working (same
+        rationale as the post-construction ``_state`` assignment there).
+        Invalid values are configuration errors and raise here -- loudly, at
+        setup time, like log_format (issue #119) -- never at ingest time.
+        """
+        normalized = validate_policy(policy)
+        if normalized == "callback" and on_risk is None:
+            logger.warning(
+                "snagline: policy='callback' without an on_risk callable; "
+                "no enforcement action will run"
+            )
+        if normalized == "halt_webhook":
+            if not halt_url:
+                raise ValueError("policy='halt_webhook' requires halt_url")
+            if halt_timeout_s <= 0:
+                raise ValueError("halt_timeout_s must be positive")
+        self._policy = normalized
+        self._on_risk = on_risk
+        self._halt_url = halt_url
+        self._halt_timeout_s = halt_timeout_s
+        self._min_severity_for_halt = min_severity_for_halt
+        self._directive_lock = threading.Lock()
+        self._last_directive = HaltDirective()
+
+    @property
+    def policy(self) -> str:
+        """The active enforcement policy (issue #93)."""
+        return self._policy
+
+    @property
+    def halt_url(self) -> str | None:
+        """The halt webhook endpoint, or None when not in halt_webhook mode."""
+        return self._halt_url
+
+    @property
+    def last_directive(self) -> HaltDirective:
+        """The latest halt-webhook directive, thread-safe (issue #93).
+
+        Starts at action="continue" so consumers always read a valid
+        directive; on timeout/error/dead endpoint it stays at or falls back
+        to continue (fail-open).
+        """
+        with self._directive_lock:
+            return self._last_directive
 
     def ingest(self, event: StepEvent) -> None:
         """Run all detectors against ``event`` and dispatch any risks.
@@ -141,7 +266,8 @@ class Monitor:
         Detection runs under a per-instance lock, but dispatch to sinks happens
         *outside* that lock (issue #8): a slow or network-bound sink (e.g. the
         webhook sink) must not block concurrent ``ingest`` calls, and a sink
-        that re-enters ``ingest`` must not deadlock.
+        that re-enters ``ingest`` must not deadlock. The enforcement policy
+        runs after the sinks, also outside the lock (issue #93).
         """
         risks: list[FailureRisk] = []
         with self._state.episode_lock(event.episode_id):
@@ -176,6 +302,96 @@ class Monitor:
                 )
                 if not self._fail_open:
                     raise
+        # Documented ordering (issue #93): detectors -> sinks -> policy. The
+        # tail runs outside every episode lock; see _enforce.
+        self._enforce(risk)
+
+    # --- Enforcement policy tail (issue #93) ---------------------------------
+
+    def _enforce(self, risk: FailureRisk) -> None:
+        """Run the configured enforcement policy for one dispatched risk.
+
+        Called strictly AFTER the sink loop, outside every episode lock, so a
+        slow halt webhook delays only its own dispatch thread, never other
+        episodes' ingest. With the default ``policy="observe"`` this is a
+        single string comparison: no behavior change, no overhead.
+        """
+        if self._policy == "observe":
+            return
+        if self._policy == "callback":
+            self._run_risk_callback(risk)
+        else:
+            self._run_halt_webhook(risk)
+
+    def _run_risk_callback(self, risk: FailureRisk) -> None:
+        """Invoke the host callback wrapped exactly like a sink (issue #93).
+
+        Exceptions are counted under ``policy_errors``, logged fault-once, and
+        swallowed unless ``fail_open=False`` -- identical semantics to the
+        sink loop in ``_dispatch``, verified by parity tests against
+        tests/test_monitor_fail_open.py.
+        """
+        callback = self._on_risk
+        if callback is None:
+            return
+        try:
+            callback(risk)
+        except Exception:
+            self._incr("policy_errors")
+            self._log_fault_once("risk callback raised; ignoring (fail-open)")
+            if not self._fail_open:
+                raise
+
+    def _run_halt_webhook(self, risk: FailureRisk) -> None:
+        """Fire-and-collect POST of one risk to the halt endpoint (issue #93).
+
+        Only risks scoring at or above ``min_severity_for_halt`` pay the
+        round-trip cost. The response JSON ``{"action": ..., "reason": ...}``
+        becomes ``monitor.last_directive``; anything unexpected -- timeout,
+        connection error, malformed body, unknown action -- leaves the
+        directive at continue (fail-open) and counts one ``policy_error``.
+        Never raises into the host loop while ``fail_open=True``.
+        """
+        if risk.score < self._min_severity_for_halt:
+            return
+        payload = {
+            "episode_id": risk.episode_id,
+            "step_id": risk.step_id,
+            "score": risk.score,
+            "trigger": risk.trigger,
+            "detail": risk.detail,
+            "timestamp": risk.timestamp,
+            "severity": risk.severity,
+        }
+        try:
+            req = urllib.request.Request(
+                self._halt_url or "",
+                data=json.dumps(payload).encode("utf-8"),
+                headers={"Content-Type": "application/json"},
+                method="POST",
+            )
+            with urllib.request.urlopen(req, timeout=self._halt_timeout_s) as resp:
+                body = resp.read(_MAX_HALT_RESPONSE_BYTES)
+            parsed = json.loads(body.decode("utf-8"))
+            if not isinstance(parsed, dict):
+                raise ValueError("halt response must be a JSON object")
+            action = str(parsed.get("action", HALT_ACTION_CONTINUE)).strip().lower()
+            if action not in VALID_HALT_ACTIONS:
+                raise ValueError(f"unknown halt action {action!r}")
+            reason = str(parsed.get("reason", ""))
+            directive = HaltDirective(
+                action=action, reason=reason, timestamp=time.time()
+            )
+        except Exception:
+            self._incr("policy_errors")
+            self._log_fault_once(
+                f"halt webhook {self._halt_url} failed; continuing (fail-open)"
+            )
+            if not self._fail_open:
+                raise
+            return
+        with self._directive_lock:
+            self._last_directive = directive
 
     def _incr(self, name: str) -> None:
         with self._metrics_lock:
@@ -539,4 +755,17 @@ class Monitor:
         # Set after construction so subclasses with a fixed __init__ signature
         # (e.g. test doubles) still work; base Monitor.__init__ also sets it.
         monitor._state = state_backend or default_state_backend()
+        # Enforcement layer (issue #93): applied through _configure_policy for
+        # the same subclass-compatibility reason as _state above. on_risk is
+        # deliberately absent from Config (callables cannot arrive via env or
+        # config files), so callback mode through default() runs inert unless
+        # a callable is attached directly afterwards; _configure_policy warns
+        # about exactly that case.
+        monitor._configure_policy(
+            policy=cfg.policy,
+            on_risk=None,
+            halt_url=cfg.halt_url,
+            halt_timeout_s=cfg.halt_timeout_s,
+            min_severity_for_halt=cfg.min_severity_for_halt,
+        )
         return monitor

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -23,6 +23,7 @@ import urllib.request
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 from snagline.calibration import (
     CalibrationPlan,
@@ -228,6 +229,18 @@ class Monitor:
                 raise ValueError("policy='halt_webhook' requires halt_url")
             if halt_timeout_s <= 0:
                 raise ValueError("halt_timeout_s must be positive")
+            # Control-plane endpoint: restrict to http(s). urllib would happily
+            # attempt other schemes (file://, ftp://); a typo or injection in
+            # operator config must fail loudly here, not probe odd handlers.
+            scheme = urlsplit(str(halt_url)).scheme.strip().lower()
+            if scheme not in ("http", "https"):
+                raise ValueError(
+                    f"halt_url must be an http(s) endpoint; got scheme {scheme!r}"
+                )
+        # Risk scores live in [0, 1]; a threshold outside that range would
+        # silently disable or permanently enable halting.
+        if not 0.0 <= float(min_severity_for_halt) <= 1.0:
+            raise ValueError("min_severity_for_halt must be within [0, 1]")
         self._policy = normalized
         self._on_risk = on_risk
         self._halt_url = halt_url

--- a/tests/test_enforcement_policy.py
+++ b/tests/test_enforcement_policy.py
@@ -1,0 +1,749 @@
+"""Enforcement policy layer (issue #93): callback + halt_webhook, fail-open.
+
+Parity with tests/test_monitor_fail_open.py is the core contract: the
+enforcement tail must be exactly as safe as the sink loop it mirrors.
+Documented ordering: detectors -> sinks -> policy. The halt webhook runs
+outside every episode lock and never raises into the host loop under
+fail_open=True: timeout, error, dead endpoint, malformed body, or unknown
+action all leave ``monitor.last_directive`` at continue.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import socket
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+import pytest
+
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.monitor import HaltDirective, Monitor
+from snagline.risk import FailureRisk
+
+
+def _event(step_id: str = "s1", episode_id: str = "ep1") -> StepEvent:
+    return StepEvent(
+        step_id=step_id,
+        episode_id=episode_id,
+        timestamp=1.0,
+        action_type="tool_call",
+        action_signature=f"sig-{step_id}",
+    )
+
+
+class _FixedRiskDetector:
+    """Emits one synthetic risk at a fixed score on every observe() call."""
+
+    name = "fixed_risk"
+
+    def __init__(self, score: float = 0.9, trigger: str = "loop") -> None:
+        self.score = score
+        self.trigger = trigger
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            self.score,
+            self.trigger,
+            "synthetic risk",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        pass
+
+
+class _FinalizeRiskDetector:
+    """Silent during observe(); emits one risk from finalize()."""
+
+    name = "finalize_risk"
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        return None
+
+    def finalize(self, episode_id: str) -> FailureRisk | None:
+        return FailureRisk(
+            episode_id,
+            "final",
+            0.95,
+            "silent_abort",
+            "synthetic finalize risk",
+            2.0,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        pass
+
+
+class _BlockStepRiskDetector:
+    """Emits a high-score risk ONLY for the step named 'block'.
+
+    Lets the outside-the-lock test give one thread a halting risk while a
+    concurrent ingest of the SAME episode stays risk-free, isolating the
+    episode-lock behavior from the webhook itself.
+    """
+
+    name = "block_step_risk"
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        if event.step_id != "block":
+            return None
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            0.95,
+            "loop",
+            "synthetic blocking risk",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        pass
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.received: list[FailureRisk] = []
+
+    def emit(self, risk: FailureRisk) -> None:
+        self.received.append(risk)
+
+
+class _HaltEndpoint:
+    """Configurable local halt endpoint used by the webhook tests.
+
+    responder(parsed_body) -> (status, response_obj); when raw_body is set it
+    is sent verbatim instead. delay > 0 stalls every response until the
+    release event fires or the delay elapses, whichever comes first.
+    """
+
+    def __init__(self, responder=None, raw_body=None, delay: float = 0.0) -> None:
+        self.requests: list[dict] = []
+        self.lock = threading.Lock()
+        self.entered = threading.Event()
+        self.release = threading.Event()
+        self._responder = responder
+        self._raw_body = raw_body
+        self._delay = delay
+        outer = self
+
+        class _Handler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802
+                length = int(self.headers.get("Content-Length") or 0)
+                body = self.rfile.read(length)
+                with outer.lock:
+                    outer.requests.append(json.loads(body.decode("utf-8")))
+                outer.entered.set()
+                if outer._delay > 0:
+                    outer.release.wait(outer._delay)
+                if outer._raw_body is not None:
+                    payload, status = outer._raw_body, 200
+                elif outer._responder is not None:
+                    status, payload = outer._responder(outer.requests[-1])
+                else:
+                    status, payload = 200, {"action": "continue", "reason": ""}
+                data = (
+                    payload
+                    if isinstance(payload, bytes)
+                    else json.dumps(payload).encode("utf-8")
+                )
+                self.send_response(status)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self.url = f"http://127.0.0.1:{self._server.server_port}/halt"
+        self._thread = threading.Thread(target=self._server.serve_forever)
+        self._thread.start()
+
+    def wait_entered(self, timeout: float = 2.0) -> bool:
+        return self.entered.wait(timeout)
+
+    def stop(self) -> None:
+        self.release.set()
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2)
+
+
+@pytest.fixture
+def halt_endpoint():
+    endpoint = _HaltEndpoint()
+    yield endpoint
+    endpoint.stop()
+
+
+def _dead_url() -> str:
+    """An address where nothing listens anymore (bound once, then closed)."""
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    port = sock.getsockname()[1]
+    sock.close()
+    return f"http://127.0.0.1:{port}/halt"
+
+
+# --- Default construction unchanged (acceptance criterion 1) -----------------
+
+
+def test_default_construction_unchanged_observe_policy():
+    sink = _RecordingSink()
+    monitor = Monitor([_FixedRiskDetector()], [sink])
+    assert monitor.policy == "observe"
+    assert monitor.halt_url is None
+    assert monitor.last_directive.action == "continue"
+    monitor.ingest(_event())
+    # Identical pre-#93 dispatch behavior plus a zero-count policy counter.
+    assert len(sink.received) == 1
+    assert monitor.metrics()["policy_errors"] == 0
+
+
+def test_observe_policy_ignores_enforcement_arguments():
+    # Passing halt-only arguments without opting into a policy changes nothing.
+    sink = _RecordingSink()
+    monitor = Monitor(
+        [_FixedRiskDetector(score=0.99)],
+        [sink],
+        halt_url=_dead_url(),
+        halt_timeout_s=0.01,
+    )
+    assert monitor.policy == "observe"
+    monitor.ingest(_event())
+    assert len(sink.received) == 1
+    assert monitor.last_directive.action == "continue"
+
+
+# --- Callback mode (parity with test_monitor_fail_open.py) --------------------
+
+
+def test_callback_invoked_after_sinks_in_documented_order():
+    order: list[str] = []
+
+    class OrderSink:
+        def emit(self, risk: FailureRisk) -> None:
+            order.append("sink")
+
+    def on_risk(risk: FailureRisk) -> None:
+        order.append("callback")
+
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [OrderSink()],
+        policy="callback",
+        on_risk=on_risk,
+    )
+    monitor.ingest(_event())
+    assert order == ["sink", "callback"]
+
+
+def test_callback_receives_the_risk_object():
+    seen: list[FailureRisk] = []
+    monitor = Monitor(
+        [_FixedRiskDetector(trigger="error_cascade")],
+        [],
+        policy="callback",
+        on_risk=seen.append,
+    )
+    monitor.ingest(_event("s9"))
+    assert len(seen) == 1
+    assert seen[0].trigger == "error_cascade"
+    assert seen[0].step_id == "s9"
+
+
+class _RaisingCallback:
+    def __call__(self, risk: FailureRisk) -> None:
+        raise RuntimeError("boom in callback")
+
+
+def test_callback_exception_swallowed_fail_open():
+    sink = _RecordingSink()
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [sink],
+        policy="callback",
+        on_risk=_RaisingCallback(),
+    )
+    # Must NOT raise, mirroring test_fail_open_default_swallows_sink_exception.
+    monitor.ingest(_event("a"))
+    monitor.ingest(_event("b"))
+    # Both risks still reached the sink; the callback never broke ingest.
+    assert len(sink.received) == 2
+
+
+def test_callback_exception_logged_and_counted(caplog):
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="callback",
+        on_risk=_RaisingCallback(),
+    )
+    with caplog.at_level(logging.ERROR, logger="snagline"):
+        monitor.ingest(_event("a"))
+        monitor.ingest(_event("b"))
+    assert any("callback" in r.message for r in caplog.records)
+    assert any("fail-open" in r.message for r in caplog.records)
+    # Counted on every occurrence even though logged only once (issue #14).
+    assert monitor.metrics()["policy_errors"] == 2
+
+
+def test_callback_exception_propagates_when_fail_open_false():
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        fail_open=False,
+        policy="callback",
+        on_risk=_RaisingCallback(),
+    )
+    with pytest.raises(RuntimeError):
+        monitor.ingest(_event())
+
+
+def test_callback_not_filtered_by_min_severity():
+    seen: list[FailureRisk] = []
+    monitor = Monitor(
+        [_FixedRiskDetector(score=0.2)],
+        [],
+        policy="callback",
+        on_risk=seen.append,
+        min_severity_for_halt=0.99,
+    )
+    monitor.ingest(_event())
+    # The threshold gates only the webhook cost; callbacks see every risk.
+    assert len(seen) == 1
+
+
+def test_callback_policy_without_callable_warns_but_never_crashes(caplog):
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        monitor = Monitor([], [], policy="callback")
+    assert monitor.policy == "callback"
+    assert any("on_risk" in r.message for r in caplog.records)
+
+
+# --- Halt webhook mode --------------------------------------------------------
+
+
+def test_directive_starts_at_continue_before_any_webhook(halt_endpoint):
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    assert monitor.last_directive == HaltDirective()
+
+
+def test_halt_webhook_pause_response_surfaced_as_last_directive(halt_endpoint):
+    halt_endpoint._responder = lambda req: (
+        200,
+        {"action": "pause", "reason": "budget breach"},
+    )
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    monitor.ingest(_event())
+    directive = monitor.last_directive
+    assert directive.action == "pause"
+    assert directive.reason == "budget breach"
+    assert directive.timestamp > 0
+
+
+def test_halt_webhook_continue_response(halt_endpoint):
+    halt_endpoint._responder = lambda req: (200, {"action": "continue"})
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    monitor.ingest(_event())
+    assert monitor.last_directive.action == "continue"
+
+
+def test_halt_webhook_payload_carries_only_risk_fields(halt_endpoint):
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    monitor.ingest(_event("sp"))
+    assert halt_endpoint.wait_entered()
+    body = halt_endpoint.requests[0]
+    assert set(body) == {
+        "episode_id",
+        "step_id",
+        "score",
+        "trigger",
+        "detail",
+        "timestamp",
+        "severity",
+    }
+    assert body["step_id"] == "sp"
+    assert "metadata" not in body
+
+
+def test_halt_webhook_below_threshold_skips_post(halt_endpoint):
+    monitor = Monitor(
+        [_FixedRiskDetector(score=0.5)],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    monitor.ingest(_event())
+    time.sleep(0.05)
+    assert halt_endpoint.requests == []
+    assert monitor.last_directive.action == "continue"
+
+
+def test_halt_webhook_at_threshold_posts(halt_endpoint):
+    monitor = Monitor(
+        [_FixedRiskDetector(score=0.8)],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    monitor.ingest(_event())
+    assert halt_endpoint.wait_entered()
+    assert len(halt_endpoint.requests) == 1
+
+
+def test_halt_webhook_dead_endpoint_defaults_to_continue():
+    sink = _RecordingSink()
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [sink],
+        policy="halt_webhook",
+        halt_url=_dead_url(),
+    )
+    start = time.perf_counter()
+    monitor.ingest(_event())  # must NOT raise
+    elapsed = time.perf_counter() - start
+    assert monitor.last_directive.action == "continue"
+    assert monitor.metrics()["policy_errors"] == 1
+    # Sink dispatch was unaffected by the failed consultation.
+    assert len(sink.received) == 1
+    # Connection-refused fails fast locally; guard against surprise stalls.
+    assert elapsed < 1.0
+
+
+def test_halt_webhook_stalled_endpoint_times_out_to_continue():
+    endpoint = _HaltEndpoint(delay=5.0)
+    try:
+        monitor = Monitor(
+            [_FixedRiskDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=endpoint.url,
+            halt_timeout_s=0.15,
+        )
+        start = time.perf_counter()
+        monitor.ingest(_event())  # must NOT raise
+        elapsed = time.perf_counter() - start
+        # Paid roughly the timeout budget, not the endpoint's full stall.
+        assert 0.15 <= elapsed < 2.0
+        assert monitor.last_directive.action == "continue"
+        assert monitor.metrics()["policy_errors"] == 1
+    finally:
+        endpoint.stop()
+
+
+def test_halt_webhook_malformed_body_defaults_to_continue():
+    endpoint = _HaltEndpoint(raw_body=b"this is not json")
+    try:
+        monitor = Monitor(
+            [_FixedRiskDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=endpoint.url,
+        )
+        monitor.ingest(_event())
+        assert monitor.last_directive.action == "continue"
+        assert monitor.metrics()["policy_errors"] == 1
+    finally:
+        endpoint.stop()
+
+
+def test_halt_webhook_unknown_action_defaults_to_continue():
+    endpoint = _HaltEndpoint(responder=lambda req: (200, {"action": "explode"}))
+    try:
+        monitor = Monitor(
+            [_FixedRiskDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=endpoint.url,
+        )
+        monitor.ingest(_event())
+        assert monitor.last_directive.action == "continue"
+        assert monitor.metrics()["policy_errors"] == 1
+    finally:
+        endpoint.stop()
+
+
+def test_halt_webhook_error_status_defaults_to_continue():
+    endpoint = _HaltEndpoint(responder=lambda req: (500, {"action": "pause"}))
+    try:
+        monitor = Monitor(
+            [_FixedRiskDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=endpoint.url,
+        )
+        monitor.ingest(_event())
+        assert monitor.last_directive.action == "continue"
+        assert monitor.metrics()["policy_errors"] == 1
+    finally:
+        endpoint.stop()
+
+
+def test_halt_webhook_failure_propagates_when_fail_open_false():
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        fail_open=False,
+        policy="halt_webhook",
+        halt_url=_dead_url(),
+    )
+    with pytest.raises(Exception):
+        monitor.ingest(_event())
+
+
+def test_halt_webhook_runs_outside_ingest_lock():
+    """A stalled halt consultation must not hold the episode lock (issue #93).
+
+    Thread A ingests a high-score event for ep1 and parks inside the webhook;
+    while it is parked, a low-score ingest for the SAME episode must still
+    complete its locked detection phase. If the webhook ever moved inside the
+    episode lock, the second ingest would hang until the release.
+    """
+    endpoint = _HaltEndpoint(delay=30.0)
+    try:
+        monitor = Monitor(
+            [_BlockStepRiskDetector()],
+            [],
+            policy="halt_webhook",
+            halt_url=endpoint.url,
+            halt_timeout_s=10.0,
+        )
+        blocker = threading.Thread(
+            target=monitor.ingest, args=(_event("block", "ep1"),)
+        )
+        blocker.start()
+        assert endpoint.wait_entered(2.0), "webhook was never consulted"
+
+        done = threading.Event()
+
+        def second_ingest() -> None:
+            monitor.ingest(_event("after", "ep1"))
+            done.set()
+
+        worker = threading.Thread(target=second_ingest)
+        worker.start()
+        assert done.wait(2.0), (
+            "second ingest blocked: halt webhook appears to hold the "
+            "episode lock (ordering detectors -> sinks -> policy violated)"
+        )
+        # Low-score risk skipped the webhook, so exactly one POST so far.
+        with endpoint.lock:
+            assert len(endpoint.requests) == 1
+        endpoint.release.set()
+        blocker.join(timeout=15)
+        assert not blocker.is_alive()
+        worker.join(timeout=2)
+    finally:
+        endpoint.stop()
+
+
+def test_last_directive_thread_safe_under_concurrent_ingest(halt_endpoint):
+    halt_endpoint._responder = lambda req: (
+        200,
+        {"action": "pause" if req["step_id"].endswith("0") else "continue"},
+    )
+    failures: list[str] = []
+
+    def check(directive: HaltDirective) -> None:
+        if directive.action not in ("continue", "pause"):
+            failures.append(f"torn directive: {directive!r}")
+
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    threads = [
+        threading.Thread(
+            target=lambda k=k: [
+                check(monitor.last_directive) or monitor.ingest(_event(f"t{k}-{i}"))
+                for i in range(10)
+            ]
+        )
+        for k in range(8)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+    assert failures == []
+    assert monitor.last_directive.action in ("continue", "pause")
+
+
+def test_finalize_risks_also_reach_policy_tail(halt_endpoint):
+    """end_episode() dispatches finalized risks through the same tail."""
+    halt_endpoint._responder = lambda req: (
+        200,
+        {"action": "pause", "reason": "silent abort"},
+    )
+    monitor = Monitor(
+        [_FinalizeRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=halt_endpoint.url,
+    )
+    monitor.ingest(_event())
+    assert monitor.last_directive.action == "continue"
+    monitor.end_episode("ep1")
+    assert monitor.last_directive.action == "pause"
+
+
+# --- Configuration and validation ---------------------------------------------
+
+
+def test_invalid_policy_raises_valueerror():
+    with pytest.raises(ValueError):
+        Monitor([], [], policy="nope")
+    with pytest.raises(ValueError):
+        Config(policy="nope")
+
+
+def test_halt_webhook_without_url_raises():
+    with pytest.raises(ValueError):
+        Monitor([], [], policy="halt_webhook")
+    with pytest.raises(ValueError):
+        Monitor([], [], policy="halt_webhook", halt_url="")
+
+
+def test_halt_webhook_nonpositive_timeout_raises():
+    with pytest.raises(ValueError):
+        Monitor([], [], policy="halt_webhook", halt_url="http://x/", halt_timeout_s=0)
+
+
+def test_monitor_default_wires_policy_from_config(halt_endpoint):
+    monitor = Monitor.default(
+        config=Config(policy="halt_webhook", halt_url=halt_endpoint.url),
+        sinks=[],
+    )
+    assert monitor.policy == "halt_webhook"
+    assert monitor.halt_url == halt_endpoint.url
+    assert monitor.last_directive.action == "continue"
+    # And the stock default stays observe.
+    stock = Monitor.default(config=Config(), sinks=[])
+    assert stock.policy == "observe"
+
+
+def test_config_env_layering_for_policy_fields():
+    cfg = Config.resolve(
+        environ={
+            "SNAGLINE_POLICY": "Halt_Webhook ",
+            "SNAGLINE_HALT_URL": "http://127.0.0.1:9/halt",
+            "SNAGLINE_HALT_TIMEOUT_S": "0.4",
+            "SNAGLINE_MIN_SEVERITY_FOR_HALT": "0.6",
+        }
+    )
+    assert cfg.policy == "halt_webhook"
+    assert cfg.halt_url == "http://127.0.0.1:9/halt"
+    assert cfg.halt_timeout_s == 0.4
+    assert cfg.min_severity_for_halt == 0.6
+
+
+def test_no_extras_import_smoke():
+    """Bare import works stdlib-only; enforcement adds no third-party deps."""
+    import subprocess
+    import sys
+
+    result = subprocess.run(
+        [sys.executable, "-c", "import snagline; print(snagline.__version__)"],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip()
+
+
+# --- CLI: snagline serve --halt-forward ----------------------------------------
+
+
+def test_serve_halt_forward_enables_policy(monkeypatch):
+    from snagline import cli
+
+    captured: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        captured["monitor"] = monitor
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    url = "http://127.0.0.1:9/halt"
+    assert cli.main(["serve", "--halt-forward", url]) == 0
+    monitor = captured["monitor"]
+    assert monitor.policy == "halt_webhook"
+    assert monitor.halt_url == url
+    assert monitor.last_directive.action == "continue"
+
+
+def test_serve_without_halt_forward_stays_observe(monkeypatch):
+    from snagline import cli
+
+    captured: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        captured["monitor"] = monitor
+
+    monkeypatch.delenv("SNAGLINE_SERVE_AUTH_TOKEN", raising=False)
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert cli.main(["serve"]) == 0
+    assert captured["monitor"].policy == "observe"
+
+
+def test_serve_halt_flags_map_to_config(monkeypatch):
+    from snagline import cli
+
+    captured: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        captured["monitor"] = monitor
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert (
+        cli.main(
+            [
+                "serve",
+                "--halt-forward",
+                "http://127.0.0.1:9/halt",
+                "--halt-timeout",
+                "0.5",
+                "--min-severity-for-halt",
+                "0.6",
+            ]
+        )
+        == 0
+    )
+    monitor = captured["monitor"]
+    assert monitor._halt_timeout_s == 0.5
+    assert monitor._min_severity_for_halt == 0.6
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_enforcement_policy.py
+++ b/tests/test_enforcement_policy.py
@@ -640,6 +640,24 @@ def test_halt_webhook_nonpositive_timeout_raises():
         Monitor([], [], policy="halt_webhook", halt_url="http://x/", halt_timeout_s=0)
 
 
+def test_halt_webhook_rejects_non_http_scheme():
+    # Control-plane endpoint: urllib would happily try file://, ftp://, etc.;
+    # only http(s) is a legitimate halt transport.
+    for bad in ("file:///etc/passwd", "ftp://host/halt", "/etc/passwd"):
+        with pytest.raises(ValueError):
+            Monitor([], [], policy="halt_webhook", halt_url=bad)
+
+
+def test_min_severity_for_halt_range_validated():
+    for bad in (-0.1, 1.1, 42):
+        with pytest.raises(ValueError):
+            Monitor([], [], min_severity_for_halt=bad)
+    # The domain edges themselves are legal.
+    for edge in (0.0, 1.0):
+        monitor = Monitor([], [], min_severity_for_halt=edge)
+        assert monitor._min_severity_for_halt == edge
+
+
 def test_monitor_default_wires_policy_from_config(halt_endpoint):
     monitor = Monitor.default(
         config=Config(policy="halt_webhook", halt_url=halt_endpoint.url),


### PR DESCRIPTION
Fixes #93

## What

Optional enforcement layer on `Monitor`, running as the documented tail of every dispatched risk: detectors -> sinks -> policy, outside every episode lock (issue #8's sink-outside-lock rule carries over verbatim).

- `policy="observe"` (default): byte-identical to today. One string comparison per risk, nothing else.
- `policy="callback"`: `on_risk(risk)` invoked after the sinks, wrapped exactly like a sink error path: logged fault-once, counted under `metrics()["policy_errors"]`, swallowed unless `fail_open=False`. For in-process circuit breakers: your callback sets a flag your agent loop checks; snagline never raises into your loop.
- `policy="halt_webhook"`: fire-and-collect POST of the FailureRisk JSON to `halt_url` (`halt_timeout_s` default 250ms). The response `{"action": "continue"|"pause", "reason": ...}` is surfaced thread-safely as `monitor.last_directive` (frozen dataclass, swapped under a dedicated lock). Timeout, connection error, dead endpoint, malformed body, unknown action, and HTTP errors all default the directive to continue: fail-open by construction, never a raise into the host loop.
- `min_severity_for_halt` (default 0.8): only risks scoring at or above it pay the webhook cost. Below-threshold risks still reach sinks/callbacks untouched.
- Config gains `policy` / `halt_url` / `halt_timeout_s` / `min_severity_for_halt` with closed-set validation at construction and resolve time (same loud-failure precedent as log_format, #119). Env vars `SNAGLINE_POLICY`, `SNAGLINE_HALT_URL`, `SNAGLINE_HALT_TIMEOUT_S`, `SNAGLINE_MIN_SEVERITY_FOR_HALT` work end to end through `Monitor.default()`. `on_risk` is deliberately code-only: callables cannot arrive via env or config files.
- CLI: `snagline serve --halt-forward URL [--halt-timeout S] [--min-severity-for-halt F]` gives sidecar consumers identical semantics. Wiring goes through `dataclasses.replace(cfg, ...)` so validation still runs.

Zone discipline: monitor.py tail only (constructor kwargs + `_dispatch` tail + enforcement helpers), config.py fields/validation, cli.py serve subcommand. http_server.py untouched.

## Acceptance criteria, each cited

1. **Default construction unchanged: zero new behavior, zero overhead when policy="observe".**
   `tests/test_enforcement_policy.py::test_default_construction_unchanged_observe_policy` and `::test_observe_policy_ignores_enforcement_arguments`. Benchmark cross-check: observe baseline measured ~2 us/step, matching the published ingest number (see below).

2. **Callback exceptions never propagate (test parity with test_monitor_fail_open.py).**
   `::test_callback_exception_swallowed_fail_open` (mirrors `test_fail_open_default_swallows_sink_exception`: two consecutive ingests survive a raising callback), `::test_callback_exception_logged_and_counted` (logged fault-once, counted per occurrence), `::test_callback_exception_propagates_when_fail_open_false` (mirrors `test_fail_open_false_propagates_sink_exception`). Also `::test_callback_invoked_after_sinks_in_documented_order` proves ordering, and `::test_callback_not_filtered_by_min_severity` proves the threshold gates only webhook cost.

3. **Halt webhook timeout/dead-endpoint falls back to continue; worst-case added latency published in bench table.**
   `::test_halt_webhook_dead_endpoint_defaults_to_continue`, `::test_halt_webhook_stalled_endpoint_times_out_to_continue` (pays ~the timeout budget, not the endpoint's stall), plus malformed-body / unknown-action / HTTP-500 variants (`::test_halt_webhook_malformed_body_defaults_to_continue`, `::test_halt_webhook_unknown_action_defaults_to_continue`, `::test_halt_webhook_error_status_defaults_to_continue`) and the strict-mode counterpart `::test_halt_webhook_failure_propagates_when_fail_open_false`.
   Measured (Apple M1, arm64, CPython 3.14.5, 2026-08-26, halt_timeout_s=250ms, one above-threshold risk per step so every step pays full enforcement cost; reproduce with `python benchmarks/enforcement_benchmark.py`):

   | Leg | Median | p99 | Fail-open fallbacks |
   |---|---|---|---|
   | observe (baseline) | ~2.0 us/step | ~2.2 us/step | 0 |
   | responding localhost endpoint | ~264 to 334 us/step across runs | ~410 us/step | 0 |
   | refused (dead) endpoint | ~57 to 68 us/step | ~135 us/step | all (expected) |
   | stalled endpoint (worst case) | ~252 ms/step | ~252 ms/step | all (expected) |

   The worst case is bounded by the explicit timeout envelope (~halt_timeout_s + small epsilon) and is paid only by the dispatching thread. Numbers are also published in the README bench block and coverage table.

4. **Directive surfaced thread-safely for concurrent multi-episode use.**
   `::test_last_directive_thread_safe_under_concurrent_ingest` (8 threads x 10 ingests against a live server; reads are always complete directives), `::test_directive_starts_at_continue_before_any_webhook`. The outside-the-lock guarantee has its own deterministic proof: `::test_halt_webhook_runs_outside_ingest_lock` parks one thread inside the webhook for the same episode and completes a second ingest of that episode while it waits; if the webhook ever moved inside the episode lock this test fails instead of hanging. `::test_finalize_risks_also_reach_policy_tail` covers end_episode dispatch through the same tail.

5. **Docs: security section updated.**
   README Security section gains a halt-webhook bullet: the endpoint holds CONTROL (its response can pause the host), bind to localhost or front with an authenticated reverse proxy like the sidecar guidance in docs/ATTACH_ANY_SYSTEM.md, and the client-side fail-open contract means a downed endpoint degrades to detection-only rather than blocking the agent. New "Enforcement policy (issue #93)" subsection documents usage, ordering, envelope, env vars, and CLI flags. Payload shape asserted content-free by `::test_halt_webhook_payload_carries_only_risk_fields` (exactly seven FailureRisk fields, no metadata).

CLI acceptance: `::test_serve_halt_forward_enables_policy`, `::test_serve_without_halt_forward_stays_observe`, `::test_serve_halt_flags_map_to_config`.

## Mandatory mutation checks (both fail-open paths)

Committed the fix first, then mutated the committed file, ran the named tests red, reverted with `git checkout`.

1. **Callback raising must not propagate.** Removed the try/except swallow around `callback(risk)` so exceptions propagate unconditionally. Red: `test_callback_exception_swallowed_fail_open`, `test_callback_exception_logged_and_counted`. Reverted.
2. **Webhook timing out must fall back to continue.** Changed the except-path fallback from a continue directive into `directive = HaltDirective(action=HALT_ACTION_PAUSE, reason="mutated")`. Red: `test_halt_webhook_stalled_endpoint_times_out_to_continue`, `test_halt_webhook_dead_endpoint_defaults_to_continue`. Reverted.

## Review-bot findings addressed in-PR

- gitar-bot: halt_url accepted any urllib scheme (file://, ftp://). Now restricted to http(s) at configure time (`test_halt_webhook_rejects_non_http_scheme`); anything else raises ValueError alongside the other loud config errors.
- gitar-bot: min_severity_for_halt was never range-validated. Now must be within [0, 1] (`test_min_severity_for_halt_range_validated`).

## Verification

- Full gate green at every commit snapshot, after rebasing onto origin/master (09f1112, which landed the parallel timestamp/clock fix in adapters; hunks were disjoint, nothing dropped), and at final head b9573cc: ruff check src tests, ruff format --check src tests, mypy src clean, pytest 538 passed / 2 skipped, coverage 88.18 percent.
- No-extras import smoke: fresh stdlib-only venv, bare `import snagline` works (also pinned as `::test_no_extras_import_smoke`).
- Zero mandatory dependencies added; the halt client uses stdlib `urllib.request` only.
