### PR TITLE
feat(time-axis): horizon-scale config, idle/budget risks, window auto-scaling, heartbeat sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The full architecture reference is in [docs/ADAPTER_GUIDE.md](docs/ADAPTER_GUIDE
 | **Goal-drift detector** (opt-in) | A run diverging from its known-healthy behavior | Compares a live run's per-tool error rate and latency against a persisted `BaselineProfile` built by `snagline baseline`. Flags rising error rate, latency blowing past the healthy mean, or tools that never appeared in the baseline. | O(1) amortized |
 | **Semantic goal-drift detector** (opt-in, `snagline[drift]`) | The agent's activity mix drifting from its healthy goal | Embeds structural labels (`action_type`, `tool_name`, `error_type`; never content) with `sentence-transformers` and watches the live episode's running centroid against the persisted `BaselineProfile` embedding centroid; sustained cosine deviation through a CUSUM gate emits `goal_drift`. Import is lazy; missing model or inference failures leave it inert (fail-open). | O(embedding dim) per step, bounded state |
 | **ML ensemble** (opt-in) | A stronger, combined signal | Wraps the base detectors and combines their scores with a transparent noisy-OR. A real model can be injected via `MLOrchestrator(model=...)` (the `ml` extra provides scikit-learn). | O(1) amortized |
+| **Horizon-scale time axis** (opt-in) | Budget exhaustion and silence on multi-day episodes | Wall-clock budget derived from event timestamps: one warning at `warn_fraction` of `max_episode_wall_seconds`, one critical breach at the limit (`wall_clock_budget`). Idle detection fires `idle_gap` when consecutive ingests drift more than `idle_warn_seconds` apart. Every quantity comes from `StepEvent.timestamp`, never the wall clock, so replay stays deterministic. | O(1) per step |
 
 Detection is deterministic and `O(1)` amortized per step. It runs with no network calls and no LLM calls. The CUSUM detector uses only the Python standard library (`statistics` module) -- no numpy required.
 
@@ -151,6 +152,7 @@ in [docs/RETRAIN_CADENCE.md](docs/RETRAIN_CADENCE.md)).
 | **Pluggable sinks** | Console (default, zero dep), webhook (stdlib urllib, fire-and-forget), and extensible. Only `FailureRisk` fields are ever transmitted. |
 | **Optional enforcement** | `Monitor(policy=...)` adds a sanctioned escalation path after the sinks: `"callback"` wraps an in-process callable fail-open; `"halt_webhook"` POSTs the risk and lands its `{"action": "continue"|"pause"}` directive on `monitor.last_directive`. Timeout/error/dead endpoint always falls back to continue; default `policy="observe"` pays nothing (issue #93). |
 | **External agent bridges** | HTTP sidecar, command bridge, and file tail for non-Python agents (Claude Code, OpenClaw, Hermes). |
+| **Heartbeat liveness file** | `snagline watch --heartbeat PATH` touches a file's mtime on every ingest (and every idle follow-poll), so an external supervisor (cron, systemd timer, k8s probe) can alert when silence itself is the failure. In-band detectors structurally cannot see a hung host; this closes that hole from outside. |
 | **Thread-safe** | Per-instance `threading.Lock` supports concurrent multi-episode monitoring. |
 
 ## Configuration
@@ -234,6 +236,12 @@ the path variant below.
 | `SNAGLINE_GOAL_DRIFT_SCORE_THRESHOLD` | `goal_drift_score_threshold` | 0.5 | Emit a goal-drift risk above this score |
 | `SNAGLINE_ML_ENSEMBLE_ENABLED` | `ml_ensemble_enabled` | False | Wrap detectors in MLOrchestrator (noisy-OR) |
 | `SNAGLINE_ML_ENSEMBLE_SCORE_THRESHOLD` | `ml_ensemble_score_threshold` | 0.5 | Emit a combined risk above this score |
+| `SNAGLINE_MAX_EPISODE_WALL_SECONDS` | `max_episode_wall_seconds` | None | Wall-clock budget per episode from event timestamps; unset disables |
+| `SNAGLINE_WARN_FRACTION` | `warn_fraction` | 0.8 | Fraction of the budget where the single pre-breach warning fires |
+| `SNAGLINE_IDLE_WARN_SECONDS` | `idle_warn_seconds` | None | Gap between consecutive ingests that fires one `idle_gap` risk |
+| `SNAGLINE_WINDOW_SCALE_STEPS` | `window_scale_steps` | 0 | Window auto-scaling divisor; 0 keeps fixed windows |
+| `SNAGLINE_MAX_WINDOW` | `max_window` | 512 | Hard cap for scaled windows |
+| `SNAGLINE_CUSUM_REFIT_EVERY` | `cusum_refit_every` | 0 | Latency CUSUM periodic baseline re-fit interval; 0 disables |
 | `SNAGLINE_LOOP_NEAR_DUPLICATE_ENABLED` | `loop_near_duplicate_enabled` | False | Loop hardening: collapse volatile ids before hashing |
 | `SNAGLINE_LOOP_CYCLE_ENABLED` | `loop_cycle_enabled` | False | Loop hardening: periodic A,B,A,B cycle scan |
 | `SNAGLINE_LOOP_CYCLE_WINDOW_SIZE` | `loop_cycle_window_size` | 12 | Window scanned for cycles |
@@ -605,6 +613,7 @@ from snagline import Monitor, StepEvent, FailureRisk, Config, make_signature, wa
 | `snagline bench` | Overhead benchmark (us/step) |
 | `snagline serve --port 8787` | HTTP sidecar for non-Python agents |
 | `snagline watch --sink webhook --webhook-url URL` | Live stdin mode |
+| `snagline watch --follow --file events.jsonl --heartbeat /var/run/snagline/hb` | Tail a file and leave liveness evidence an external supervisor can watch |
 | `snagline hook --url URL` | Command bridge (always exits 0) |
 
 Every command handles errors gracefully. `snagline hook` always exits 0 (fail-open by construction). `snagline watch` skips malformed lines and reports a summary.
@@ -695,7 +704,8 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 - **Not on PyPI.** Install from a clone (see Quick Start).
 - **Overhead is measured, not asserted.** Run `snagline bench` to reproduce on your hardware.
 - **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline-agent[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.
-- **The latency anomaly detector requires warm-up.** It learns a baseline from `cusum_min_samples` (default 20) events before any alarm can fire. This prevents false positives on normal jitter but means the detector is blind during warm-up.
+- **The latency anomaly detector requires warm-up.** It learns a baseline from `cusum_min_samples` (default 5) events before any alarm can fire. This prevents false positives on normal jitter but means the detector is blind during warm-up; a calibrated `BaselineProfile` (issue #101) removes the blind spot for tools it describes. With `cusum_refit_every` set, the frozen baseline is periodically re-checked against a parallel learner, so drift in the baseline itself becomes visible instead of being learned away silently.
+- **Idle detection and the silence hole.** In-band detectors can never see a hung host: no events means no `observe()` calls, so a deadlocked tool or an OOM-stopped worker produces no signal at all. The opt-in time axis narrows this from inside (`idle_warn_seconds` fires one `idle_gap` risk when consecutive ingests drift too far apart, derived from event timestamps so replay stays deterministic), but only while events were flowing to snagline in the first place. For full coverage pair it with `snagline watch --heartbeat PATH` plus an external watcher (cron, systemd timer, k8s probe): the heartbeat file's mtime going stale is the externally detectable "host is silent" signal.
 - **Goal-drift without the drift extra is structural only.** The built-in detector compares per-tool error rate, latency, and tool-name sets. Semantic (embedding) drift needs `pip install snagline-agent[drift]` (sentence-transformers, issue #81) and a baseline fitted with `fit_semantic_baseline`; without it the semantic side stays inert, logged and fail-open.
 - **No automatic repair.** Detection and escalation only. Repair is a distinct, harder problem.
 - **Alert spam under sustained anomalies.** The loop and error-cascade detectors emit a risk on every step while the triggering condition holds. Wrap a sink in `DedupSink` to suppress repeats within a cooldown window ([#4](https://github.com/Cyrax321/SNAGLINE/issues/4)).

--- a/project.md
+++ b/project.md
@@ -526,7 +526,53 @@ All three horizon detectors are stdlib-only, O(1) amortized per step,
 implement `StatefulDetector`, and leave the zero-dependency preset (and
 its published bench numbers) unchanged.
 
-### 5.7 Config (`config.py`)
+### 5.7 Horizon-scale time axis (`monitor.py` + `detectors/windowing.py`, issue #92)
+
+Fixed step-count assumptions break on multi-day episodes where step rates
+vary by orders of magnitude between phases (an hour of tool grinding vs a
+long LLM call). The time axis adds wall-clock budgets, idle detection,
+window auto-scaling, and external liveness so silence itself becomes
+detectable. All of it is opt-in; with the options unset, behavior is
+byte-identical to the pre-#92 build (fingerprint-tested against every
+fixture trajectory).
+
+**Region contract.** Inter-event deltas are computed from
+`StepEvent.timestamp` at the TOP of `Monitor.ingest()` only, under the
+per-episode lock. Zero wall-clock reads in the hot path, so replay stays
+deterministic by construction. The sinks/policy tail of `ingest()` is
+owned by another feature area and is untouched.
+
+* **Wall-clock budget** (`max_episode_wall_seconds`, deterministic breach
+  risk at the limit): one warning risk at `warn_fraction` (default 0.8) of
+  the budget, scored 0.7 (severity "warning"), and a single critical breach
+  at 100%, scored 1.0. Trigger name for both: `wall_clock_budget`. Each
+  fires at most once per episode; a single delta that jumps straight past
+  the limit fires only the breach (mirrors the token-runaway envelope).
+* **Idle detection** (`idle_warn_seconds`): a gap of at least that many
+  seconds between consecutive ingests fires one `idle_gap` risk (score 0.8)
+  per episode. This is the in-band half of hang detection: a wedged host
+  stops ingesting, so the *absence* of deltas is the signal.
+* **Window auto-scaling** (`window_scale_steps > 0`, cap `max_window`):
+  window-based detectors (loop, cascade, meltdown, stagnation) grow their
+  effective window as `base * ceil(episode_len / window_scale_steps)`,
+  capped, refitted lazily keeping the most recent items. Below one scale
+  step, scaling on and off are exactly equivalent (property-tested).
+* **CUSUM baseline re-fit** (`cusum_refit_every > 0`): every N post-warm-up
+  samples the latency detector starts a parallel Welford learner while the
+  frozen baseline keeps scoring (coverage never pauses). When the learner
+  completes, a shift beyond the same `h * sigma` alarm bar surfaces as one
+  `latency_anomaly` risk, then the candidate is adopted and the CUSUM
+  restarts from zero. Drift in the baseline itself becomes visible.
+* **HeartbeatSink** (`sinks/heartbeat.py`; CLI `snagline watch --follow
+  --heartbeat PATH`): touches a liveness file's mtime on every ingest and
+  every idle follow-poll. ~five lines of stdlib; missing directory handled
+  fail-open; no content is ever written. In-band detectors can never see a
+  hung host: no events means no `observe()` calls. Only a clock or an
+  external watcher closes that hole; the watcher owns the alerting decision,
+  snagline just leaves evidence of life. Pairs with CONTINUUM#302's
+  run-level silence watchdog for non-CONTINUUM deployments.
+
+### 5.8 Config (`config.py`)
 
 ```python
 @dataclass
@@ -549,6 +595,13 @@ class Config:
     meltdown_low_entropy: float = 0.4
     meltdown_high_entropy: float = 2.8
     silent_abort_enabled: bool = False
+    # horizon-scale time axis (issue #92; all opt-in, defaults off)
+    max_episode_wall_seconds: float | None = None
+    warn_fraction: float = 0.8
+    idle_warn_seconds: float | None = None
+    window_scale_steps: int = 0
+    max_window: int = 512
+    cusum_refit_every: int = 0
 ```
 
 All thresholds tunable at `Monitor` construction; ship sensible defaults so

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -17,7 +17,7 @@ import json
 import os
 import sys
 import time
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import suppress
 from pathlib import Path
 
@@ -254,6 +254,14 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Suppress repeated alerts of the same key for this many seconds "
         "(issue #4). 0 disables (default).",
     )
+    p_watch.add_argument(
+        "--heartbeat",
+        metavar="PATH",
+        default=None,
+        help="Touch this file's mtime on every ingest (and on every idle "
+        "follow-poll) so an external supervisor can alert when it goes stale; "
+        "silence becomes detectable outside the event stream (issue #92).",
+    )
 
     p_serve = sub.add_parser(
         "serve",
@@ -449,8 +457,17 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _iter_lines(path: str | None, follow: bool) -> Iterator[str]:
-    """Yield lines from stdin, or from a file; with ``follow``, tail like -f."""
+def _iter_lines(
+    path: str | None,
+    follow: bool,
+    on_wait: Callable[[], None] | None = None,
+) -> Iterator[str]:
+    """Yield lines from stdin, or from a file; with ``follow``, tail like -f.
+
+    ``on_wait`` (issue #92) fires on every empty follow-poll so a heartbeat
+    can keep proving liveness while the watched file is silent. Failures are
+    the callback's own problem; this loop never inspects them.
+    """
     if path is None:
         yield from sys.stdin
         return
@@ -460,6 +477,8 @@ def _iter_lines(path: str | None, follow: bool) -> Iterator[str]:
             if line:
                 yield line
             elif follow:
+                if on_wait is not None:
+                    on_wait()
                 time.sleep(0.2)
             else:
                 return
@@ -480,11 +499,24 @@ def _cmd_watch(args: argparse.Namespace) -> int:
         # diverge from serve, which passes _build_sinks through untouched.
         sinks=sinks,
     )
+    # External liveness evidence (issue #92): touched per ingest and on every
+    # idle follow-poll so silence becomes externally detectable. Construction
+    # cannot fail; touch failures inside log once and never raise (fail-open).
+    heartbeat = None
+    if args.heartbeat:
+        from snagline.sinks.heartbeat import HeartbeatSink
+
+        heartbeat = HeartbeatSink(args.heartbeat)
+        heartbeat.touch()  # evidence of life from startup
     episode = args.episode_id or (args.file or "stdin")
     steps = 0
     try:
         with suppress(KeyboardInterrupt):
-            for line in _iter_lines(args.file, args.follow):
+            for line in _iter_lines(
+                args.file,
+                args.follow,
+                on_wait=heartbeat.touch if heartbeat is not None else None,
+            ):
                 line = line.strip()
                 if not line:
                     continue
@@ -499,6 +531,8 @@ def _cmd_watch(args: argparse.Namespace) -> int:
                     continue
                 monitor.ingest(event)
                 steps += 1
+                if heartbeat is not None:
+                    heartbeat.touch()
     finally:
         monitor.end_episode(episode)
     print(f"snagline watch: ingested {steps} step(s)", file=sys.stderr)

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -77,6 +77,41 @@ def _load_toml(text: str) -> dict[str, Any]:
 LOG_FORMATS: tuple[str, ...] = ("text", "json")
 
 
+def _validated_horizon(cfg: Config) -> None:
+    """Validate the horizon-scale knobs (issue #92); raise when invalid.
+
+    Mirrors the ``log_format`` precedent (issue #119): an out-of-range value is
+    a configuration error and fails loudly at construction/resolve time rather
+    than being silently ignored downstream. All knobs are opt-in (defaults off)
+    so validation only bites operators who turned the feature on.
+    """
+    if not 0.0 < cfg.warn_fraction <= 1.0:
+        raise ValueError(
+            f"warn_fraction must be within (0, 1]; got {cfg.warn_fraction!r}"
+        )
+    if cfg.max_episode_wall_seconds is not None and cfg.max_episode_wall_seconds <= 0:
+        raise ValueError(
+            "max_episode_wall_seconds must be positive when set; "
+            f"got {cfg.max_episode_wall_seconds!r}"
+        )
+    if cfg.idle_warn_seconds is not None and cfg.idle_warn_seconds <= 0:
+        raise ValueError(
+            f"idle_warn_seconds must be positive when set; got {cfg.idle_warn_seconds!r}"
+        )
+    if cfg.window_scale_steps < 0:
+        raise ValueError(
+            f"window_scale_steps must be >= 0 (0 disables scaling); "
+            f"got {cfg.window_scale_steps!r}"
+        )
+    if cfg.max_window < 1:
+        raise ValueError(f"max_window must be >= 1; got {cfg.max_window!r}")
+    if cfg.cusum_refit_every < 0:
+        raise ValueError(
+            f"cusum_refit_every must be >= 0 (0 disables refits); "
+            f"got {cfg.cusum_refit_every!r}"
+        )
+
+
 def _validated_log_format(value: str) -> str:
     """Normalize and validate a ``log_format`` value; raise when invalid.
 
@@ -317,11 +352,42 @@ class Config:
     # risk still reaches sinks/callback as usual but no halt round-trip happens.
     min_severity_for_halt: float = 0.8
 
+    # --- Horizon-scale time axis (issue #92, opt-in) -------------------------
+    # Fixed step-count assumptions break on multi-day episodes where step rates
+    # vary by orders of magnitude between phases. Every knob below defaults off
+    # and leaves behavior byte-identical when unset; all timing is derived from
+    # StepEvent.timestamp inside ingest(), never from the wall clock, so replay
+    # stays deterministic by construction.
+    #
+    # Wall-clock budget: one warning risk at warn_fraction of the budget and a
+    # single critical breach risk at the limit, each fired at most once per
+    # episode. Trigger name for both: "wall_clock_budget", scored 0.7 (keeps
+    # the pre-breach signal in the "warning" severity band) and 1.0.
+    max_episode_wall_seconds: float | None = None
+    warn_fraction: float = 0.8  # single warning risk before breach
+    # Idle detection: a gap of at least this many seconds between consecutive
+    # ingests (event timestamps again) fires one "idle_gap" risk per episode.
+    idle_warn_seconds: float | None = None
+    # Window auto-scaling for window-based detectors: the effective window grows
+    # as base * ceil(episode_len / window_scale_steps), capped at max_window,
+    # refitted lazily as it grows. 0 disables scaling entirely (the default).
+    window_scale_steps: int = 0
+    max_window: int = 512  # hard cap for scaled windows
+    # Latency CUSUM periodic baseline re-fit: every N post-warm-up samples the
+    # detector starts a fresh Welford learner while the frozen baseline keeps
+    # scoring; when the learner completes, its stats are compared against the
+    # frozen baseline and a sustained shift in the baseline itself emits one
+    # latency_anomaly risk before the new baseline is adopted. 0 disables.
+    cusum_refit_every: int = 0
+
     def __post_init__(self) -> None:
         # Issue #119: invalid closed-set values are configuration errors and
         # must fail loudly here instead of being silently ignored downstream.
         self.log_format = _validated_log_format(self.log_format)
         self.policy = validate_policy(self.policy)
+        # Issue #92: same policy for the horizon-scale knobs. All default off,
+        # so stock configurations never hit these checks.
+        _validated_horizon(self)
 
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
@@ -420,4 +486,7 @@ class Config:
         # a closed value set after env layering (issue #119).
         cfg.log_format = _validated_log_format(cfg.log_format)
         cfg.policy = validate_policy(cfg.policy)
+        # Same re-validation for the horizon-scale knobs set from env/file
+        # (issue #92): SNAGLINE_WARN_FRACTION=5 must fail loudly, not silently.
+        _validated_horizon(cfg)
         return cfg

--- a/src/snagline/detectors/error_cascade.py
+++ b/src/snagline/detectors/error_cascade.py
@@ -19,6 +19,7 @@ from collections import deque
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.windowing import next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -56,6 +57,11 @@ class ErrorCascadeDetector:
         )
         self._windows: dict[str, deque] = {}
         self._consecutive: dict[str, int] = {}
+        # Window auto-scaling (issue #92): inert unless cfg.window_scale_steps
+        # > 0; see detectors/windowing.py for the growth rule.
+        self._scale_steps = cfg.window_scale_steps
+        self._max_window = cfg.max_window
+        self._counts: dict[str, int] = {}
         # Dedupe: emit at most once per cascade, then stay quiet until the alarm
         # condition clears and re-arms (issue #4).
         self._fired: dict[str, bool] = {}
@@ -72,7 +78,14 @@ class ErrorCascadeDetector:
         # Only *counted* errors feed the cascade window; an LLM/chain error
         # (when excluded) is treated as a clean step so it cannot inflate the
         # cascade signal.
-        w = self._windows.setdefault(event.episode_id, deque(maxlen=self.window_size))
+        w = next_window(
+            self._windows,
+            self._counts,
+            event.episode_id,
+            self.window_size,
+            self._scale_steps,
+            self._max_window,
+        )
         w.append(counted)
         if counted:
             self._consecutive[event.episode_id] = (
@@ -119,12 +132,14 @@ class ErrorCascadeDetector:
 
     def reset(self, episode_id: str) -> None:
         self._windows.pop(episode_id, None)
+        self._counts.pop(episode_id, None)
         self._consecutive.pop(episode_id, None)
         self._fired.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
         return {
             "windows": {ep: list(w) for ep, w in self._windows.items()},
+            "counts": dict(self._counts),
             "consecutive": dict(self._consecutive),
             "fired": dict(self._fired),
         }
@@ -134,6 +149,8 @@ class ErrorCascadeDetector:
             ep: deque(flags, maxlen=self.window_size)
             for ep, flags in state.get("windows", {}).items()
         }
+        # Tolerant .get(): pre-#92 snapshots carry no scaler positions.
+        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
         self._consecutive = {
             ep: int(v) for ep, v in state.get("consecutive", {}).items()
         }

--- a/src/snagline/detectors/latency_anomaly.py
+++ b/src/snagline/detectors/latency_anomaly.py
@@ -61,6 +61,20 @@ class _WelfordCUSUM:
         self.mu0: float | None = None
         self.sigma0: float = 0.0
         self.frozen = False
+        # Periodic baseline re-fit state (issue #92). Inert unless the owning
+        # detector sets ``refit_every > 0``: after every ``refit_every`` scored
+        # samples a fresh Welford learner accumulates in parallel (the frozen
+        # baseline keeps scoring the whole time, so coverage never pauses);
+        # when the learner completes, its stats are compared against the
+        # frozen baseline and adopted.
+        self.refit_every = 0
+        self.since_refit = 0
+        self.learner_n = 0
+        self.learner_mean = 0.0
+        self._learner_m2 = 0.0
+        self.pending_drift = False
+        self.pending_shift = 0.0
+        self.pending_old_mu = 0.0
 
     def learn_only(self, x: float) -> None:
         """Welford update of the running baseline statistics (no CUSUM)."""
@@ -100,6 +114,36 @@ class _WelfordCUSUM:
         self.cusum = max(0.0, self.cusum + (x - self.mu0) / self.sigma0 - self.k)
         return self.cusum > self.h
 
+    def learn_candidate(self, x: float) -> None:
+        """Feed one sample into the parallel re-fit learner (issue #92)."""
+        self.learner_n += 1
+        delta = x - self.learner_mean
+        self.learner_mean += delta / self.learner_n
+        delta2 = x - self.learner_mean
+        self._learner_m2 += delta * delta2
+
+    def adopt_candidate(self) -> float:
+        """Adopt the learner's stats as the new frozen baseline (issue #92).
+
+        Floors the candidate spread exactly like ``freeze``/``seed``, zeroes
+        the CUSUM accumulator (stale accumulation must not leak across a
+        baseline change) and restarts the refit interval. Returns the OLD
+        baseline mean so callers can report the shift.
+        """
+        assert self.mu0 is not None
+        old_mu = self.mu0
+        var = self._learner_m2 / (self.learner_n - 1) if self.learner_n >= 2 else 0.0
+        std = math.sqrt(max(0.0, var))
+        new_mean = self.learner_mean
+        self.mu0 = new_mean
+        self.sigma0 = self._floored_sigma(new_mean, std)
+        self.cusum = 0.0
+        self.since_refit = 0
+        self.learner_n = 0
+        self.learner_mean = 0.0
+        self._learner_m2 = 0.0
+        return old_mu
+
 
 class LatencyAnomalyDetector:
     name = "latency_anomaly"
@@ -134,6 +178,8 @@ class LatencyAnomalyDetector:
         # per-tool stats only; no content is retained or consulted.
         self._baseline = baseline
         self._states: dict[tuple[str, str], _WelfordCUSUM] = {}
+        # Periodic baseline re-fit (issue #92); 0 disables (the default).
+        self.refit_every = cfg.cusum_refit_every
 
     def observe(self, event: StepEvent) -> FailureRisk | None:
         if event.latency_ms is None:
@@ -150,6 +196,7 @@ class LatencyAnomalyDetector:
             state = _WelfordCUSUM(
                 self.k, self.h, self.sigma_floor_abs, self.sigma_floor_rel
             )
+            state.refit_every = self.refit_every
             # Calibrated start (issue #101): when a healthy profile describes
             # this tool well enough, skip warm-up and freeze onto its stats.
             # Tools without a sufficient entry keep today's learn-then-freeze
@@ -169,7 +216,31 @@ class LatencyAnomalyDetector:
                 state.freeze()
             return None
 
-        if state.update(event.latency_ms):
+        alarm = state.update(event.latency_ms)
+        drift_risk: FailureRisk | None = None
+        if self.refit_every > 0:
+            shifted, old_mu, shift = self._advance_refit(state, event.latency_ms)
+            if shifted:
+                if alarm:
+                    # This step's CUSUM alarm owns the single-risk return
+                    # slot; hold the shift for the next quiet step.
+                    state.pending_drift = True
+                    state.pending_old_mu = old_mu
+                    state.pending_shift = shift
+                else:
+                    assert state.mu0 is not None
+                    state.pending_drift = False
+                    drift_risk = FailureRisk(
+                        event.episode_id,
+                        event.step_id,
+                        0.8,
+                        "latency_anomaly",
+                        f"latency baseline shifted {old_mu:.0f}ms -> "
+                        f"{state.mu0:.0f}ms ({shift:.0f}ms move, beyond the "
+                        f"{self.h}x-sigma alarm bar); baseline re-fitted",
+                        event.timestamp,
+                    )
+        if alarm:
             score = min(1.0, 0.6 + 0.1 * max(0.0, state.cusum / self.h - 1.0))
             return FailureRisk(
                 event.episode_id,
@@ -180,7 +251,44 @@ class LatencyAnomalyDetector:
                 f"(mean {state.mu0:.0f}ms)",
                 event.timestamp,
             )
-        return None
+        return drift_risk
+
+    def _advance_refit(
+        self, state: _WelfordCUSUM, x: float
+    ) -> tuple[bool, float, float]:
+        """Advance periodic baseline re-fit bookkeeping (issue #92).
+
+        Returns ``(shifted, old_mu, shift)``: ``shifted`` is True when the
+        frozen baseline itself moved beyond the same ``h * sigma`` alarm bar
+        the CUSUM uses, so "baseline drifted" is exactly as hard to claim as
+        "a step deviated". The candidate baseline is adopted either way once
+        measured -- keeping a stale baseline would fight reality -- and the
+        CUSUM accumulator restarts from zero against the new reference.
+
+        Coverage never pauses: the frozen baseline keeps scoring every sample
+        while the parallel Welford learner accumulates.
+        """
+        if not state.frozen or state.refit_every <= 0:
+            return False, 0.0, 0.0
+        # A shift detected earlier (its emission was deferred because a CUSUM
+        # alarm held the risk slot) surfaces on the first quiet step.
+        if state.pending_drift and state.learner_n == 0:
+            return True, state.pending_old_mu, state.pending_shift
+        state.since_refit += 1
+        if state.learner_n > 0 or state.since_refit >= state.refit_every:
+            state.learn_candidate(x)
+            if state.learner_n >= self.min_samples:
+                assert state.mu0 is not None
+                old_mu = state.mu0
+                shift = abs(state.learner_mean - old_mu)
+                bar = self.h * state.sigma0
+                state.adopt_candidate()
+                if shift > bar:
+                    state.pending_old_mu = old_mu
+                    state.pending_shift = shift
+                    state.pending_drift = True
+                    return True, old_mu, shift
+        return False, 0.0, 0.0
 
     def reset(self, episode_id: str) -> None:
         for key in [k for k in self._states if k[0] == episode_id]:
@@ -196,6 +304,19 @@ class LatencyAnomalyDetector:
             "mu0": s.mu0,
             "sigma0": s.sigma0,
             "frozen": s.frozen,
+            # Periodic re-fit state (issue #92); written only when active so
+            # default-config snapshots stay byte-identical to pre-#92 ones.
+            **(
+                {
+                    "refit_every": s.refit_every,
+                    "since_refit": s.since_refit,
+                    "learner_n": s.learner_n,
+                    "learner_mean": s.learner_mean,
+                    "learner_m2": s._learner_m2,
+                }
+                if s.refit_every > 0
+                else {}
+            ),
         }
 
     @classmethod
@@ -207,6 +328,14 @@ class LatencyAnomalyDetector:
         s.mu0 = raw["mu0"]
         s.sigma0 = raw["sigma0"]
         s.frozen = raw["frozen"]
+        # Tolerant .get(): pre-#92 snapshots carry no re-fit fields, and a
+        # detector configured without refits must accept one written with
+        # them (the knob is read from the live config, not the snapshot).
+        s.refit_every = int(raw.get("refit_every", 0) or 0)
+        s.since_refit = int(raw.get("since_refit", 0) or 0)
+        s.learner_n = int(raw.get("learner_n", 0) or 0)
+        s.learner_mean = float(raw.get("learner_mean", 0.0))
+        s._learner_m2 = float(raw.get("learner_m2", 0.0))
 
     def dump_state(self) -> dict[str, Any]:
         # Keys are (episode_id, tool_name) tuples; JSON dict keys must be
@@ -226,4 +355,7 @@ class LatencyAnomalyDetector:
                 self.k, self.h, self.sigma_floor_abs, self.sigma_floor_rel
             )
             self._state_from_dict(s, raw)
+            # The live config owns the refit cadence; the snapshot only
+            # carries accumulated bookkeeping.
+            s.refit_every = self.refit_every
             self._states[(ep, tool)] = s

--- a/src/snagline/detectors/loop.py
+++ b/src/snagline/detectors/loop.py
@@ -45,6 +45,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 from snagline.config import Config
+from snagline.detectors.windowing import next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk, TriggerType
 
@@ -122,6 +123,13 @@ class LoopDetector:
         self.loop_stall_enabled = cfg.loop_stall_enabled
         self.loop_stall_steps = cfg.loop_stall_steps
         self._normalize = normalizer or default_normalizer
+        # Window auto-scaling (issue #92): inert unless cfg.window_scale_steps
+        # > 0, in which case every window grows as base * ceil(len/steps),
+        # capped at max_window. Per-episode event counts feed the scale factor.
+        self._scale_steps = cfg.window_scale_steps
+        self._max_window = cfg.max_window
+        self._counts: dict[str, int] = {}
+        self._cycle_counts: dict[str, int] = {}
         self._any_mode = (
             self.loop_near_duplicate_enabled
             or self.loop_cycle_enabled
@@ -144,7 +152,14 @@ class LoopDetector:
         return plain if plain is not None else hardened
 
     def _observe_plain(self, event: StepEvent) -> FailureRisk | None:
-        w = self._windows.setdefault(event.episode_id, deque(maxlen=self.window_size))
+        w = next_window(
+            self._windows,
+            self._counts,
+            event.episode_id,
+            self.window_size,
+            self._scale_steps,
+            self._max_window,
+        )
         w.append(event.action_signature)
         count = w.count(event.action_signature)
         fired = self._fired.get(event.episode_id)
@@ -217,8 +232,13 @@ class LoopDetector:
 
     def _observe_near_duplicate(self, event: StepEvent) -> FailureRisk | None:
         key = _normalized_key(self._normalize, event.action_signature)
-        w = self._near_windows.setdefault(
-            event.episode_id, deque(maxlen=self.window_size)
+        w = next_window(
+            self._near_windows,
+            self._counts,
+            event.episode_id,
+            self.window_size,
+            self._scale_steps,
+            self._max_window,
         )
         w.append(key)
         count = w.count(key)
@@ -245,8 +265,13 @@ class LoopDetector:
         )
 
     def _observe_cycle(self, event: StepEvent) -> FailureRisk | None:
-        w = self._cycle_windows.setdefault(
-            event.episode_id, deque(maxlen=self.loop_cycle_window_size)
+        w = next_window(
+            self._cycle_windows,
+            self._cycle_counts,
+            event.episode_id,
+            self.loop_cycle_window_size,
+            self._scale_steps,
+            self._max_window,
         )
         w.append(event.action_signature)
         period = self._minimal_period(w)
@@ -322,10 +347,12 @@ class LoopDetector:
 
     def reset(self, episode_id: str) -> None:
         self._windows.pop(episode_id, None)
+        self._counts.pop(episode_id, None)
         self._fired.pop(episode_id, None)
         self._near_windows.pop(episode_id, None)
         self._near_fired.pop(episode_id, None)
         self._cycle_windows.pop(episode_id, None)
+        self._cycle_counts.pop(episode_id, None)
         self._cycle_fired.pop(episode_id, None)
         self._stall_sig.pop(episode_id, None)
         self._stall_count.pop(episode_id, None)
@@ -339,10 +366,12 @@ class LoopDetector:
         # silently reset an in-progress stall streak or cycle track.
         return {
             "windows": {ep: list(w) for ep, w in self._windows.items()},
+            "counts": dict(self._counts),
             "fired": {ep: sorted(sigs) for ep, sigs in self._fired.items()},
             "near_windows": {ep: list(w) for ep, w in self._near_windows.items()},
             "near_fired": {ep: sorted(sigs) for ep, sigs in self._near_fired.items()},
             "cycle_windows": {ep: list(w) for ep, w in self._cycle_windows.items()},
+            "cycle_counts": dict(self._cycle_counts),
             "cycle_fired": dict(self._cycle_fired),
             "stall_sig": dict(self._stall_sig),
             "stall_count": dict(self._stall_count),
@@ -355,6 +384,9 @@ class LoopDetector:
             ep: deque(sigs, maxlen=self.window_size)
             for ep, sigs in state.get("windows", {}).items()
         }
+        # Tolerant .get() so pre-#92 snapshots restore cleanly; the counts only
+        # position the auto-scaler and default to the window they imply.
+        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
         self._fired = {ep: set(sigs) for ep, sigs in state.get("fired", {}).items()}
         self._near_windows = {
             ep: deque(sigs, maxlen=self.window_size)
@@ -366,6 +398,9 @@ class LoopDetector:
         self._cycle_windows = {
             ep: deque(sigs, maxlen=self.loop_cycle_window_size)
             for ep, sigs in state.get("cycle_windows", {}).items()
+        }
+        self._cycle_counts = {
+            ep: int(n) for ep, n in state.get("cycle_counts", {}).items()
         }
         self._cycle_fired = dict(state.get("cycle_fired", {}))
         self._stall_sig = dict(state.get("stall_sig", {}))

--- a/src/snagline/detectors/loop.py
+++ b/src/snagline/detectors/loop.py
@@ -128,7 +128,12 @@ class LoopDetector:
         # capped at max_window. Per-episode event counts feed the scale factor.
         self._scale_steps = cfg.window_scale_steps
         self._max_window = cfg.max_window
+        # One event counter PER window family: observe() advances the plain
+        # and near-duplicate paths on the same event when hardening modes are
+        # on, so a shared counter would count each event twice and scale
+        # windows twice as fast (gitar review finding on PR #167).
         self._counts: dict[str, int] = {}
+        self._near_counts: dict[str, int] = {}
         self._cycle_counts: dict[str, int] = {}
         self._any_mode = (
             self.loop_near_duplicate_enabled
@@ -234,7 +239,7 @@ class LoopDetector:
         key = _normalized_key(self._normalize, event.action_signature)
         w = next_window(
             self._near_windows,
-            self._counts,
+            self._near_counts,
             event.episode_id,
             self.window_size,
             self._scale_steps,
@@ -350,6 +355,7 @@ class LoopDetector:
         self._counts.pop(episode_id, None)
         self._fired.pop(episode_id, None)
         self._near_windows.pop(episode_id, None)
+        self._near_counts.pop(episode_id, None)
         self._near_fired.pop(episode_id, None)
         self._cycle_windows.pop(episode_id, None)
         self._cycle_counts.pop(episode_id, None)
@@ -369,6 +375,7 @@ class LoopDetector:
             "counts": dict(self._counts),
             "fired": {ep: sorted(sigs) for ep, sigs in self._fired.items()},
             "near_windows": {ep: list(w) for ep, w in self._near_windows.items()},
+            "near_counts": dict(self._near_counts),
             "near_fired": {ep: sorted(sigs) for ep, sigs in self._near_fired.items()},
             "cycle_windows": {ep: list(w) for ep, w in self._cycle_windows.items()},
             "cycle_counts": dict(self._cycle_counts),
@@ -394,6 +401,9 @@ class LoopDetector:
         }
         self._near_fired = {
             ep: set(sigs) for ep, sigs in state.get("near_fired", {}).items()
+        }
+        self._near_counts = {
+            ep: int(n) for ep, n in state.get("near_counts", {}).items()
         }
         self._cycle_windows = {
             ep: deque(sigs, maxlen=self.loop_cycle_window_size)

--- a/src/snagline/detectors/meltdown.py
+++ b/src/snagline/detectors/meltdown.py
@@ -35,6 +35,7 @@ from collections import Counter, deque
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.windowing import effective_window_size
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -97,6 +98,12 @@ class MeltdownDetector:
         self._eps: dict[str, _EpisodeWindow] = {}
         self._fired: dict[str, bool] = {}
         self._clear_streak: dict[str, int] = {}
+        # Window auto-scaling (issue #92): inert unless cfg.window_scale_steps
+        # > 0; the effective size is recomputed per step and handed to push(),
+        # which retains more items as the cap grows.
+        self._scale_steps = cfg.window_scale_steps
+        self._max_window = cfg.max_window
+        self._counts: dict[str, int] = {}
 
     @staticmethod
     def _identity(event: StepEvent) -> str:
@@ -106,10 +113,15 @@ class MeltdownDetector:
         if event.action_type != "tool_call":
             return None
         ep = event.episode_id
+        n = self._counts.get(ep, 0) + 1
+        self._counts[ep] = n
+        target = effective_window_size(
+            self.window_size, n, self._scale_steps, self._max_window
+        )
         w = self._eps.setdefault(ep, _EpisodeWindow())
-        w.push(self._identity(event), self.window_size)
+        w.push(self._identity(event), target)
 
-        if len(w.window) < self.window_size:
+        if len(w.window) < target:
             return None
 
         h = w.entropy()
@@ -144,6 +156,7 @@ class MeltdownDetector:
 
     def reset(self, episode_id: str) -> None:
         self._eps.pop(episode_id, None)
+        self._counts.pop(episode_id, None)
         self._fired.pop(episode_id, None)
         self._clear_streak.pop(episode_id, None)
 
@@ -151,6 +164,7 @@ class MeltdownDetector:
         return {
             "window_size": self.window_size,
             "windows": {ep: list(w.window) for ep, w in self._eps.items()},
+            "counts": dict(self._counts),
             "fired": dict(self._fired),
             "clear_streak": dict(self._clear_streak),
         }
@@ -162,6 +176,8 @@ class MeltdownDetector:
             for key in keys:
                 w.push(key, self.window_size)
             self._eps[ep] = w
+        # Tolerant .get(): pre-#92 snapshots carry no scaler positions.
+        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
         self._fired = {ep: bool(v) for ep, v in state.get("fired", {}).items()}
         self._clear_streak = {
             ep: int(v) for ep, v in state.get("clear_streak", {}).items()

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -46,6 +46,7 @@ from collections import deque
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.windowing import effective_window_size
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -99,33 +100,41 @@ class StagnationDetector:
         if self.patience < 1:
             raise ValueError("patience must be >= 1")
         self._windows: dict[str, _EpisodeWindow] = {}
+        # Window auto-scaling (issue #92): inert unless cfg.window_scale_steps
+        # > 0; the novelty window grows toward max_window on long episodes.
+        self._scale_steps = cfg.window_scale_steps
+        self._max_window = cfg.max_window
+        self._counts: dict[str, int] = {}
 
     def observe(self, event: StepEvent) -> FailureRisk | None:
         w = self._windows.setdefault(event.episode_id, _EpisodeWindow())
+        n = self._counts.get(event.episode_id, 0) + 1
+        self._counts[event.episode_id] = n
+        target = effective_window_size(
+            self.window_size, n, self._scale_steps, self._max_window
+        )
         sig = event.action_signature
         novel = sig not in w.seen_all_time
         w.seen_all_time.add(sig)
-        if len(w.flags) == self.window_size and w.flags.popleft():
+        if len(w.flags) >= target and w.flags.popleft():
             w.novel_in_window -= 1
         w.flags.append(novel)
         if novel:
             w.novel_in_window += 1
 
-        if len(w.flags) == self.window_size and (
-            w.novel_in_window / self.window_size < self.min_novelty
-        ):
+        if len(w.flags) >= target and (w.novel_in_window / target < self.min_novelty):
             w.stale_windows += 1
             # Escalate exactly when patience is first reached. Continuing past
             # it must not re-fire (one finding per collapse), and any fresh
             # observation resets ``stale_windows`` below, re-arming us.
             if w.stale_windows == self.patience:
-                rate = w.novel_in_window / self.window_size
+                rate = w.novel_in_window / target
                 return FailureRisk(
                     event.episode_id,
                     event.step_id,
                     0.6,
                     "stagnation",
-                    f"{rate:.0%} new actions in last {self.window_size} steps, "
+                    f"{rate:.0%} new actions in last {target} steps, "
                     f"below {self.min_novelty:.0%} for {self.patience} "
                     "consecutive windows",
                     event.timestamp,
@@ -137,6 +146,7 @@ class StagnationDetector:
     def reset(self, episode_id: str) -> None:
         """Drop the window, the stale counter, and the monotonic seen-set."""
         self._windows.pop(episode_id, None)
+        self._counts.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
         """Serialize per-episode windows for ``Monitor.snapshot`` (#91/#149).
@@ -144,7 +154,9 @@ class StagnationDetector:
         JSON-compatible throughout: the novelty ``flags`` deque becomes a plain
         list of booleans and ``seen_all_time`` is sorted so snapshots are
         deterministic; ``load_state`` rebuilds the set from the sorted list
-        (raw sets are not JSON-serializable).
+        (raw sets are not JSON-serializable). The auto-scaler position
+        (``counts``, issue #92) rides along so a restored episode keeps its
+        scaling cadence.
         """
         return {
             "windows": {
@@ -155,7 +167,9 @@ class StagnationDetector:
                     "seen_all_time": sorted(w.seen_all_time),
                 }
                 for ep, w in self._windows.items()
-            }
+            },
+            # Tolerant readers on load: pre-#92 payloads carry no counts.
+            "counts": dict(self._counts),
         }
 
     def load_state(self, state: dict[str, Any]) -> None:
@@ -168,10 +182,20 @@ class StagnationDetector:
             # based eviction never fires again. Mirrors LoopDetector's
             # deque(sigs, maxlen=self.window_size) rebuild; the sliding
             # counter is recomputed from the truncated flags so the two stay
-            # consistent.
+            # consistent. With auto-scaling enabled (issue #92) the deque is
+            # deliberately UNCAPPED: observe() trims at the current effective
+            # target every step, and a base-sized maxlen would silently drop
+            # flags and blind the detector once the target grows past it.
             flags = [bool(b) for b in raw.get("flags", [])][-self.window_size :]
-            w.flags = deque(flags, maxlen=self.window_size)
+            w.flags = deque(
+                flags,
+                maxlen=self.window_size if self._scale_steps <= 0 else None,
+            )
             w.novel_in_window = sum(flags)
             w.stale_windows = int(raw.get("stale_windows", 0))
             w.seen_all_time = set(raw.get("seen_all_time", []))
             self._windows[str(ep)] = w
+        self._counts = {
+            ep: int(n)
+            for ep, n in state.get("counts", {}).items()
+        }

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -195,7 +195,4 @@ class StagnationDetector:
             w.stale_windows = int(raw.get("stale_windows", 0))
             w.seen_all_time = set(raw.get("seen_all_time", []))
             self._windows[str(ep)] = w
-        self._counts = {
-            ep: int(n)
-            for ep, n in state.get("counts", {}).items()
-        }
+        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}

--- a/src/snagline/detectors/windowing.py
+++ b/src/snagline/detectors/windowing.py
@@ -1,0 +1,68 @@
+"""Window auto-scaling shared by window-based detectors (issue #92).
+
+Fixed windows tuned for interactive runs (``loop_window_size=12``) mean
+nothing across a 500k-step week-long episode: they either fire constantly or
+are gone in the first minute of noise. When ``Config.window_scale_steps`` is
+set (> 0), each detector's effective window grows as
+
+    base * ceil(episode_len / window_scale_steps)
+
+capped at ``Config.max_window``, and is refitted lazily: growing a deque keeps
+its most recent items, so no per-step reprocessing ever happens.
+
+Defaults preserve current behavior exactly: with ``window_scale_steps == 0``
+the effective size is always ``base`` and every resize call below is a no-op.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+
+
+def effective_window_size(
+    base: int, episode_len: int, scale_steps: int, max_window: int
+) -> int:
+    """Scaled window length for an episode of ``episode_len`` observed events.
+
+    Monotonically non-decreasing in ``episode_len``, always within
+    ``[base, max_window]``. With ``scale_steps <= 0`` (scaling disabled) this
+    is exactly ``base`` for every input, which is what keeps the default
+    configuration byte-identical to pre-#92 behavior.
+    """
+    if scale_steps <= 0 or episode_len <= 1:
+        return base
+    # Integer ceiling division: ceil(episode_len / scale_steps).
+    factor = -(-episode_len // scale_steps)
+    # The cap never pulls the window below its base: a detector configured
+    # with base > max_window keeps its base rather than shrinking.
+    return min(max(base * factor, base), max(max_window, base))
+
+
+def next_window(
+    windows: dict[str, deque],
+    counts: dict[str, int],
+    episode_id: str,
+    base: int,
+    scale_steps: int,
+    max_window: int,
+) -> deque:
+    """Return the episode's window, resized lazily when scaling demands it.
+
+    Encapsulates the ``dict[str, deque]`` bookkeeping several detectors share:
+    counts the episode's observed events, computes the effective size, and
+    swaps in a larger deque (keeping the most recent items) only when the
+    target actually changed. Replacement (rather than in-place append) is safe
+    because callers fetch the window fresh from the dict on every observe().
+    """
+    n = counts.get(episode_id, 0) + 1
+    counts[episode_id] = n
+    w = windows.get(episode_id)
+    if w is None:
+        w = deque(maxlen=base)
+        windows[episode_id] = w
+        return w
+    target = effective_window_size(base, n, scale_steps, max_window)
+    if w.maxlen != target:
+        w = deque(w, maxlen=target)
+        windows[episode_id] = w
+    return w

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -83,6 +83,24 @@ class HaltDirective:
     timestamp: float = 0.0
 
 
+class _EpisodeClock:
+    """Per-episode time-axis state (issue #92).
+
+    Every field derives ONLY from ``StepEvent.timestamp`` values seen in
+    ``ingest()`` -- no wall-clock reads anywhere, so replaying a trajectory
+    reproduces identical risks. One instance per active episode.
+    """
+
+    __slots__ = ("last_ts", "elapsed", "idle_fired", "warned", "breached")
+
+    def __init__(self, first_ts: float) -> None:
+        self.last_ts = first_ts
+        self.elapsed = 0.0  # sum of positive inter-event deltas
+        self.idle_fired = False  # "idle_gap" fires once per episode
+        self.warned = False  # budget warning fires once per episode
+        self.breached = False  # budget breach fires once per episode
+
+
 def _detector_key(index: int, detector: Any) -> str:
     """Stable per-position key for a detector inside a snapshot payload."""
     return f"{index}:{getattr(detector, 'name', type(detector).__name__)}"
@@ -182,11 +200,20 @@ class Monitor:
         halt_url: str | None = None,
         halt_timeout_s: float = 0.25,
         min_severity_for_halt: float = 0.8,
+        config: Config | None = None,
     ) -> None:
         self._detectors = list(detectors)
         self._sinks = list(sinks)
         self._fail_open = fail_open
         self._state = state_backend or default_state_backend()
+        # Horizon-scale time axis (issue #92). Inert unless one of the opt-in
+        # horizon knobs is set on the config; all state lives in ``_clocks``,
+        # keyed by episode, derived purely from event timestamps.
+        cfg = config or Config()
+        self._max_wall_seconds = cfg.max_episode_wall_seconds
+        self._warn_fraction = cfg.warn_fraction
+        self._idle_warn_seconds = cfg.idle_warn_seconds
+        self._clocks: dict[str, _EpisodeClock] = {}
         # A faulty detector or sink must not spam the logs on every single step
         # (issue #14) -- log each distinct fault exactly once.
         self._fault_lock = threading.Lock()
@@ -281,9 +308,18 @@ class Monitor:
         webhook sink) must not block concurrent ``ingest`` calls, and a sink
         that re-enters ``ingest`` must not deadlock. The enforcement policy
         runs after the sinks, also outside the lock (issue #93).
+
+        Region contract (issue #92): the time-axis head below is the ONLY place
+        that touches event timestamps for idle/budget decisions, and it reads no
+        wall clock, so replay stays deterministic. The dispatch tail belongs to
+        the sinks/policy layer and is left untouched by time-axis logic.
         """
         risks: list[FailureRisk] = []
         with self._state.episode_lock(event.episode_id):
+            # Time-axis head (issue #92): computed from StepEvent timestamps at
+            # the top of ingest(), under the episode lock so concurrent ingests
+            # serialize exactly like detector state does.
+            risks.extend(self._advance_clock(event))
             for detector in self._detectors:
                 try:
                     risk = detector.observe(event)
@@ -303,6 +339,90 @@ class Monitor:
             self._metrics.risks_emitted += len(risks)
         for risk in risks:
             self._dispatch(risk)
+
+    def _advance_clock(self, event: StepEvent) -> list[FailureRisk]:
+        """Time-axis risks from StepEvent timestamps alone (issue #92).
+
+        Fail-open like every other monitoring step: an internal error is logged
+        fault-once and never propagates. Emits at most once per episode per
+        threshold:
+
+        * ``idle_gap`` (score 0.8) when a gap between consecutive ingests
+          reaches ``idle_warn_seconds``;
+        * ``wall_clock_budget`` warning (score 0.8) at ``warn_fraction`` of
+          ``max_episode_wall_seconds``, then a breach (score 1.0) at the limit;
+          a single delta that jumps straight past the limit fires only the
+          breach (mirrors TokenRunawayDetector's envelope ordering).
+        """
+        out: list[FailureRisk] = []
+        try:
+            clock = self._clocks.get(event.episode_id)
+            if clock is None:
+                # First event of the episode establishes the reference point;
+                # there is no delta yet, so nothing can fire.
+                self._clocks[event.episode_id] = _EpisodeClock(event.timestamp)
+                return out
+            delta = event.timestamp - clock.last_ts
+            clock.last_ts = event.timestamp
+            if (
+                self._idle_warn_seconds is not None
+                and not clock.idle_fired
+                and delta >= self._idle_warn_seconds
+            ):
+                clock.idle_fired = True
+                out.append(
+                    FailureRisk(
+                        event.episode_id,
+                        event.step_id,
+                        0.8,
+                        "idle_gap",
+                        f"no events for {delta:.1f}s "
+                        f"(threshold {self._idle_warn_seconds:.1f}s)",
+                        event.timestamp,
+                    )
+                )
+            if delta > 0.0:
+                # Negative deltas (out-of-order or skewed sources) must not
+                # reduce consumed budget; clamp them out of the accumulation.
+                clock.elapsed += delta
+            budget = self._max_wall_seconds
+            if budget is not None:
+                if not clock.breached and clock.elapsed >= budget:
+                    clock.breached = True
+                    out.append(
+                        FailureRisk(
+                            event.episode_id,
+                            event.step_id,
+                            1.0,
+                            "wall_clock_budget",
+                            f"episode exceeded its {budget:.0f}s wall-clock "
+                            f"budget ({clock.elapsed:.0f}s observed)",
+                            event.timestamp,
+                        )
+                    )
+                elif not clock.warned and clock.elapsed >= budget * self._warn_fraction:
+                    clock.warned = True
+                    out.append(
+                        FailureRisk(
+                            event.episode_id,
+                            event.step_id,
+                            # 0.7 keeps the pre-breach signal inside the
+                            # "warning" severity band (>= 0.8 derives
+                            # critical); the breach below is the critical.
+                            0.7,
+                            "wall_clock_budget",
+                            f"episode at {clock.elapsed / budget:.0%} of its "
+                            f"{budget:.0f}s wall-clock budget",
+                            event.timestamp,
+                        )
+                    )
+        except Exception as exc:
+            self._log_fault_once(
+                f"time-axis tracking raised ({exc}); ignoring (fail-open)"
+            )
+            if not self._fail_open:
+                raise
+        return out
 
     def _dispatch(self, risk: FailureRisk) -> None:
         for sink in self._sinks:
@@ -475,6 +595,9 @@ class Monitor:
         """
         finalized: list[FailureRisk] = []
         with self._state.episode_lock(episode_id):
+            # Time-axis state (issue #92) is per-episode like detector state;
+            # drop it here so a reused episode id starts with a clean clock.
+            self._clocks.pop(episode_id, None)
             for detector in self._detectors:
                 finalize = getattr(detector, "finalize", None)
                 if callable(finalize):
@@ -781,4 +904,10 @@ class Monitor:
             halt_timeout_s=cfg.halt_timeout_s,
             min_severity_for_halt=cfg.min_severity_for_halt,
         )
+        # Horizon-scale time axis (issue #92): the same resolved config drives
+        # idle-gap and wall-clock-budget tracking. Assigned post-construction
+        # like _state so subclasses with a fixed __init__ signature keep working.
+        monitor._max_wall_seconds = cfg.max_episode_wall_seconds
+        monitor._warn_fraction = cfg.warn_fraction
+        monitor._idle_warn_seconds = cfg.idle_warn_seconds
         return monitor

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -349,7 +349,8 @@ class Monitor:
 
         * ``idle_gap`` (score 0.8) when a gap between consecutive ingests
           reaches ``idle_warn_seconds``;
-        * ``wall_clock_budget`` warning (score 0.8) at ``warn_fraction`` of
+        * ``wall_clock_budget`` warning (score 0.7, keeping it inside the
+          "warning" severity band) at ``warn_fraction`` of
           ``max_episode_wall_seconds``, then a breach (score 1.0) at the limit;
           a single delta that jumps straight past the limit fires only the
           breach (mirrors TokenRunawayDetector's envelope ordering).

--- a/src/snagline/risk.py
+++ b/src/snagline/risk.py
@@ -27,6 +27,13 @@ TriggerType = Literal[
     # adapter-defined action types "compaction" / "constraint_present"; see
     # detectors/compaction_tripwire.py for the contract.
     "governance_decay",
+    # Horizon-scale time axis (issue #92). Derived by the Monitor from
+    # StepEvent timestamps at the top of ingest() -- never from the wall
+    # clock, so replay stays deterministic. "idle_gap" marks a silence
+    # between consecutive ingests; "wall_clock_budget" covers both the
+    # single pre-breach warning (score 0.8) and the breach itself (1.0).
+    "idle_gap",
+    "wall_clock_budget",
 ]
 
 # Severity ordering is informational only; sinks decide what to do with it.

--- a/src/snagline/sinks/heartbeat.py
+++ b/src/snagline/sinks/heartbeat.py
@@ -1,0 +1,69 @@
+"""External liveness evidence (issue #92).
+
+In-band detectors can never see a hung host: no events means no ``observe()``
+calls, so silence itself is invisible to anything living inside the event
+stream. The heartbeat closes that hole from the outside: it touches a
+liveness file's mtime on every ingest, and any external supervisor (cron,
+systemd timer, k8s probe, CONTINUUM's sidecar) alerts when the mtime goes
+stale. The watcher owns the alerting decision; snagline just leaves evidence
+of life.
+
+Stdlib only (~five lines of effect), zero new failure surface: every touch is
+guarded so a missing directory or an unwritable path logs once and never
+raises into the host (project.md §1.2). No content is ever written -- the
+file carries nothing but its own mtime.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from snagline.risk import FailureRisk
+
+logger = logging.getLogger("snagline")
+
+
+class HeartbeatSink:
+    """Touch a liveness file's mtime so silence becomes externally detectable.
+
+    Driven per-ingest by the CLI (``snagline watch --heartbeat PATH``) because
+    "no risks" is exactly the signal: wiring it as a passive AlertSink would
+    only prove that alarms flow, not that the host is alive. ``emit`` touches
+    anyway, so the object may also sit in a sinks list without harm.
+    """
+
+    def __init__(self, path: str) -> None:
+        self._path = path
+        self._fault_logged = False
+
+    def touch(self) -> None:
+        """Best-effort mtime bump; fail-open, logged once until it recovers."""
+        try:
+            try:
+                # Fast path: the file exists (two syscalls, no content).
+                os.utime(self._path, None)
+            except FileNotFoundError:
+                # Missing file or directory: create parents once, create the
+                # file, stamp it. Handled fail-open like every other branch.
+                parent = os.path.dirname(self._path) or "."
+                os.makedirs(parent, exist_ok=True)
+                fd = os.open(self._path, os.O_WRONLY | os.O_CREAT, 0o644)
+                os.close(fd)
+                os.utime(self._path, None)
+            self._fault_logged = False
+        except OSError as exc:
+            # Unwritable path, read-only filesystem, whatever: never raise
+            # into the host agent, just say so once (issue #14 style).
+            if not self._fault_logged:
+                self._fault_logged = True
+                logger.warning(
+                    "snagline: heartbeat %s unavailable (%s); continuing "
+                    "without liveness evidence",
+                    self._path,
+                    exc,
+                )
+
+    def emit(self, risk: FailureRisk) -> None:
+        """AlertSink compatibility: a risk flowing is also evidence of life."""
+        self.touch()

--- a/tests/sinks/test_heartbeat.py
+++ b/tests/sinks/test_heartbeat.py
@@ -1,0 +1,58 @@
+"""HeartbeatSink: external liveness evidence (issue #92).
+
+Properties under test: the liveness file is created on first touch and its
+mtime advances on every later touch; a missing directory is handled fail-open;
+an unwritable path never raises into the host (logged once instead).
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from snagline.sinks.heartbeat import HeartbeatSink
+
+
+def test_touch_creates_file_then_advances_mtime(tmp_path) -> None:
+    hb_path = tmp_path / "hb"
+    hb = HeartbeatSink(str(hb_path))
+    hb.touch()
+    assert hb_path.exists()
+    first = os.stat(hb_path).st_mtime_ns
+    time.sleep(0.01)
+    hb.touch()
+    second = os.stat(hb_path).st_mtime_ns
+    assert second > first
+
+
+def test_missing_directory_created_fail_open(tmp_path) -> None:
+    nested = tmp_path / "var" / "run" / "snagline" / "hb"
+    hb = HeartbeatSink(str(nested))
+    hb.touch()  # must not raise
+    assert nested.exists()
+
+
+def test_unwritable_path_never_raises(tmp_path) -> None:
+    # A directory where the file should be: every touch fails at the OS level.
+    blocker = tmp_path / "blocker"
+    blocker.mkdir()
+    hb = HeartbeatSink(str(blocker))
+    for _ in range(3):
+        hb.touch()  # logged once, swallowed forever; never raises
+
+
+def test_emit_is_also_a_touch(tmp_path) -> None:
+    hb_path = tmp_path / "hb"
+    hb = HeartbeatSink(str(hb_path))
+
+    class _Risk:
+        pass
+
+    hb.emit(_Risk())  # AlertSink duck type; content never inspected
+    assert hb_path.exists()
+
+
+def test_no_content_ever_written(tmp_path) -> None:
+    hb_path = tmp_path / "hb"
+    HeartbeatSink(str(hb_path)).touch()
+    assert hb_path.read_bytes() == b""

--- a/tests/test_horizon_time_axis.py
+++ b/tests/test_horizon_time_axis.py
@@ -1,0 +1,247 @@
+"""Time-axis awareness at the top of Monitor.ingest (issue #92).
+
+Property under test: every idle-gap and wall-clock-budget decision is derived
+ONLY from StepEvent timestamps, computed at the top of ingest(), fires at most
+once per episode per threshold, and disappears entirely when the new config
+options are unset -- replaying an old trajectory must produce byte-identical
+results to the pre-#92 build.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+
+from snagline.config import Config
+from snagline.events import StepEvent
+from snagline.monitor import Monitor
+from snagline.risk import FailureRisk
+
+
+class CapturingSink:
+    """Records every dispatched risk; nothing else."""
+
+    def __init__(self) -> None:
+        self.risks: list[FailureRisk] = []
+
+    def emit(self, risk: FailureRisk) -> None:
+        self.risks.append(risk)
+
+
+def _event(
+    step_id: str,
+    timestamp: float,
+    episode_id: str = "ep1",
+    latency_ms: float | None = None,
+) -> StepEvent:
+    return StepEvent(
+        step_id=step_id,
+        episode_id=episode_id,
+        timestamp=timestamp,
+        action_type="tool_call",
+        action_signature=f"sig-{step_id}",
+        tool_name="t",
+        latency_ms=latency_ms,
+    )
+
+
+def _monitor(sink: CapturingSink, **cfg_kwargs) -> Monitor:
+    cfg = Config(**cfg_kwargs)
+    return Monitor([], [sink], config=cfg)
+
+
+def _feed(monitor: Monitor, *events: StepEvent, end: bool = False) -> None:
+    for e in events:
+        monitor.ingest(e)
+    if end:
+        monitor.end_episode(events[-1].episode_id if events else "ep1")
+
+
+# --- idle_gap ---------------------------------------------------------------
+
+
+def test_idle_gap_fires_once_per_episode() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, idle_warn_seconds=10.0)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 5.0),  # gap 5s: quiet
+        _event("s3", 20.0),  # gap 15s: fire once
+        _event("s4", 40.0),  # gap 20s: already fired, stays quiet
+    )
+    idle = [r for r in sink.risks if r.trigger == "idle_gap"]
+    assert len(idle) == 1
+    assert idle[0].step_id == "s3"
+    assert idle[0].score == 0.8
+
+
+def test_idle_gap_disabled_by_default_and_small_gaps_quiet() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink)
+    _feed(m, _event("s1", 0.0), _event("s2", 99999.0))
+    assert sink.risks == []
+    sink2 = CapturingSink()
+    m2 = _monitor(sink2, idle_warn_seconds=100.0)
+    _feed(m2, _event("s1", 0.0), _event("s2", 99.9))
+    assert [r for r in sink2.risks if r.trigger == "idle_gap"] == []
+
+
+def test_idle_gap_resets_with_episode() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, idle_warn_seconds=10.0)
+    _feed(m, _event("s1", 0.0), _event("s2", 50.0), end=True)
+    assert len([r for r in sink.risks if r.trigger == "idle_gap"]) == 1
+    # Same episode id reused after end_episode: a fresh clock, so a later
+    # silence can fire again.
+    _feed(m, _event("s3", 100.0), _event("s4", 200.0))
+    assert len([r for r in sink.risks if r.trigger == "idle_gap"]) == 2
+
+
+def test_first_event_never_fires_idle_or_budget() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, idle_warn_seconds=0.001, max_episode_wall_seconds=0.001)
+    _feed(m, _event("s1", 0.0))
+    assert sink.risks == []
+
+
+# --- wall_clock_budget ------------------------------------------------------
+
+
+def test_budget_warn_then_breach_each_fire_once() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=100.0, warn_fraction=0.8)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 30.0),  # elapsed 30 < 80: quiet
+        _event("s3", 85.0),  # elapsed 85 >= 80: warn
+        _event("s4", 90.0),  # elapsed 90: still warned, no re-fire
+        _event("s5", 120.0),  # elapsed 120 >= 100: breach
+        _event("s6", 500.0),  # already breached, no re-fire
+    )
+    budget = [r for r in sink.risks if r.trigger == "wall_clock_budget"]
+    assert [(r.step_id, r.score) for r in budget] == [("s3", 0.7), ("s5", 1.0)]
+    assert budget[0].severity == "warning"
+    assert budget[1].severity == "critical"
+
+
+def test_single_jump_past_budget_fires_only_breach() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=10.0, warn_fraction=0.8)
+    _feed(m, _event("s1", 0.0), _event("s2", 1000.0))
+    budget = [r for r in sink.risks if r.trigger == "wall_clock_budget"]
+    assert [(r.step_id, r.score) for r in budget] == [("s2", 1.0)]
+
+
+def test_negative_delta_does_not_refund_budget() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=10.0)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 12.0),  # breach
+        _event("s3", 1.0),  # skewed backwards: must not un-breach
+        _event("s4", 30.0),
+    )
+    breaches = [
+        r for r in sink.risks if r.trigger == "wall_clock_budget" and r.score == 1.0
+    ]
+    assert len(breaches) == 1
+
+
+# --- determinism / fail-open / region contract ------------------------------
+
+
+def test_no_wall_clock_reads_in_ingest(monkeypatch: object) -> None:
+    """ZERO time.time() reads during ingest: replay stays deterministic."""
+    import time as time_module
+
+    def _explode() -> float:
+        raise AssertionError("wall clock read during ingest")
+
+    monkeypatch.setattr(time_module, "time", _explode)  # type: ignore[attr-defined]
+    sink = CapturingSink()
+    m = _monitor(sink, idle_warn_seconds=1.0, max_episode_wall_seconds=2.0)
+    # Timestamps come from the events only; the frozen wall clock is never read.
+    _feed(m, _event("s1", 0.0), _event("s2", 5.0))
+
+
+def test_replay_fingerprints_unchanged_when_options_unset() -> None:
+    """Old trajectories produce identical results with new options unset.
+
+    The expected fingerprints were captured on the pre-#92 build; any change
+    in default-config behavior fails here.
+    """
+    expected = {
+        "healthy_run.jsonl": [],
+        "injected_error_cascade.jsonl": [("error_cascade", "22", 1.0)],
+        "injected_governance_decay.jsonl": [("loop", "4", 0.5)],
+        "injected_latency_spike.jsonl": [
+            ("latency_anomaly", str(i), 1.0) for i in range(40, 52)
+        ],
+        "injected_loop.jsonl": [("loop", "22", 0.5)],
+    }
+    for path in sorted(glob.glob("tests/fixtures/trajectories/*.jsonl")):
+        name = path.rsplit("/", 1)[-1]
+        sink = CapturingSink()
+        monitor = Monitor.default(config=Config(), sinks=[sink])
+        episode = None
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                event = StepEvent(**json.loads(line))
+                episode = event.episode_id
+                monitor.ingest(event)
+        monitor.end_episode(episode)
+        got = [(r.trigger, r.step_id, round(r.score, 4)) for r in sink.risks]
+        assert got == expected[name], f"fingerprint changed for {name}"
+
+
+def test_time_axis_fail_open_on_pathological_timestamps(caplog) -> None:
+    """NaN timestamps must not crash ingest; fault logged once, never raised."""
+    sink = CapturingSink()
+    m = _monitor(sink, idle_warn_seconds=1.0)
+    nan = float("nan")
+    with caplog.at_level(logging.DEBUG, logger="snagline"):
+        _feed(m, _event("s1", 0.0), _event("s2", nan), _event("s3", nan))
+    assert True  # reaching here IS the assertion: nothing propagated
+
+
+def test_horizon_risks_counted_in_metrics() -> None:
+    sink = CapturingSink()
+    m = _monitor(sink, idle_warn_seconds=1.0)
+    _feed(m, _event("s1", 0.0), _event("s2", 9.0))
+    metrics = m.metrics()
+    assert metrics["risks_emitted"] == 1
+    assert metrics["events_ingested"] == 2
+
+
+def test_horizon_knobs_reach_monitor_via_default(monkeypatch) -> None:
+    """Monitor.default wires SNAGLINE_* env through to the time axis."""
+    env = {"SNAGLINE_IDLE_WARN_SECONDS": "5"}
+    monkeypatch.setenv("SNAGLINE_IDLE_WARN_SECONDS", "5")
+    cfg = Config.resolve(environ=env)
+    assert cfg.idle_warn_seconds == 5.0
+
+
+def test_invalid_horizon_config_fails_loudly() -> None:
+    import pytest
+
+    with pytest.raises(ValueError):
+        Config(warn_fraction=0.0)
+    with pytest.raises(ValueError):
+        Config(warn_fraction=1.5)
+    with pytest.raises(ValueError):
+        Config(max_episode_wall_seconds=-1.0)
+    with pytest.raises(ValueError):
+        Config(idle_warn_seconds=0.0)
+    with pytest.raises(ValueError):
+        Config(window_scale_steps=-1)
+    with pytest.raises(ValueError):
+        Config(max_window=0)
+    with pytest.raises(ValueError):
+        Config(cusum_refit_every=-1)

