### PR TITLE
fix(server): 400 on malformed Content-Length instead of a handler traceback

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -342,6 +342,14 @@ them is purely operational.
   oversized payloads are dropped at the edge instead of consuming sidecar
   memory and CPU. The cap exists to bound per-request memory while still
   admitting batched `StepEvent` arrays.
+- **Expect 400 on unusable request framing.** A POST whose `Content-Length`
+  is non-numeric or negative gets `{"error": "invalid Content-Length"}` with
+  400 and the connection is closed, because the body's extent is unknown and
+  a reused connection would misread the leftover bytes as the next request
+  (issue #129). An absent `Content-Length` is read as an empty body instead,
+  so it fails on the JSON parse like any other empty payload. Health
+  checkers and fuzzers that emit bad headers therefore get a clean status
+  line rather than a dropped connection and a server-side traceback.
 - **Remember nothing sensitive is retained.** Events carry hashes, timings,
   counts, and booleans, never prompt or response content. `GET /risks`
   retains the most recent 1000 `FailureRisk` records (ids, scores, trigger

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -18,7 +18,10 @@ counting finished episodes without waiting for cap eviction.
 
 POST bodies are capped at ``max_body_bytes`` (default 1 MB); larger payloads
 get 413. This keeps the sidecar safe to expose and able to absorb buffered
-telemetry from any host.
+telemetry from any host. A missing ``Content-Length`` counts as an empty
+body; a malformed one (non-numeric or negative) gets 400 and the connection
+is closed, because the body's extent is unknown and a reused connection
+would misread the leftover bytes as the next request (issue #129).
 
 Optionally protect the endpoints with a shared secret by passing
 ``auth_token=`` to ``make_server``/``serve``. When set, requests must carry the
@@ -59,6 +62,7 @@ one-way telemetry, and callers should not block on detection results.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import math
@@ -96,6 +100,17 @@ _MAX_OVERCAP_DRAIN_EXCESS = 65_536
 # Drain reads happen in fixed chunks, so peak memory stays at one chunk no
 # matter what Content-Length claims.
 _DRAIN_CHUNK_BYTES = 16_384
+# A malformed Content-Length leaves the body's extent unknown, so the drain
+# above cannot be used to clear the socket before the 400 goes out (issue
+# #129). Instead the connection is drained under a hard total deadline: long
+# enough that a sender whose body is still in flight sees the status line
+# rather than an RST, short enough that a stalled sender cannot hold the
+# handler thread. A client waiting on the response never closes first, so this
+# is paid in full on every malformed request -- measured on loopback, a purely
+# non-blocking drain lost the 400 to a reset on 31 of 200 requests while any
+# nonzero deadline delivered all 200, hence a small one rather than none.
+# Bytes are bounded by the body cap as usual.
+_BAD_FRAMING_DRAIN_SECONDS = 0.05
 
 
 def _escape_label(value: str) -> str:
@@ -401,16 +416,24 @@ def make_handler(
             self._respond_text(200, body, PROMETHEUS_CONTENT_TYPE)
 
         def do_POST(self) -> None:  # noqa: N802 - http.server naming
+            length = self._content_length()
+            if length is None:
+                # Framing is unusable, so this has to be settled before auth
+                # or routing: every branch below reads or drains the body,
+                # and none of them can know where it ends. Answering 400 up
+                # front leaks nothing an unauthenticated caller could not
+                # already tell from the header it sent itself (issue #129).
+                self._reject_bad_content_length()
+                return
             if not self._authorized():
                 # Drain the declared body before replying: closing a
                 # connection that still has unread inbound data makes the
                 # kernel send RST and the sender can lose the 401 response
                 # entirely (same rationale as the over-cap drain, #121;
                 # observed over TLS where close timing shifts the race).
-                self._discard_overcap_body(int(self.headers.get("Content-Length") or 0))
+                self._discard_overcap_body(length)
                 self._respond(401, {"error": "unauthorized"})
                 return
-            length = int(self.headers.get("Content-Length") or 0)
             if length > self.snagline_max_body:
                 # Consume the over-cap body first: closing with megabytes
                 # unread makes the peer see EPIPE/reset instead of the 413
@@ -427,7 +450,7 @@ def make_handler(
             elif self.path == "/risks":
                 self._post_risks()
             else:
-                self._discard_overcap_body(int(self.headers.get("Content-Length") or 0))
+                self._discard_overcap_body(length)
                 self._respond(404, {"error": "not found"})
 
         def _post_risks(self) -> None:
@@ -581,6 +604,81 @@ def make_handler(
                 },
             )
 
+        def _content_length(self) -> int | None:
+            """Parse ``Content-Length``, or None when the value is unusable.
+
+            A missing or empty header means "no body" and yields 0, which is
+            the right reading for every endpoint here: they all treat an
+            absent body as an empty one and answer 400 on the failed JSON
+            parse that follows.
+
+            A header that is present but malformed -- ``abc``, ``0x10``, a
+            negative number -- has no such reading. Left to ``int()`` it
+            raised straight out of the handler into ``socketserver``, which
+            printed a traceback per request and dropped the connection, so
+            the client got an empty reply instead of a status line; negative
+            values reached ``rfile.read(-n)`` and failed there instead
+            (issue #129). Callers turn None into a 400 without touching the
+            body.
+            """
+            raw = self.headers.get("Content-Length")
+            if raw is None or not raw.strip():
+                return 0
+            try:
+                length = int(raw)
+            except ValueError:
+                return None
+            return length if length >= 0 else None
+
+        def _reject_bad_content_length(self) -> None:
+            """Answer 400 for unparseable framing and close the connection.
+
+            The body is never interpreted: its extent is unknown, so bytes
+            left in the socket would be misread as the next request line on
+            a reused connection. Closing is the only safe resynchronization,
+            and the drain below only exists so the peer actually receives the
+            400 before that close (see ``_drain_unknown_body``).
+            """
+            self.close_connection = True
+            self._respond(400, {"error": "invalid Content-Length"})
+            self._drain_unknown_body()
+
+        def _drain_unknown_body(self) -> None:
+            """Discard whatever the sender wrote, bounded in bytes and time.
+
+            Closing with unread inbound data makes the kernel answer with RST
+            and the 400 just written is discarded along with it, so the client
+            sees an empty reply -- the very symptom being fixed. #121 handles
+            this by draining the declared length, which is not available here,
+            so the read is bounded by ``_BAD_FRAMING_DRAIN_SECONDS`` of wall
+            clock instead. Reading the raw connection rather than ``rfile``
+            keeps this to the kernel buffer, which is what triggers the reset;
+            anything already buffered by the header parse is harmless.
+
+            Entirely best-effort: the response is on the wire before this
+            runs, so every failure mode just ends the drain.
+            """
+            connection = self.connection
+            previous_timeout = connection.gettimeout()
+            remaining = self.snagline_max_body + _MAX_OVERCAP_DRAIN_EXCESS
+            deadline = time.monotonic() + _BAD_FRAMING_DRAIN_SECONDS
+            try:
+                self.wfile.flush()
+                while remaining > 0:
+                    budget = deadline - time.monotonic()
+                    if budget <= 0:
+                        return
+                    connection.settimeout(budget)
+                    chunk = connection.recv(min(remaining, _DRAIN_CHUNK_BYTES))
+                    if not chunk:
+                        return  # peer hung up: nothing left to reset over
+                    remaining -= len(chunk)
+            except (OSError, ValueError):
+                logger.debug("snagline: bad-framing drain ended early", exc_info=True)
+            finally:
+                with contextlib.suppress(OSError):
+                    connection.settimeout(previous_timeout)
+
         def _discard_overcap_body(self, declared_length: int) -> None:
             """Read and throw away an over-cap body before replying 413.
 
@@ -609,7 +707,12 @@ def make_handler(
                 remaining -= len(chunk)
 
         def _read_body(self) -> bytes:
-            length = int(self.headers.get("Content-Length") or 0)
+            length = self._content_length()
+            if length is None:
+                # Unreachable through do_POST, which rejects bad framing
+                # before routing; belt-and-braces so a future caller cannot
+                # reintroduce the ValueError escape of issue #129.
+                return b""
             return self.rfile.read(length)
 
         def _respond(self, code: int, payload: dict) -> None:

--- a/tests/server/test_content_length_400.py
+++ b/tests/server/test_content_length_400.py
@@ -1,0 +1,306 @@
+"""Malformed ``Content-Length`` must become a 400, not a traceback (#129).
+
+``int(self.headers.get("Content-Length") or 0)`` raised inside ``do_POST``,
+so ``socketserver`` printed a full traceback per bad request and dropped the
+connection: the client saw an empty reply (or a reset, for negative values
+that reached ``rfile.read(-n)``) instead of a status line, and a repeating
+sender produced unbounded server-side log noise. These tests pin the
+remedy -- a clean 400 on the wire, no exception escaping the handler, and
+the well-formed and absent-header paths left untouched.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+import types
+
+from snagline.monitor import Monitor
+from snagline.server import http_server
+from snagline.server.http_server import (
+    _BAD_FRAMING_DRAIN_SECONDS,
+    _DRAIN_CHUNK_BYTES,
+    _MAX_OVERCAP_DRAIN_EXCESS,
+    make_handler,
+    make_server,
+)
+
+
+def _start(**kwargs):
+    server = make_server(Monitor([], []), host="127.0.0.1", port=0, **kwargs)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def _post_raw(port: int, header_value: str | None, body: bytes, path: str = "/events"):
+    """Send one POST with a verbatim Content-Length header, return the reply.
+
+    The header is written by hand rather than through a client library
+    precisely because no client library will emit an invalid one.
+    """
+    sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+    try:
+        head = f"POST {path} HTTP/1.0\r\nHost: localhost\r\n"
+        if header_value is not None:
+            head += f"Content-Length: {header_value}\r\n"
+        head += "\r\n"
+        sock.sendall(head.encode())
+        if body:
+            sock.sendall(body)
+        chunks: list[bytes] = []
+        while True:
+            data = sock.recv(65536)
+            if not data:
+                break
+            chunks.append(data)
+        return b"".join(chunks)
+    finally:
+        sock.close()
+
+
+def test_non_numeric_content_length_gets_400():
+    server, port = _start()
+    try:
+        response = _post_raw(port, "abc", b'{"step_id": "1"}')
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 400"), response[:120]
+    assert b"invalid Content-Length" in response
+
+
+def test_negative_content_length_gets_400():
+    """Negatives never reach ``rfile.read(-n)``, which raises its own error."""
+    server, port = _start()
+    try:
+        response = _post_raw(port, "-5", b'{"step_id": "1"}')
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 400"), response[:120]
+    assert b"invalid Content-Length" in response
+
+
+def test_bad_content_length_is_rejected_before_auth_and_routing():
+    """Framing is settled first: no drain, no route dispatch, no 401/404.
+
+    Every later branch reads or drains the body, and none of them can know
+    where an unparseable body ends -- so an authenticated sidecar and an
+    unknown path both still answer 400 here.
+    """
+    server, port = _start(auth_token="secret")
+    try:
+        unauthorized = _post_raw(port, "abc", b"")
+        unknown_path = _post_raw(port, "abc", b"", path="/nope")
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert unauthorized.startswith(b"HTTP/1.0 400"), unauthorized[:120]
+    assert b"unauthorized" not in unauthorized
+    assert unknown_path.startswith(b"HTTP/1.0 400"), unknown_path[:120]
+
+
+def test_no_traceback_escapes_the_handler(capfd):
+    """socketserver prints to stderr when a handler raises; it must not."""
+    server, port = _start()
+    try:
+        for value in ("abc", "0x10", "-5", "1e3", "1 2"):
+            response = _post_raw(port, value, b"x")
+            assert response.startswith(b"HTTP/1.0 400"), (value, response[:120])
+    finally:
+        server.shutdown()
+        server.server_close()
+    captured = capfd.readouterr()
+    assert "Traceback" not in captured.err, captured.err
+    assert "ValueError" not in captured.err, captured.err
+
+
+def test_absent_content_length_still_reads_as_empty_body():
+    """No header means length 0, so /events answers on the JSON parse."""
+    server, port = _start()
+    try:
+        response = _post_raw(port, None, b"")
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 400"), response[:120]
+    assert b"invalid StepEvent JSON" in response
+
+
+def test_well_formed_content_length_is_unaffected():
+    event = {
+        "step_id": "0",
+        "episode_id": "ep-cl",
+        "timestamp": 1718300000.0,
+        "action_type": "tool_call",
+        "action_signature": "aaaa1111bbbb2222",
+    }
+    raw = json.dumps(event).encode()
+    server, port = _start()
+    try:
+        response = _post_raw(port, str(len(raw)), raw)
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 202"), response[:120]
+    assert b'"status": "ingested"' in response
+
+
+def test_content_length_helper_classifies_values():
+    """Unit-level table for the shared parse helper."""
+    handler_cls = make_handler(Monitor([], []))
+
+    def parse(value):
+        headers = {} if value is None else {"Content-Length": value}
+        fake = types.SimpleNamespace(headers=headers)
+        return handler_cls._content_length(fake)
+
+    assert parse(None) == 0  # absent header: no body
+    assert parse("") == 0
+    assert parse("   ") == 0
+    assert parse("0") == 0
+    assert parse("42") == 42
+    assert parse(" 42 ") == 42  # int() tolerates surrounding whitespace
+    assert parse("abc") is None
+    assert parse("0x10") is None
+    assert parse("1e3") is None
+    assert parse("-1") is None  # would otherwise become read(-1): read to EOF
+
+
+def test_read_body_returns_empty_on_unusable_length():
+    """The shared helper keeps _read_body from raising if reached directly."""
+    handler_cls = make_handler(Monitor([], []))
+
+    class _Unused:
+        def read(self, n: int) -> bytes:  # pragma: no cover - must not be called
+            raise AssertionError("body must not be read for bad framing")
+
+    fake = types.SimpleNamespace(headers={"Content-Length": "abc"}, rfile=_Unused())
+    fake._content_length = lambda: handler_cls._content_length(fake)
+    assert handler_cls._read_body(fake) == b""
+
+
+def test_bad_framing_drain_releases_a_stalled_sender():
+    """The drain is time-bounded: a silent sender cannot pin the handler.
+
+    Nothing is written after the headers, so there is no body for the drain
+    to find; the handler must still finish within the deadline (plus slack
+    for scheduling) rather than blocking on a read that never completes.
+    """
+    server, port = _start()
+    try:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        try:
+            sock.sendall(
+                b"POST /events HTTP/1.0\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: abc\r\n"
+                b"\r\n"
+            )
+            started = time.perf_counter()
+            chunks: list[bytes] = []
+            while True:
+                data = sock.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+            elapsed = time.perf_counter() - started
+            response = b"".join(chunks)
+        finally:
+            sock.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 400"), response[:120]
+    # Generous ceiling: the point is that it is bounded at all, not the exact
+    # figure, which is why the assertion is not a tight one (CI runners are
+    # noisy).
+    assert elapsed < _BAD_FRAMING_DRAIN_SECONDS + 5.0, elapsed
+
+
+def test_bad_framing_drain_is_byte_bounded_and_error_tolerant():
+    """Unit level: the drain stops at the cap and swallows socket errors."""
+    handler_cls = make_handler(Monitor([], []), max_body_bytes=1_000)
+    budget = 1_000 + _MAX_OVERCAP_DRAIN_EXCESS
+
+    class _EndlessConnection:
+        def __init__(self) -> None:
+            self.consumed = 0
+            self.reads: list[int] = []
+            self.timeouts: list[float | None] = []
+
+        def gettimeout(self) -> float | None:
+            return None
+
+        def settimeout(self, value: float | None) -> None:
+            self.timeouts.append(value)
+
+        def recv(self, n: int) -> bytes:
+            self.reads.append(n)
+            self.consumed += n
+            return b"x" * n
+
+    connection = _EndlessConnection()
+    fake = types.SimpleNamespace(
+        connection=connection,
+        wfile=types.SimpleNamespace(flush=lambda: None),
+        snagline_max_body=1_000,
+    )
+    handler_cls._drain_unknown_body(fake)
+    assert connection.consumed == budget
+    assert max(connection.reads) <= _DRAIN_CHUNK_BYTES
+    assert connection.timeouts[-1] is None  # original timeout restored
+
+    class _ResetConnection(_EndlessConnection):
+        def recv(self, n: int) -> bytes:
+            raise ConnectionResetError("peer reset before the 400 was read")
+
+    connection = _ResetConnection()
+    fake = types.SimpleNamespace(
+        connection=connection,
+        wfile=types.SimpleNamespace(flush=lambda: None),
+        snagline_max_body=1_000,
+    )
+    handler_cls._drain_unknown_body(fake)  # must not raise
+    assert connection.timeouts[-1] is None
+
+
+def test_bad_framing_drain_stops_on_hangup_and_on_a_spent_deadline(monkeypatch):
+    """The two quiet exits: peer EOF, and the wall-clock budget running out."""
+    handler_cls = make_handler(Monitor([], []), max_body_bytes=1_000)
+
+    class _Connection:
+        def __init__(self, chunks):
+            self.chunks = list(chunks)
+            self.timeouts: list[float | None] = []
+
+        def gettimeout(self) -> float | None:
+            return 7.5  # a distinctive prior value, to prove it is restored
+
+        def settimeout(self, value: float | None) -> None:
+            self.timeouts.append(value)
+
+        def recv(self, n: int) -> bytes:
+            return self.chunks.pop(0) if self.chunks else b""
+
+    def drain(connection):
+        fake = types.SimpleNamespace(
+            connection=connection,
+            wfile=types.SimpleNamespace(flush=lambda: None),
+            snagline_max_body=1_000,
+        )
+        handler_cls._drain_unknown_body(fake)
+
+    hung_up = _Connection([b"partial", b""])
+    drain(hung_up)  # stops at EOF well inside both budgets
+    assert hung_up.timeouts[-1] == 7.5
+
+    # A zero-length deadline: the loop must give up before its first recv
+    # rather than reading with a non-positive timeout.
+    monkeypatch.setattr(http_server, "_BAD_FRAMING_DRAIN_SECONDS", 0.0)
+    spent = _Connection([b"x" * _DRAIN_CHUNK_BYTES])
+    drain(spent)
+    assert spent.timeouts == [7.5]  # restore only: no read timeout was ever set

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -162,6 +162,43 @@ def test_plaintext_probe_is_not_served_and_server_survives(tmp_path):
 
 
 @requires_openssl
+def test_malformed_content_length_gets_400_over_tls(tmp_path):
+    """The #129 400 path also works when ``self.connection`` is an SSLSocket.
+
+    Worth pinning separately: the bad-framing drain reads and re-times the
+    raw connection object, which is a wrapped socket on this listener, and
+    no client library will emit an invalid Content-Length for us.
+    """
+    server, _ = _start_tls_server(tmp_path)
+    host, port = server.server_address[0], server.server_address[1]
+    try:
+        raw = socket.create_connection((host, port), timeout=10)
+        client = _insecure_client_context().wrap_socket(raw)
+        try:
+            client.sendall(
+                b"POST /events HTTP/1.0\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: abc\r\n"
+                b"\r\n"
+            )
+            client.sendall(b"x")  # unread body: the reset race the drain covers
+            chunks = []
+            while True:
+                data = client.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+            reply = b"".join(chunks)
+        finally:
+            client.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert reply.startswith(b"HTTP/1.0 400"), reply[:120]
+    assert b"invalid Content-Length" in reply
+
+
+@requires_openssl
 def test_make_server_accepts_ready_ssl_context(tmp_path):
     certfile, keyfile = _generate_self_signed_cert(tmp_path)
     context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)


### PR DESCRIPTION
Fixes #129.

## Summary of Changes

`do_POST` and `_read_body` both parsed the request length with a bare
`int(self.headers.get("Content-Length") or 0)`. Both now go through one
helper, `_content_length()`, which returns `0` for an absent header (the
existing reading, unchanged) and `None` for anything unusable. `do_POST`
resolves framing before auth and routing and answers
`400 {"error": "invalid Content-Length"}` with the connection closed.

Two values were broken, not one:

| `Content-Length` | before | after |
| --- | --- | --- |
| `abc`, `0x10`, `1e3` | `ValueError` in `do_POST`, traceback, empty reply | `400` |
| `-5` | passed the cap check, then `ValueError` in `rfile.read(-5)`, RST | `400` |
| absent | length 0, empty body | unchanged |
| `42` | read 42 bytes | unchanged |

Verified on upstream/master (`6a2757a`) before the fix, on an ephemeral
loopback port:

```
non-numeric 'abc': b'<EMPTY REPLY>'
negative '-5':     recv raised ConnectionResetError: [Errno 54] Connection reset by peer
hex '0x10':        b'<EMPTY REPLY>'
```

and after:

```
non-numeric 'abc': b'HTTP/1.0 400 Bad Request'
negative '-5':     b'HTTP/1.0 400 Bad Request'
hex '0x10':        b'HTTP/1.0 400 Bad Request'
```

### Two judgement calls worth reviewing

**Framing is settled before the auth check.** Every branch after it either
reads or drains the body, and none of them can know where an unparseable
body ends, so the 401 drain added in #121 would have been the next thing to
raise. The 400 reveals nothing an unauthenticated caller could not infer
from the header it sent itself, and path probing stays behind the token: an
unknown path with bad framing gets 400, never 404. Both are pinned by
`test_bad_content_length_is_rejected_before_auth_and_routing`.

**The 400 needs a bounded drain to actually arrive.** Closing with unread
inbound data makes the kernel answer RST, which discards the response the
client had not read yet -- exactly the race #121 solved for over-cap bodies
by draining the declared length. That length does not exist here, so
`_drain_unknown_body` bounds the read by wall clock instead
(`_BAD_FRAMING_DRAIN_SECONDS = 0.05`) plus the usual byte cap, reads the raw
connection so only the kernel buffer is touched, restores the previous
socket timeout, and treats every error as "stop". Measured on loopback,
200 requests per setting:

```
deadline=0.0    400-delivered=169/200  median=  0.09ms  p95=  0.13ms
deadline=0.005  400-delivered=200/200  median=  6.07ms  p95=  6.29ms
deadline=0.025  400-delivered=200/200  median= 26.69ms  p95= 27.00ms
deadline=0.05   400-delivered=200/200  median= 51.93ms  p95= 52.23ms
deadline=0.25   400-delivered=200/200  median=252.05ms  p95=252.37ms
```

A purely non-blocking drain loses the 400 roughly 15% of the time; any
nonzero deadline delivered all 200. A client waiting on the response never
closes first, so the deadline is paid in full on every malformed request --
50ms is the tradeoff picked between delivery and how long one bad sender
holds a handler thread. Easy to retune; it is a single module constant, and
the timing assertion in the tests is deliberately loose so CI noise cannot
make it flaky.

This is deliberately time-bounded only on this one path, via a timeout set
and restored inside the call, so it does not pre-empt or depend on #130.

## Justification

Any health checker, proxy, fuzzer, or buggy client emitting a non-numeric
length produced a full traceback per request (unbounded stderr noise under
repetition) and an opaque transport error client-side. It also contradicted
the fail-open spirit of the project: bad input should become a 400, not an
exception escaping into the server plumbing.

## Kind of Contribution

Bug Fix

## Unit Tests

`tests/server/test_content_length_400.py` (11 cases), following the
raw-socket style of `tests/server/test_413_drain.py` because no client
library will emit an invalid `Content-Length` for you:

- non-numeric and negative values each get a 400 status line on the wire
- bad framing is resolved before auth and before routing (401 and 404 paths)
- `capfd` asserts no `Traceback` or `ValueError` reaches stderr across
  `abc`, `0x10`, `-5`, `1e3`, `1 2`
- absent header still reads as an empty body; a well-formed length still
  gets 202
- helper table for the classification, including `" 42 "` and `-1`
- `_read_body` returns `b""` rather than raising if ever reached directly
- the drain: byte bound, chunk size, timeout restored, peer hangup, spent
  deadline, and a mid-drain `ConnectionResetError`

`tests/test_server_tls.py` gains `test_malformed_content_length_gets_400_over_tls`,
since the drain re-times `self.connection`, which is an `SSLSocket` on that
listener.

## Execution Tests

```
ruff check src tests                -> All checks passed!
ruff format --check src tests        -> 122 files already formatted
mypy src                            -> Success: no issues found in 55 source files
python -m pytest tests/ -q          -> 634 passed, 2 skipped
                                       coverage 88.99% (gate 80%)
```

`http_server.py` coverage 88% -> 89%; every line added here is covered.

Local note, unrelated to this change: six `tests/test_server_tls.py` cases
that use `urllib` fail on my machine because a system HTTP proxy intercepts
`urlopen`. They fail identically on a clean `upstream/master` checkout, and
all pass with `no_proxy='*'`; the counts above are from that run.

## Docs

One bullet in the `docs/ATTACH_ANY_SYSTEM.md` hardening checklist, next to
the existing `--max-body-bytes`/413 bullet, plus the module docstring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
