### PR TITLE
feat(detectors): snapshot/restore for stagnation, side-effect guard, compaction tripwire

### DIFF
--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -370,5 +370,9 @@ pickle) participate in `Monitor.snapshot(path)` / `Monitor.restore(path)`.
 Snapshots are written atomically (tmp + `os.replace`). Restore is a
 setup-time operation: a version or strict-composition mismatch raises rather
 than failing open -- a monitor that silently starts blank is exactly the quiet
-misbehavior this exists to prevent. All shipped detectors implement it, and
-`DedupSink` persists cooldowns when used with its default key function.
+misbehavior this exists to prevent. Every shipped detector implements it
+(`loop`, `error_cascade`, `latency_anomaly`, `token_runaway`, `silent_abort`,
+`meltdown`, `ml_ensemble`, `goal_drift`, `stagnation`,
+`side_effect_guard`, and `compaction_tripwire` -- the last two added by
+issue #149), and `DedupSink` persists cooldowns when used with its default
+key function.

--- a/src/snagline/detectors/compaction_tripwire.py
+++ b/src/snagline/detectors/compaction_tripwire.py
@@ -47,6 +47,8 @@ pins (small by construction). Memory: one small state object per episode;
 
 from __future__ import annotations
 
+from typing import Any
+
 from snagline.config import Config
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
@@ -151,6 +153,43 @@ class CompactionTripwireDetector:
     def reset(self, episode_id: str) -> None:
         """Drop the event ordinal and any pending window for the episode."""
         self._episodes.pop(episode_id, None)
+
+    def dump_state(self) -> dict[str, Any]:
+        """Serialize per-episode ordinals and pending windows (#91/#149).
+
+        All primitives are JSON-compatible; pin sets become sorted lists (raw
+        sets are not JSON-serializable) and ``load_state`` rebuilds the set.
+        Pins are hashes by contract, so serialization carries no content risk.
+        A restart between a compaction and its confirmations must not let the
+        grace deadline vanish silently: the pending set, its deadline ordinal,
+        and the fired latch all survive.
+        """
+        episodes: dict[str, Any] = {}
+        for ep, st in self._episodes.items():
+            entry: dict[str, Any] = {"ordinal": st.ordinal, "pending": None}
+            if st.pending is not None:
+                entry["pending"] = {
+                    "pins": sorted(st.pending.pins),
+                    "deadline_ordinal": st.pending.deadline_ordinal,
+                    "fired": st.pending.fired,
+                }
+            episodes[ep] = entry
+        return {"episodes": episodes}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self._episodes = {}
+        for ep, entry in state.get("episodes", {}).items():
+            st = _EpisodeState()
+            st.ordinal = int(entry.get("ordinal", 0))
+            raw_pending = entry.get("pending")
+            if raw_pending is not None:
+                pending = _PendingPins(
+                    set(raw_pending.get("pins", [])),
+                    int(raw_pending.get("deadline_ordinal", 0)),
+                )
+                pending.fired = bool(raw_pending.get("fired", False))
+                st.pending = pending
+            self._episodes[str(ep)] = st
 
     def _open_window(self, metadata: dict, ordinal: int) -> _PendingPins | None:
         """Build the pending window for a compaction event, or None when the

--- a/src/snagline/detectors/side_effect_guard.py
+++ b/src/snagline/detectors/side_effect_guard.py
@@ -39,7 +39,7 @@ The trigger string is API: CONTINUUM's policy table maps
 
 from __future__ import annotations
 
-from typing import cast
+from typing import Any, cast
 
 from snagline.config import Config
 from snagline.events import StepEvent
@@ -102,3 +102,28 @@ class SideEffectGuardDetector:
     def reset(self, episode_id: str) -> None:
         """Drop every counted action for ``episode_id`` (Monitor.end_episode)."""
         self._counts.pop(episode_id, None)
+
+    def dump_state(self) -> dict[str, Any]:
+        """Serialize occurrence counters for ``Monitor.snapshot`` (#91/#149).
+
+        Plain nested dicts of ints by construction; only the inner
+        ``(tool_name, action_signature)`` tuple keys need encoding, which
+        become two-element JSON lists. Sorted so snapshots are deterministic.
+        """
+        return {
+            "counts": {
+                ep: [
+                    [list(key), count]
+                    for key, count in sorted(
+                        per_episode.items(), key=lambda kv: repr(kv[0])
+                    )
+                ]
+                for ep, per_episode in self._counts.items()
+            }
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self._counts = {
+            str(ep): {(key[0], key[1]): int(count) for key, count in raw_counts}
+            for ep, raw_counts in state.get("counts", {}).items()
+        }

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -162,8 +162,16 @@ class StagnationDetector:
         self._windows = {}
         for ep, raw in state.get("windows", {}).items():
             w = _EpisodeWindow()
-            w.flags = deque(bool(b) for b in raw.get("flags", []))
-            w.novel_in_window = int(raw.get("novel_in_window", 0))
+            # Clamp to the CURRENT window_size: restore is tolerant by default
+            # (matches by name, ignores config), so a snapshot taken with a
+            # larger window must not leave an overlong deque whose equality-
+            # based eviction never fires again. Mirrors LoopDetector's
+            # deque(sigs, maxlen=self.window_size) rebuild; the sliding
+            # counter is recomputed from the truncated flags so the two stay
+            # consistent.
+            flags = [bool(b) for b in raw.get("flags", [])][-self.window_size :]
+            w.flags = deque(flags, maxlen=self.window_size)
+            w.novel_in_window = sum(flags)
             w.stale_windows = int(raw.get("stale_windows", 0))
             w.seen_all_time = set(raw.get("seen_all_time", []))
             self._windows[str(ep)] = w

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -43,6 +43,7 @@ see :meth:`snagline.monitor.Monitor.default`.
 from __future__ import annotations
 
 from collections import deque
+from typing import Any
 
 from snagline.config import Config
 from snagline.events import StepEvent
@@ -136,3 +137,33 @@ class StagnationDetector:
     def reset(self, episode_id: str) -> None:
         """Drop the window, the stale counter, and the monotonic seen-set."""
         self._windows.pop(episode_id, None)
+
+    def dump_state(self) -> dict[str, Any]:
+        """Serialize per-episode windows for ``Monitor.snapshot`` (#91/#149).
+
+        JSON-compatible throughout: the novelty ``flags`` deque becomes a plain
+        list of booleans and ``seen_all_time`` is sorted so snapshots are
+        deterministic; ``load_state`` rebuilds the set from the sorted list
+        (raw sets are not JSON-serializable).
+        """
+        return {
+            "windows": {
+                ep: {
+                    "flags": list(w.flags),
+                    "novel_in_window": w.novel_in_window,
+                    "stale_windows": w.stale_windows,
+                    "seen_all_time": sorted(w.seen_all_time),
+                }
+                for ep, w in self._windows.items()
+            }
+        }
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self._windows = {}
+        for ep, raw in state.get("windows", {}).items():
+            w = _EpisodeWindow()
+            w.flags = deque(bool(b) for b in raw.get("flags", []))
+            w.novel_in_window = int(raw.get("novel_in_window", 0))
+            w.stale_windows = int(raw.get("stale_windows", 0))
+            w.seen_all_time = set(raw.get("seen_all_time", []))
+            self._windows[str(ep)] = w

--- a/tests/test_detector_snapshots.py
+++ b/tests/test_detector_snapshots.py
@@ -146,6 +146,31 @@ def test_stagnation_already_fired_collapse_stays_quiet_after_restore():
     assert _risks(d1, _repeats(12, 4)) == []
 
 
+def test_stagnation_restore_clamps_flags_to_current_window_size():
+    """Review-bot finding on #168: restore is tolerant by default (config is
+    not carried), so a snapshot written with a larger window_size must clamp
+    to the loading detector's window. An overlong deque would defeat the
+    equality-based eviction in observe() and grow without bound."""
+    d_big = StagnationDetector(window_size=8, min_novelty=0.25, patience=2)
+    d_big.observe(_ev(0, signature="n0"))
+    d_big.observe(_ev(1, signature="n1"))
+    d_big.observe(_ev(2, signature="stale"))
+    for i in range(3, 8):
+        d_big.observe(_ev(i, signature="stale"))
+    dumped = d_big.dump_state()
+    assert len(dumped["windows"]["ep"]["flags"]) == 8
+
+    d_small = StagnationDetector(window_size=4, min_novelty=0.25, patience=2)
+    d_small.load_state(json.loads(json.dumps(dumped)))
+    w = d_small._windows["ep"]
+    assert len(w.flags) == 4, "restored flags must clamp to current window"
+    assert w.novel_in_window == sum(w.flags), "counter must match truncated flags"
+    # The window stays bounded afterwards: equality eviction still engages.
+    for i in range(10):
+        d_small.observe(_ev(100 + i, signature="stale"))
+    assert len(d_small._windows["ep"].flags) == 4
+
+
 def test_stagnation_recovery_rearms_after_restore():
     d1 = _stagnation_detector()
     _warm_unique(d1)

--- a/tests/test_detector_snapshots.py
+++ b/tests/test_detector_snapshots.py
@@ -1,0 +1,338 @@
+"""Round-trip snapshot/restore tests for StagnationDetector,
+SideEffectGuardDetector, and CompactionTripwireDetector (issue #149).
+
+These mirror the behavioral style of ``tests/test_monitor_snapshot.py``: state
+goes through a true JSON round trip (``json.loads(json.dumps(...))``), then
+the restored detector must behave identically to the never-restarted original.
+The issue's acceptance criteria are covered verbatim: a key that already fired
+pre-restart stays quiet after restore, and a key that had not yet fired still
+fires afterwards. CompactionTripwireDetector is included per the maintainer's
+scope-extension comment on #149 (it landed via #147 without the pair).
+"""
+
+from __future__ import annotations
+
+import json
+
+from snagline.detectors.compaction_tripwire import CompactionTripwireDetector
+from snagline.detectors.side_effect_guard import SideEffectGuardDetector
+from snagline.detectors.stagnation import StagnationDetector
+from snagline.events import StepEvent
+from snagline.monitor import Monitor
+
+
+def _ev(
+    step: int,
+    *,
+    signature: str = "s",
+    tool_name: str | None = "api",
+    side_effect: bool = False,
+    action_type: str = "tool_call",
+    metadata: dict | None = None,
+    episode_id: str = "ep",
+) -> StepEvent:
+    return StepEvent(
+        step_id=str(step),
+        episode_id=episode_id,
+        timestamp=float(step),
+        action_type=action_type,
+        action_signature=signature,
+        tool_name=tool_name,
+        side_effect=side_effect,
+        metadata=metadata or {},
+    )
+
+
+def _risks(det, events):
+    return [r for e in events if (r := det.observe(e)) is not None]
+
+
+def _round_trip(det):
+    """A true JSON round trip: floats/lists/dicts pass through repr()."""
+    det.load_state(json.loads(json.dumps(det.dump_state())))
+
+
+# --- SideEffectGuardDetector -------------------------------------------------
+
+
+def _guard_stream(first: int, count: int):
+    return [
+        _ev(i, signature="charge", tool_name="payment", side_effect=True)
+        for i in range(first, first + count)
+    ]
+
+
+def test_side_effect_guard_unfired_key_still_fires_after_restore():
+    d1 = SideEffectGuardDetector(allowed_repeats=1)
+    assert _risks(d1, _guard_stream(0, 1)) == [], "first occurrence is tolerated"
+
+    d2 = SideEffectGuardDetector(allowed_repeats=1)
+    d2.load_state(json.loads(json.dumps(d1.dump_state())))
+
+    risks = _risks(d2, _guard_stream(1, 1))
+    assert len(risks) == 1, "the repeat spanning the restart must still fire"
+    assert risks[0].trigger == "side_effect_duplicate"
+
+
+def test_side_effect_guard_already_fired_key_stays_quiet_after_restore():
+    d1 = SideEffectGuardDetector(allowed_repeats=1)
+    assert len(_risks(d1, _guard_stream(0, 2))) == 1, "fires on the 2nd occurrence"
+    _round_trip(d1)
+
+    # Third and fourth identical occurrences stay silent: edge-triggered latch
+    # survives the restart, so a repeated payment cannot alert-spam across it.
+    assert _risks(d1, _guard_stream(2, 2)) == []
+
+
+def test_side_effect_guard_distinct_keys_independent_after_restore():
+    d1 = SideEffectGuardDetector(allowed_repeats=1)
+    _risks(d1, [_ev(0, signature="charge", tool_name="payment", side_effect=True)])
+    _round_trip(d1)
+
+    # A different (tool, signature) key was never seen pre-restart: it must get
+    # its own full tolerance, not inherit the fired state of another key.
+    fresh = [_ev(1, signature="deploy", tool_name="shipit", side_effect=True)]
+    assert _risks(d1, fresh) == []
+    again = [_ev(2, signature="deploy", tool_name="shipit", side_effect=True)]
+    assert len(_risks(d1, again)) == 1
+
+
+# --- StagnationDetector -------------------------------------------------------
+
+
+def _stagnation_detector() -> StagnationDetector:
+    # Small window so the scenario fits in a handful of steps: stale when fewer
+    # than 1-in-4 actions are novel, firing after 2 consecutive stale windows.
+    return StagnationDetector(window_size=4, min_novelty=0.25, patience=2)
+
+
+def _warm_unique(det: StagnationDetector) -> None:
+    det.observe(_ev(0, signature="u0"))
+    det.observe(_ev(1, signature="u1"))
+    det.observe(_ev(2, signature="u2"))
+    det.observe(_ev(3, signature="u3"))
+
+
+def _repeats(first: int, count: int):
+    return [
+        _ev(i, signature="stuck", tool_name="planner")
+        for i in range(first, first + count)
+    ]
+
+
+def test_stagnation_unfired_collapse_still_fires_after_restore():
+    d1 = _stagnation_detector()
+    _warm_unique(d1)
+    assert _risks(d1, _repeats(4, 4)) == [], "one stale window: below patience"
+
+    d2 = _stagnation_detector()
+    d2.load_state(json.loads(json.dumps(d1.dump_state())))
+
+    risks = _risks(d2, _repeats(8, 4))
+    assert len(risks) == 1, "collapse completing after restart must still fire"
+    assert risks[0].trigger == "stagnation"
+
+
+def test_stagnation_already_fired_collapse_stays_quiet_after_restore():
+    d1 = _stagnation_detector()
+    _warm_unique(d1)
+    _risks(d1, _repeats(4, 4))  # stale_windows reaches 1
+    fired = _risks(d1, _repeats(8, 4))  # stale_windows reaches patience: fires
+    assert len(fired) == 1
+    _round_trip(d1)
+
+    # Continuing the same collapse must not re-fire (one finding per collapse),
+    # and the restored stale counter is what keeps it quiet.
+    assert _risks(d1, _repeats(12, 4)) == []
+
+
+def test_stagnation_recovery_rearms_after_restore():
+    d1 = _stagnation_detector()
+    _warm_unique(d1)
+    _risks(d1, _repeats(4, 8))  # fired mid-stream
+    _round_trip(d1)
+
+    # Novelty recovers (fresh signatures), then collapses again: the restored
+    # re-arm state must allow exactly one new finding.
+    recovery = [_ev(20 + i, signature=f"fresh{i}") for i in range(4)]
+    assert _risks(d1, recovery) == [], "recovery resets the stale counter"
+    refire = _risks(d1, _repeats(30, 4))
+    assert refire == []  # only 1 stale window since recovery
+    refire = _risks(d1, _repeats(40, 4))
+    assert len(refire) == 1, "second collapse after recovered novelty fires again"
+
+
+# --- CompactionTripwireDetector ----------------------------------------------
+
+
+_PIN_A = "a" * 64
+_PIN_B = "b" * 64
+
+
+def _compaction(step: int, pins: list[str]) -> StepEvent:
+    return _ev(
+        step,
+        # Stable signature: the tripwire keys on action_type/metadata only, and
+        # stable strings keep the co-hosted stagnation scenarios predictable.
+        signature="compact",
+        tool_name=None,
+        action_type="compaction",
+        metadata={"pinned": pins},
+    )
+
+
+def _confirm(step: int, pin: str) -> StepEvent:
+    return _ev(
+        step,
+        signature="confirm",
+        tool_name=None,
+        action_type="constraint_present",
+        metadata={"pin": pin},
+    )
+
+
+def _filler(step: int) -> StepEvent:
+    return _ev(step, signature="fill", tool_name="worker")
+
+
+def test_compaction_tripwire_pending_window_survives_restore_and_still_fires():
+    """The maintainer's acceptance sketch (#149 comment): snapshot after
+    ``compaction`` but before any ``constraint_present``, restore, feed
+    confirmations past the deadline; the unconfirmed pin still decays."""
+    d1 = CompactionTripwireDetector(grace_steps=3)
+    d1.observe(_compaction(0, [_PIN_A, _PIN_B]))
+    d1.observe(_filler(1))  # ordinal 2 of 4; deadline not reached yet
+    _round_trip(d1)
+
+    # Restored: confirm A, then burn past the grace deadline. B was never
+    # confirmed, so governance_decay must still fire -- exactly once.
+    events = [_confirm(2, _PIN_A), _filler(3), _filler(4)]
+    risks = _risks(d1, events)
+    assert len(risks) == 1, "unconfirmed pin must decay after restore"
+    assert risks[0].trigger == "governance_decay"
+    # Detail names only unconfirmed pin prefixes: B decayed, A was confirmed.
+    assert "b" * 16 in risks[0].detail
+    assert "a" * 16 not in risks[0].detail
+
+
+def test_compaction_tripwire_already_fired_stays_quiet_after_restore():
+    d1 = CompactionTripwireDetector(grace_steps=3)
+    d1.observe(_compaction(0, [_PIN_A, _PIN_B]))
+    risks = _risks(
+        d1,
+        [_filler(1), _filler(2), _filler(3)],  # deadline passes unconfirmed
+    )
+    assert len(risks) == 1
+    _round_trip(d1)
+
+    # Confirming B late must not retract or re-fire anything, and pin A was
+    # never confirmed: only the restored fired latch keeps this episode quiet.
+    tail = [_confirm(4, _PIN_B), _filler(5), _filler(6)]
+    assert _risks(d1, tail) == []
+
+
+def test_compaction_tripwire_no_pending_window_round_trips_cleanly():
+    d1 = CompactionTripwireDetector(grace_steps=3)
+    d1.observe(_filler(0))  # ordinal tracked, nothing pending
+    _round_trip(d1)
+    # After restore a later compaction opens a normal window.
+    d1.observe(_compaction(1, [_PIN_A]))
+    risks = _risks(d1, [_filler(2), _filler(3), _filler(4)])
+    assert len(risks) == 1
+
+
+# --- Monitor-level participation ---------------------------------------------
+
+
+class ListSink:
+    def __init__(self) -> None:
+        self.risks: list = []
+
+    def emit(self, risk) -> None:
+        self.risks.append(risk)
+
+
+def _composition() -> tuple[list, list]:
+    detectors: list = [
+        SideEffectGuardDetector(allowed_repeats=1),
+        StagnationDetector(window_size=4, min_novelty=0.25, patience=2),
+        CompactionTripwireDetector(grace_steps=3),
+    ]
+    return detectors, [ListSink()]
+
+
+def _mixed_stream() -> list[StepEvent]:
+    """Signals from all three detectors land AFTER the snapshot boundary.
+
+    Episodes are kept separate so scenarios cannot contaminate each other's
+    per-episode detector state: "main" carries guard + tripwire, "stag" a
+    self-contained stagnation collapse (same numbers as the unit tests above).
+    """
+    events: list[StepEvent] = [
+        # Guard (main): first occurrence tolerated, fires only after boundary.
+        _ev(0, signature="charge", tool_name="payment", side_effect=True),
+        # Stagnation (stag): warm-up plus four repeats; patience not reached.
+        _ev(100, signature="u0", episode_id="stag"),
+        _ev(101, signature="u1", episode_id="stag"),
+        _ev(102, signature="u2", episode_id="stag"),
+        _ev(103, signature="u3", episode_id="stag"),
+        _ev(104, signature="stuck", episode_id="stag"),
+        _ev(105, signature="stuck", episode_id="stag"),
+        _ev(106, signature="stuck", episode_id="stag"),
+        _ev(107, signature="stuck", episode_id="stag"),
+        # Tripwire (main): compaction opens a grace window of 3 events.
+        _compaction(9, [_PIN_A, _PIN_B]),
+        # Confirm A before the boundary; B stays pending across the restart.
+        _confirm(10, _PIN_A),
+    ]
+    return events
+
+
+def test_monitor_snapshot_restore_matches_never_restarted_twin(tmp_path):
+    path = str(tmp_path / "state.json")
+
+    m_source = Monitor(*_composition())
+    m_twin = Monitor(*_composition())
+    stream = _mixed_stream()
+    for e in stream:
+        m_source.ingest(e)
+        m_twin.ingest(e)
+    pre_tail_count = len(m_source._sinks[0].risks)
+    m_source.snapshot(path)
+
+    # Before this issue these three serialized as null and were skipped on
+    # restore; participation itself is part of the acceptance criteria.
+    dumped = json.loads(open(path, encoding="utf-8").read())
+    states = [v for v in dumped["detectors"].values() if v is not None]
+    assert len(states) == 3, "all three detectors must serialize non-null"
+
+    m_restored = Monitor(*_composition())
+    m_restored.restore(path)
+
+    tail = [
+        # Tripwire (main): ordinal 13 reaches the deadline; B decays once.
+        _filler(12),
+        _filler(13),
+        # Stagnation (stag): the collapse completes after the boundary.
+        _ev(108, signature="stuck", episode_id="stag"),
+        _ev(109, signature="stuck", episode_id="stag"),
+        _ev(110, signature="stuck", episode_id="stag"),
+        _ev(111, signature="stuck", episode_id="stag"),
+        # Guard (main): repeat fires.
+        _ev(16, signature="charge", tool_name="payment", side_effect=True),
+    ]
+    for e in tail:
+        m_source.ingest(e)
+        m_restored.ingest(e)
+
+    source_risks = [(r.step_id, r.trigger, r.score) for r in m_source._sinks[0].risks][
+        pre_tail_count:
+    ]
+    restored_risks = [
+        (r.step_id, r.trigger, r.score) for r in m_restored._sinks[0].risks
+    ]
+    assert source_risks == restored_risks
+    triggers = {t for _, t, _ in source_risks}
+    assert {"side_effect_duplicate", "stagnation", "governance_decay"} <= triggers, (
+        "the tail must exercise all three restored detectors"
+    )


### PR DESCRIPTION
Fixes #149

## What

`Monitor.snapshot()`/`restore()` (from #91) silently skipped three shipped detectors: `StagnationDetector`, `SideEffectGuardDetector`, and `CompactionTripwireDetector`. All three serialized as `null`, so a restart mid-episode reset their state with no warning: a repeated non-idempotent payment spanning a deploy never fired `side_effect_duplicate`, an in-progress stagnation window evaporated, and a governance grace deadline vanished between a compaction and its confirmations. The DETECTOR_GUIDE blanket claim that all shipped detectors implement the pair was wrong on master.

## Implementation (LoopDetector pattern, JSON-compatible only)

- **SideEffectGuardDetector**: occurrence counters are plain nested dicts of ints; inner `(tool_name, action_signature)` tuple keys are encoded as two-element JSON lists, sorted for deterministic snapshots.
- **StagnationDetector**: per-episode novelty flags deque becomes a plain list of booleans; the monotonic seen-signature set is dumped as a sorted list and rebuilt as a set on load (raw sets are not JSON-serializable). `stale_windows`/`novel_in_window` ride along, so an in-progress collapse still fires after restore and recovery still re-arms.
- **CompactionTripwireDetector** (scope extension per the maintainer comment on #149): dumps ordinal plus pending window `{pins: sorted list, deadline_ordinal, fired}`. A restart between a `compaction` and its confirmations no longer lets the deadline vanish; a pinned constraint dropped by compaction still decays after restore.

Privacy: pins are hashes by contract, flags are booleans, signatures are one-way digests. No content retention anywhere (project.md §1.4).

## Docs

DETECTOR_GUIDE now names exactly which detectors participate instead of the incorrect blanket claim.

## Tests (`tests/test_detector_snapshots.py`, mirroring `tests/test_monitor_snapshot.py`)

Per detector, through true JSON round trips:
- already-fired key stays quiet after restore; not-yet-fired key still fires afterwards (the issue's acceptance criteria, verbatim)
- guard: distinct keys stay independent across restore
- stagnation: recovery re-arms after restore
- tripwire: maintainer's sketch (snapshot after `compaction`, restore, confirmations past deadline fire exactly one `governance_decay`; late confirmations do not retract or re-fire)
- Monitor-level twin parity: all three serialize non-null and a restored monitor matches a never-restarted twin's post-boundary risks exactly

## Mutation checks (three, one per detector)

Committed first, then mutated each committed file and confirmed a specific test went red before reverting via `git checkout --`:

1. Guard counts zeroed on load -> `test_side_effect_guard_already_fired_key_stays_quiet_after_restore` red (key re-fired)
2. Stagnation seen-set dropped on load -> `test_stagnation_unfired_collapse_still_fires_after_restore` red (novelty reset, collapse never completed)
3. Tripwire fired latch forced False -> `test_compaction_tripwire_already_fired_stays_quiet_after_restore` red (episode re-fired). First version of this test masked the mutation by confirming every pin; tightened to leave pin A unconfirmed so only the latch keeps it quiet.

## Gate

Full gate green at this snapshot: `pytest tests/ -q -o addopts=""` (521 passed, 1 skipped), `ruff check src tests`, `ruff format --check src tests`, `mypy src`.

Refs #87, Refs #88, Refs #90, Refs #91, Refs #147. Board: #106