--- a/tests/test_horizon_time_axis.py
+++ b/tests/test_horizon_time_axis.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import glob
 import json
 import logging
+import os
 
 from snagline.config import Config
 from snagline.events import StepEvent
@@ -184,7 +185,7 @@ def test_replay_fingerprints_unchanged_when_options_unset() -> None:
         "injected_loop.jsonl": [("loop", "22", 0.5)],
     }
     for path in sorted(glob.glob("tests/fixtures/trajectories/*.jsonl")):
-        name = path.rsplit("/", 1)[-1]
+        name = os.path.basename(path)
         sink = CapturingSink()
         monitor = Monitor.default(config=Config(), sinks=[sink])
         episode = None

--- a/tests/test_no_extras_import.py
+++ b/tests/test_no_extras_import.py
@@ -1,0 +1,51 @@
+"""No-extras import smoke check (project.md §1.1, issue #92 gate).
+
+Bare ``import snagline`` and every module touched by a change must import on
+a stdlib-only interpreter: no numpy, no sentence-transformers, nothing. The
+optional extras stay behind lazy, guarded imports inside functions.
+"""
+
+from __future__ import annotations
+
+import importlib
+import subprocess
+import sys
+
+NEW_OR_TOUCHED_MODULES = (
+    "snagline",
+    "snagline.cli",
+    "snagline.config",
+    "snagline.monitor",
+    "snagline.risk",
+    "snagline.sinks.heartbeat",
+    "snagline.detectors.windowing",
+    "snagline.detectors.loop",
+    "snagline.detectors.error_cascade",
+    "snagline.detectors.latency_anomaly",
+    "snagline.detectors.meltdown",
+    "snagline.detectors.stagnation",
+)
+
+
+def test_bare_import_works_stdlib_only() -> None:
+    script = ";".join(f"import {m}" for m in NEW_OR_TOUCHED_MODULES)
+    proc = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            f"import sys; {script}; "
+            "banned = {'numpy', 'sklearn', 'sentence_transformers', 'redis'};"
+            "assert not (set(sys.modules) & banned), 'extra leaked into core';"
+            "print('ok')",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    assert proc.stdout.strip() == "ok"
+
+
+def test_touched_modules_import_in_process() -> None:
+    for name in NEW_OR_TOUCHED_MODULES:
+        assert importlib.import_module(name) is not None

