### PR TITLE
ci: add least-privilege permissions block to workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [master, main]


### PR DESCRIPTION
Fixes #154

## What

Adds least-privilege `permissions: contents: read` at the top of `.github/workflows/ci.yml`. Both jobs (`test`, `test-ml`, plus `benchmark-accuracy` from #162) inherit it; neither needs write. Verified by audit that `ci.yml` was the only workflow without a permissions block (12 other workflows already declare one).

## Verification

- Re-ran workflow on this branch: full matrix green, zero `excessive-permissions` findings from zizmor on `ci.yml`.
- Local full gate green: pytest 620 passed / 3 skipped, coverage 88.87% (>=80%), ruff check/format clean, mypy src clean.
- No em dashes.

Refs #116, board #106
