### PR TITLE
test(hooks): poll for the delivered loop payload before follow teardown

### DIFF
--- a/tests/test_hook_bridge.py
+++ b/tests/test_hook_bridge.py
@@ -377,11 +377,15 @@ def test_watch_follow_teardown_reaps_the_child_on_a_healthy_run(tmp_path, childr
     """Issue #69 regression, healthy path, runs on every platform.
 
     The follow-mode watcher dispatches its loop risk to a live localhost
-    sink endpoint (first accepted connection = deterministic readiness,
-    no sleeps). A malformed sentinel line then proves the child finished
-    counting all four events before ``_graceful_stop`` ever runs. The child
-    must end fully reaped: poll() non-None, no ProcessLookupError, and the
-    module-level children fixture leaves zero lingering processes.
+    sink endpoint. Delivery is proven deadline-based: the test polls
+    ``server.bodies`` for the expected loop-trigger payload and proceeds
+    only once the POST has landed (issue #156 -- the former readiness
+    signal, the first accepted connection, raced the actual body landing,
+    which lost intermittently on windows-latest). A malformed sentinel line
+    then proves the child finished counting all four events before
+    ``_graceful_stop`` ever runs. The child must end fully reaped: poll()
+    non-None, no ProcessLookupError, and the module-level children fixture
+    leaves zero lingering processes.
     """
     path = tmp_path / "healthy.jsonl"
     path.write_text("\n".join(json.dumps(_base_event(i)) for i in range(4)) + "\n")
@@ -392,9 +396,18 @@ def test_watch_follow_teardown_reaps_the_child_on_a_healthy_run(tmp_path, childr
             path, f"http://127.0.0.1:{server.port}/sink", children
         )
         catcher = _StderrCatcher(proc, _MALFORMED_MARKER)
-        assert server.wait_for_connection(30), (
-            "watcher never dispatched a risk to the local sink endpoint"
-        )
+        # Contract under test: the loop risk is delivered END-TO-END through
+        # watch --follow to an HTTP sink. Poll for the delivered payload with
+        # a generous deadline instead of trusting connection-level readiness;
+        # teardown must not begin until delivery is observed (issue #156).
+        deadline = time.monotonic() + 30.0
+        while not any(b'"trigger": "loop"' in body for body in server.bodies):
+            if time.monotonic() >= deadline:
+                pytest.fail(
+                    "watcher never delivered the loop risk to the sink "
+                    f"endpoint within 30s; bodies={server.bodies!r}"
+                )
+            time.sleep(0.05)
         # Sentinel: once the CLI logs this line it has already counted every
         # seeded event and is back in the follow poll loop, so stopping it
         # now cannot truncate the run into an exit-code race.


### PR DESCRIPTION
Fixes #156

## What

`test_watch_follow_teardown_reaps_the_child_on_a_healthy_run` was intermittently red on windows-latest (CI run 32940426869, passed on rerun of the same commit). The test's readiness signal was the FIRST accepted connection, but its assertion needs the loop-risk POST BODY to have landed in the stub server's `bodies`. Connection accepted does not imply body received and appended, so on a slow runner `_graceful_stop` could win the race and the bodies list ended up holding a POST without the `"trigger": "loop"` line.

## Change

Replace the connection-based signal with deadline-based polling of `server.bodies` for the expected `'trigger': 'loop'` payload, exactly as proposed in the issue:

- generous 30s deadline (matching the other waits in this file), 50ms poll interval
- teardown (`malformed sentinel` write + `marker_seen` + `_graceful_stop`) only begins once delivery is observed; deadline expiry fails with a precise message including the captured bodies
- the sentinel contract (all four events counted before stop) and every reaping assertion are untouched

The dead-endpoint sibling test keeps `wait_for_connection`: there no body ever lands by design, so the first accepted connection IS the failure signal under test.

## Verification

- **30 consecutive local runs** of the target test: 30/30 green
- **Suite run in parallel with itself** (two concurrent full-suite pytest processes): both suites fail with the same three hook-bridge tests (`returncode == -15` graceful-stop escalation under CPU starvation). Flaky protocol followed:
  - base = pristine origin/master without this change, same parallel load, same machine: identical three failures
  - base+mine: identical three failures, and critically ZERO "never delivered" failures in either suite -- the deadline version held under load, which is what the issue asks to confirm
  - conclusion: the parallel-run failures are a pre-existing environmental artifact of the graceful-stop ladder under extreme CPU contention, not introduced or worsened by this change; the delivery-vs-teardown race itself is gone
- Full gate green after rebase onto current master (#164, #166): `pytest tests/ -q -o addopts=""` (579 passed, 2 skipped), `ruff check src tests`, `ruff format --check src tests`, `mypy src`
- windows-latest leg required green on this PR before completion comment per the issue's verification plan

## Mutation check

Committed first, then mutated the committed file (poll needle `'loop'` -> `'never'`): the test failed after the deadline with the precise message, whose captured body shows the real POST did contain `"trigger": "loop"` -- proving the poll detects genuine delivery and fails deterministically when it never arrives. Reverted via `git checkout --`; tree verified clean.

Refs #116, Refs #69. Board: #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved follow-mode teardown test synchronization by waiting for the expected diagnostic payload to reach the HTTP sink.
  * Added a timeout to prevent tests from waiting indefinitely.
  * Retained malformed-line handling before graceful process termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->