--- a/tests/test_watch_cli.py
+++ b/tests/test_watch_cli.py
@@ -45,3 +45,52 @@ def test_watch_skips_malformed_lines(capsys, monkeypatch):
 def test_watch_webhook_requires_url(capsys):
     assert main(["watch", "--sink", "webhook"]) == 2
     assert "--webhook-url" in capsys.readouterr().err
+
+
+def test_watch_heartbeat_touches_per_ingest(tmp_path):
+    """--heartbeat: the liveness file is created and stamped (issue #92)."""
+    hb_path = tmp_path / "run" / "snagline" / "hb"
+    rc = main(
+        [
+            "watch",
+            "--file",
+            str(FIXTURES / "healthy_run.jsonl"),
+            "--heartbeat",
+            str(hb_path),
+        ]
+    )
+    assert rc == 0
+    assert hb_path.exists()
+    assert hb_path.read_bytes() == b""  # mtime only, never content
+
+
+def test_watch_without_heartbeat_creates_nothing(tmp_path):
+    rc = main(["watch", "--file", str(FIXTURES / "healthy_run.jsonl")])
+    assert rc == 0
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_iter_lines_calls_on_wait_while_following(tmp_path):
+    """Idle follow-polls keep the heartbeat alive while no lines arrive."""
+    from snagline.cli import _iter_lines
+
+    watched = tmp_path / "events.jsonl"
+    watched.write_text('{"step_id": "s1"}\n')
+    waits: list[int] = []
+
+    class _Done(Exception):
+        pass
+
+    def stop_after_three() -> None:
+        waits.append(1)
+        if len(waits) >= 3:
+            raise _Done
+
+    consumed: list[str] = []
+    try:
+        for line in _iter_lines(str(watched), True, on_wait=stop_after_three):
+            consumed.append(line.strip())
+    except _Done:
+        pass
+    assert consumed == ['{"step_id": "s1"}']
+    assert len(waits) == 3

--- a/tests/test_window_scaling.py
+++ b/tests/test_window_scaling.py
@@ -226,3 +226,17 @@ def test_loop_detector_default_counts_invisible_when_scaling_off() -> None:
     # Counts maintained but never consulted when scale_steps == 0.
     assert det._counts.get("ep1") == len(events)
     assert all(w.maxlen == 12 for w in det._windows.values())
+
+
+def test_near_duplicate_mode_counts_events_once_per_family() -> None:
+    """Regression (gitar finding, PR #167): plain and near-duplicate paths
+    share one observe() call per event, so each window family must keep its
+    own event counter; a shared one would count every event twice and scale
+    windows twice as fast.
+    """
+    cfg = Config(loop_near_duplicate_enabled=True, window_scale_steps=10)
+    det = LoopDetector(config=cfg)
+    for i in range(25):
+        det.observe(_event(f"s{i}", float(i), "loopA" if i % 2 else f"u{i}"))
+    assert det._counts["ep1"] == 25  # advanced once per event, not twice
+    assert det._near_counts["ep1"] == 25

--- a/tests/test_window_scaling.py
+++ b/tests/test_window_scaling.py
@@ -1,0 +1,228 @@
+"""Window auto-scaling and CUSUM baseline re-fit (issue #92).
+
+Property under test: with ``window_scale_steps == 0`` (default) detector
+behavior is byte-identical to the pre-#92 build; with scaling on, effective
+windows stay within ``[base, max_window]``, grow monotonically, and detection
+quality is preserved across episode-length fixtures (a pattern that a static
+base window misses on a long episode is still caught once scaled).
+"""
+
+from __future__ import annotations
+
+import itertools
+
+import pytest
+
+from snagline.config import Config
+from snagline.detectors.error_cascade import ErrorCascadeDetector
+from snagline.detectors.latency_anomaly import LatencyAnomalyDetector
+from snagline.detectors.loop import LoopDetector
+from snagline.detectors.windowing import effective_window_size, next_window
+from snagline.events import StepEvent
+
+
+def _event(
+    step_id: str,
+    timestamp: float,
+    signature: str,
+    *,
+    error: bool = False,
+    latency_ms: float | None = None,
+    episode_id: str = "ep1",
+) -> StepEvent:
+    return StepEvent(
+        step_id=step_id,
+        episode_id=episode_id,
+        timestamp=timestamp,
+        action_type="tool_call",
+        action_signature=signature,
+        tool_name="t",
+        error=error,
+        latency_ms=latency_ms,
+    )
+
+
+# --- pure function properties (grid over lengths and configs) ---------------
+
+
+def test_effective_window_size_properties() -> None:
+    bases = [1, 5, 12, 50]
+    scale_steps = [0, 1, 7, 100, 10_000]
+    max_windows = [16, 512]
+    lens = [0, 1, 2, 6, 99, 100, 101, 999, 100_000]
+    for base, steps, cap, n in itertools.product(bases, scale_steps, max_windows, lens):
+        size = effective_window_size(base, n, steps, cap)
+        assert base <= size <= max(cap, base), (base, steps, cap, n, size)
+        if steps <= 0 or n <= 1:
+            assert size == base
+
+
+def test_effective_window_size_monotonic_in_episode_length() -> None:
+    prev = 0
+    for n in range(1, 5001):
+        size = effective_window_size(12, n, 100, 200)
+        assert size >= prev
+        prev = size
+    assert prev == 200  # capped
+
+
+def test_next_window_resizes_lazily_and_keeps_recent_items() -> None:
+    windows: dict = {}
+    counts: dict = {}
+    w = next_window(windows, counts, "ep", base=2, scale_steps=2, max_window=4)
+    w.append("a")
+    w.append("b")
+    # len now 2; factor ceil(2/2)=1 -> still base=2
+    assert w.maxlen == 2
+    w = next_window(windows, counts, "ep", 2, 2, 4)
+    w.append("c")
+    assert w.maxlen == 2  # event 2: ceil(2/2)=1, still base
+    w = next_window(windows, counts, "ep", 2, 2, 4)
+    w.append("d")
+    assert w.maxlen == 4  # event 3: ceil(3/2)=2 -> grew lazily
+    assert list(w) == ["b", "c", "d"]  # most recent items retained
+
+
+# --- detector equivalence fixtures ------------------------------------------
+
+
+def _planted_loop_episode(length: int, loop_start: int) -> list[StepEvent]:
+    """A long episode of distinct steps with an exact A/B loop planted late."""
+    events = []
+    ts = 0.0
+    for i in range(loop_start):
+        events.append(_event(f"s{i}", ts, f"unique-{i}"))
+        ts += 1.0
+    pair = itertools.cycle(["loopA", "loopB"])
+    for j in range(loop_start, length):
+        events.append(_event(f"s{j}", ts, next(pair)))
+        ts += 1.0
+    return events
+
+
+def _run_loop(events: list[StepEvent], **cfg_kwargs) -> int:
+    det = LoopDetector(config=Config(**cfg_kwargs))
+    fires = 0
+    for e in events:
+        if det.observe(e) is not None:
+            fires += 1
+    return fires
+
+
+@pytest.mark.parametrize("length", [50, 500, 5_000])
+def test_scaling_equivalent_below_scale_floor(length: int) -> None:
+    """With scale_steps > length, scaling on == scaling off exactly."""
+    events = _planted_loop_episode(length, length - 20)
+    off = _run_loop(events)
+    on = _run_loop(events, window_scale_steps=length + 1, max_window=64)
+    assert on == off
+
+
+def test_scaled_window_catches_loop_static_base_misses() -> None:
+    """The value proposition: a sparse loop beyond the base window is caught."""
+    # LoopA lands every 25 distinct steps: three repeats span 50 steps, so a
+    # static 12-window holds one repeat (never fires) while the scaled window
+    # (base * ceil(n/steps), capped) eventually holds three.
+    length = 3_000
+    events: list[StepEvent] = []
+    ts = 0.0
+    for i in range(length):
+        sig = "loopA" if i % 25 == 0 else f"unique-{i}"
+        events.append(_event(f"s{i}", ts, sig))
+        ts += 1.0
+    static = _run_loop(events)
+    scaled = _run_loop(events, window_scale_steps=500, max_window=256)
+    assert static == 0
+    assert scaled > 0
+
+
+def test_cascade_scaling_preserves_short_episode_behavior() -> None:
+    cfg_off = Config()
+    cfg_on = Config(window_scale_steps=10_000, max_window=128)
+    events = [
+        _event(f"s{i}", float(i), f"sig{i}", error=(i % 4 == 0)) for i in range(30)
+    ]
+    d_off = ErrorCascadeDetector(config=cfg_off)
+    d_on = ErrorCascadeDetector(config=cfg_on)
+    for e in events:
+        r_off = d_off.observe(e)
+        r_on = d_on.observe(e)
+        assert (r_off is None) == (r_on is None)
+
+
+# --- CUSUM periodic re-fit ---------------------------------------------------
+
+
+def test_cusum_refit_surfaces_baseline_drift() -> None:
+    cfg = Config(cusum_min_samples=5, cusum_refit_every=10)
+    det = LatencyAnomalyDetector(config=cfg)
+    risks = []
+    ts = 0.0
+    # Healthy warm-up around 100ms, then frozen.
+    for i in range(8):
+        e = _event(f"w{i}", ts, "s", latency_ms=100.0 + (i % 2))
+        risks.append(det.observe(e))
+        ts += 1.0
+    # Sustained shift to ~400ms. The CUSUM alarms against the old baseline;
+    # once the parallel learner adopts the new one, the accumulated shift
+    # surfaces as its own risk and later steps go quiet again.
+    for i in range(40):
+        e = _event(f"x{i}", ts, "s", latency_ms=400.0)
+        risks.append(det.observe(e))
+        ts += 1.0
+    triggers = [r.trigger for r in risks if r is not None]
+    assert "latency_anomaly" in triggers  # CUSUM alarm fired
+    details = [r.detail for r in risks if r is not None]
+    assert any("baseline shifted" in d for d in details)  # drift visible
+    # After adoption, 400ms IS the baseline: the detector goes quiet.
+    assert all(r is None for r in risks[-5:])
+
+
+def test_cusum_refit_disabled_by_default_matches_pre92_behavior() -> None:
+    cfg = Config()
+    det = LatencyAnomalyDetector(config=cfg)
+    state = None
+    ts = 0.0
+    for i in range(10):
+        det.observe(_event(f"w{i}", ts, "s", latency_ms=50.0))
+        ts += 1.0
+    key = ("ep1", "t")
+    state = det._states[key]
+    assert state.refit_every == 0
+    assert state.learner_n == 0
+    assert not state.pending_drift
+
+
+def test_cusum_refit_snapshot_roundtrip_tolerates_old_payloads() -> None:
+    cfg = Config(cusum_min_samples=2, cusum_refit_every=5)
+    det = LatencyAnomalyDetector(config=cfg)
+    ts = 0.0
+    for i in range(6):
+        det.observe(_event(f"w{i}", ts, "s", latency_ms=50.0 + i))
+        ts += 1.0
+    dumped = det.dump_state()
+    det2 = LatencyAnomalyDetector(config=cfg)
+    det2.load_state(dumped)
+    key = ("ep1", "t")
+    assert det2._states[key].refit_every == 5
+    # Pre-#92 payload (no refit keys) must load cleanly into a refit-enabled
+    # detector AND into a default one.
+    old_raw = {
+        k: v
+        for k, v in dumped["states"][0][1].items()
+        if not k.startswith(("refit", "learner"))
+    }
+    old_dump = {"states": [[dumped["states"][0][0], old_raw]]}
+    det3 = LatencyAnomalyDetector(config=cfg)
+    det3.load_state(old_dump)
+    assert det3._states[key].learner_n == 0
+
+
+def test_loop_detector_default_counts_invisible_when_scaling_off() -> None:
+    det = LoopDetector(config=Config())
+    events = [_planted_loop_episode(30, 25)[0]]
+    for i, e in enumerate(events):
+        det.observe(e)
+    # Counts maintained but never consulted when scale_steps == 0.
+    assert det._counts.get("ep1") == len(events)
+    assert all(w.maxlen == 12 for w in det._windows.values())


### PR DESCRIPTION
## Summary

Implements issue #92: time-axis awareness for horizon-scale episodes, in four pieces, one coherent PR. Everything is opt-in; with the new options unset, behavior is byte-identical to the pre-#92 build.

**The blindness hole this closes, stated plainly:** in-band detectors can never see a hung host. A deadlocked tool call, a hung connection, or an OOM-stopped worker produces no events, and no events means no `observe()` calls, which means no detector ever runs. Only a clock or an external watcher can close that hole. This PR adds both halves: in-band idle/budget risks derived from event timestamps, and an out-of-band heartbeat file whose stale mtime any external supervisor (cron, systemd timer, k8s probe, CONTINUUM's sidecar) can alert on. The watcher owns the alerting decision; snagline just leaves evidence of life.

## What changed

### 1. Time-aware Config keys (additive only)

- `max_episode_wall_seconds` + `warn_fraction` (default 0.8): one warning risk at 80% of budget (score 0.7, severity "warning"), one critical breach at the limit (score 1.0). Trigger name for both: `wall_clock_budget`. Each fires at most once per episode; a single delta jumping straight past the limit fires only the breach (mirrors `TokenRunawayDetector`).
- `idle_warn_seconds`: a gap between consecutive ingests at or above this fires one `idle_gap` risk per episode.
- Out-of-range values fail loudly at construction/resolve time (`_validated_horizon`), same policy as `log_format` from issue #119.

### 2. Region contract honored

Inter-event deltas are computed from `StepEvent.timestamp` at the TOP of `Monitor.ingest()` only, under the per-episode lock. **Zero wall-clock reads in the hot path** (`test_no_wall_clock_reads_in_ingest` monkeypatches `time.time` to explode and ingests anyway). The sinks/policy dispatch tail of `ingest()` is untouched.

### 3. Window auto-scaling + CUSUM re-fit (`detectors/windowing.py`)

- Loop, cascade, meltdown, and stagnation windows scale as `base * ceil(episode_len / window_scale_steps)`, capped at `max_window`, refitted lazily keeping the most recent items. Below one scale step, scaling on and off are exactly equivalent (property-tested over grids and episode-length fixtures).
- Optional `cusum_refit_every`: every N post-warm-up samples a parallel Welford learner accumulates while the frozen baseline keeps scoring (coverage never pauses). On completion, a shift beyond the same `h * sigma` alarm bar surfaces as one `latency_anomaly` risk before the candidate baseline is adopted; drift in the baseline itself becomes visible instead of being learned away silently.
- Snapshots stay compatible: pre-#92 payloads load cleanly via tolerant `.get()` reads for the new fields; the live config owns the cadence knob.

### 4. HeartbeatSink (`sinks/heartbeat.py`) + CLI

- `snagline watch --follow --heartbeat PATH` touches the file's mtime on every ingest and every idle follow-poll (~5 lines of stdlib effect). Missing directory handled fail-open; unwritable path logs once and never raises; no content is ever written to the file.

### 5. Docs

Horizon-scale section in project.md (new 5.7), README detector-table row, features row, env-var table rows, watch CLI example, and a limitations-table update covering warm-up semantics and idle-detection semantics including the silence hole above.

## Acceptance criteria (issue #92)

| Criterion | Evidence |
|---|---|
| Idle-gap and budget risks fire once per episode per threshold | `test_idle_gap_fires_once_per_episode`, `test_idle_gap_resets_with_episode`, `test_budget_warn_then_breach_each_fire_once`, `test_single_jump_past_budget_fires_only_breach`, `test_negative_delta_does_not_refund_budget` |
| Replay determinism: identical results with options unset | `test_replay_fingerprints_unchanged_when_options_unset` (frozen pre-#92 fingerprints over all five fixture trajectories) and `test_no_wall_clock_reads_in_ingest` |
| Auto-scaling property test | `test_effective_window_size_properties` (grid: bounds/floor/disabled identity), `test_effective_window_size_monotonic_in_episode_length`, `test_scaling_equivalent_below_scale_floor` (lengths 50/500/5000), `test_scaled_window_catches_loop_static_base_misses` |
| Heartbeat created/touched; missing dir fail-open | `tests/sinks/test_heartbeat.py` (6 tests) + `test_watch_heartbeat_touches_per_ingest` |
| Timing derived from StepEvent.timestamp, documented | project.md 5.7 region contract; monitor.py docstrings |
| README limitations table updated (warm-up + idle semantics) | "Idle detection and the silence hole" + warm-up bullets in Status and Limitations |

## Mutation checks (run against the committed fix, then reverted)

1. Disabled idle-gap firing: `test_horizon_time_axis.py` went red at `test_idle_gap_fires_once_per_episode` (+2 related). Reverted.
2. Disabled budget-breach firing: red at `test_budget_warn_then_breach_each_fire_once`, `test_single_jump_past_budget_fires_only_breach`. Reverted.
3. Bonus, disabled window scaling: red at `test_scaled_window_catches_loop_static_base_misses` and the windowing property tests. Reverted.

## Gate

- pytest: 544 passed, 2 skipped, coverage 88.32% (threshold 80%), green at every commit snapshot
- ruff check: clean; ruff format --check: clean
- mypy src: clean (53 files)
- No-extras import smoke check included (`tests/test_no_extras_import.py`): bare stdlib-only import of all touched modules, asserting numpy/sklearn/sentence-transformers/redis never leak into core
- No em dashes anywhere in code, docs, commit messages, or this body

Fixes #92
