### PR TITLE
feat(server): bound sidecar connection reads so a stalled sender cannot pin a handler thread

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -342,6 +342,17 @@ them is purely operational.
   oversized payloads are dropped at the edge instead of consuming sidecar
   memory and CPU. The cap exists to bound per-request memory while still
   admitting batched `StepEvent` arrays.
+- **Leave the read timeout on.** A sender that promises a large
+  `Content-Length`, writes a few bytes and goes quiet would otherwise hold one
+  handler thread for as long as it likes -- slowloris-style retention, and the
+  body-size cap does not help because the bytes never arrive.
+  `--read-timeout` (default 30, or `$SNAGLINE_SERVE_READ_TIMEOUT_S`) bounds
+  how long any single read may wait before the connection is dropped and its
+  thread released. The budget is per read, not per request, so a slow client
+  that keeps making progress is still served. Raise it if you genuinely have
+  senders slower than that; `0` restores the old unbounded behavior. With TLS
+  terminated in the sidecar the same budget also bounds the handshake, which
+  a silent peer could otherwise stall indefinitely.
 - **Remember nothing sensitive is retained.** Events carry hashes, timings,
   counts, and booleans, never prompt or response content. `GET /risks`
   retains the most recent 1000 `FailureRisk` records (ids, scores, trigger

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -305,6 +305,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "[default: 1000].",
     )
     p_serve.add_argument(
+        "--read-timeout",
+        type=float,
+        default=None,
+        help="Seconds any single read on a connection may wait before the "
+        "sidecar drops it, so a stalled sender cannot pin a handler thread "
+        "(issue #130). Falls back to $SNAGLINE_SERVE_READ_TIMEOUT_S, then 30. "
+        "Use 0 to wait indefinitely.",
+    )
+    p_serve.add_argument(
         "--sink",
         choices=["console", "webhook", "slack", "pagerduty"],
         default="console",
@@ -849,6 +858,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             auth_token=auth_token,
             max_body_bytes=args.max_body_bytes,
             max_risks=args.max_risks,
+            read_timeout=args.read_timeout,
             **tls_kwargs,
         )
     return 0

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -334,6 +334,19 @@ class Config:
     # ?format=prometheus; environment override SNAGLINE_METRICS_FORMAT.
     metrics_format: str = "prometheus"
 
+    # --- Sidecar socket read timeout (issue #130) ----------------------------
+    # How long one sidecar connection may go without producing the bytes it
+    # promised before the server drops it. Without a timeout every
+    # ``rfile.read(n)`` blocks until exactly n bytes arrive, so a client that
+    # declares ``Content-Length: 500000`` and then sends seven bytes holds a
+    # handler thread of the ThreadingHTTPServer for as long as it likes --
+    # slowloris-style resource retention against the sidecar. Applies per read,
+    # not per request, so a genuinely slow sender that keeps making progress is
+    # never cut off; the ceiling is deliberately generous for that reason.
+    # Values <= 0 restore the pre-#130 unbounded behavior for anyone who needs
+    # it. Environment override SNAGLINE_SERVE_READ_TIMEOUT_S.
+    serve_read_timeout_s: float = 30.0
+
     # --- Enforcement policy (issue #93) ---------------------------------------
     # Optional escalation layer that runs AFTER the sinks on every dispatched
     # risk (documented ordering: detectors -> sinks -> policy). "observe" (the

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -20,6 +20,14 @@ POST bodies are capped at ``max_body_bytes`` (default 1 MB); larger payloads
 get 413. This keeps the sidecar safe to expose and able to absorb buffered
 telemetry from any host.
 
+Every accepted connection also carries a read timeout (issue #130):
+``read_timeout=`` seconds, or ``SNAGLINE_SERVE_READ_TIMEOUT_S``, defaulting to
+30. Without it a client could declare ``Content-Length: 500000``, send seven
+bytes and go quiet, holding one handler thread of the ``ThreadingHTTPServer``
+indefinitely. The budget applies per read rather than per request, so a slow
+sender that keeps making progress is never cut off; a sender that stops is
+dropped and its thread released. Pass a value at or below zero to disable.
+
 Optionally protect the endpoints with a shared secret by passing
 ``auth_token=`` to ``make_server``/``serve``. When set, requests must carry the
 token via ``Authorization: Bearer <token>`` or ``X-Snagline-Token: <token>``;
@@ -59,6 +67,7 @@ one-way telemetry, and callers should not block on detection results.
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import math
@@ -68,7 +77,7 @@ import threading
 import time
 from collections import OrderedDict, deque
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any
+from typing import Any, ClassVar
 from urllib.parse import parse_qs, urlsplit
 
 from snagline.adapters.claude_code import HookTracker, ingest_payload
@@ -111,6 +120,41 @@ def _format_sample_value(value: float | int) -> str:
     if math.isinf(number):
         return "+Inf" if number > 0 else "-Inf"
     return repr(float(value))
+
+
+def _resolve_read_timeout(explicit: float | None) -> float | None:
+    """Pick the socket read timeout for sidecar connections (issue #130).
+
+    Precedence mirrors ``_resolve_metrics_format``: explicit argument, then
+    SNAGLINE_SERVE_READ_TIMEOUT_S via Config, then the built-in Config
+    default. A value at or below zero means "no timeout" and returns None,
+    which restores the pre-#130 behavior of blocking until the promised bytes
+    arrive; unusable values are logged and fall back to the default rather
+    than taking the sidecar down (fail-open).
+    """
+    candidate = explicit
+    if candidate is None:
+        try:
+            candidate = Config.from_env_overrides().get("serve_read_timeout_s")
+        except Exception:
+            logger.debug(
+                "snagline: env lookup for serve_read_timeout_s failed", exc_info=True
+            )
+            candidate = None
+    if candidate is None:
+        candidate = Config().serve_read_timeout_s
+    try:
+        seconds = float(candidate)
+    except (TypeError, ValueError):
+        logger.warning(
+            "snagline: unusable read timeout %r; using %ss",
+            candidate,
+            Config().serve_read_timeout_s,
+        )
+        seconds = Config().serve_read_timeout_s
+    if seconds <= 0 or math.isnan(seconds):
+        return None  # explicitly disabled
+    return seconds
 
 
 def _resolve_metrics_format(explicit: str | None) -> str:
@@ -326,12 +370,22 @@ def make_handler(
     max_body_bytes: int = 1_000_000,
     max_risks: int = 1000,
     metrics_format: str | None = None,
+    read_timeout: float | None = None,
 ) -> type[BaseHTTPRequestHandler]:
     """Build a request-handler class bound to ``monitor``.
 
     ``metrics_format`` pins the default GET /metrics body; when omitted the
     SNAGLINE_METRICS_FORMAT environment variable decides, then the built-in
     "prometheus" default (see ``_resolve_metrics_format``).
+
+    ``read_timeout`` is the per-read socket timeout applied to every accepted
+    connection (issue #130); when omitted SNAGLINE_SERVE_READ_TIMEOUT_S
+    decides, then the 30s Config default. Pass a value at or below zero to
+    disable it. Assigning ``timeout`` on the handler class is all that is
+    needed: stdlib ``StreamRequestHandler.setup`` puts it on the connection
+    and ``handle_one_request`` already turns the resulting TimeoutError --
+    from the request line or from a body read inside ``do_POST`` alike -- into
+    a logged message plus a closed connection.
     """
     tracker = HookTracker()
 
@@ -344,6 +398,11 @@ def make_handler(
         snagline_max_body: int = 1_000_000
         snagline_collector: Any = None
         snagline_metrics_format: str = "prometheus"
+        # Read timeout for this connection, applied by StreamRequestHandler.
+        # setup(); None keeps the stdlib default of blocking forever (#130).
+        # ClassVar to match the base declaration: this is set once on the
+        # class below, never per instance.
+        timeout: ClassVar[float | None] = None
 
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
             # Route http.server's access log through logging, not stderr raw.
@@ -638,6 +697,7 @@ def make_handler(
     _Handler.snagline_collector = SidecarMetricsCollector()
     _attach_metrics_collector(monitor, _Handler.snagline_collector)
     _Handler.snagline_metrics_format = _resolve_metrics_format(metrics_format)
+    _Handler.timeout = _resolve_read_timeout(read_timeout)
     return _Handler
 
 
@@ -685,20 +745,31 @@ class _TLSThreadingHTTPServer(ThreadingHTTPServer):
         self,
         *args: Any,
         snagline_ssl_context: ssl.SSLContext,
+        snagline_handshake_timeout: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
         self.snagline_ssl_context = snagline_ssl_context
+        self.snagline_handshake_timeout = snagline_handshake_timeout
 
     def finish_request(self, request: Any, client_address: Any) -> None:
+        # The handler's read timeout cannot cover the handshake: setup() only
+        # runs once the connection is wrapped. So bound it here too, or a peer
+        # that opens a socket and never speaks TLS holds this worker thread
+        # forever -- the same retention #130 closes for body reads. Cleared
+        # afterwards so setup() applies the handler timeout as usual.
+        if self.snagline_handshake_timeout is not None:
+            with contextlib.suppress(OSError):
+                request.settimeout(self.snagline_handshake_timeout)
         try:
             tls_request = self.snagline_ssl_context.wrap_socket(
                 request, server_side=True
             )
         except (ssl.SSLError, OSError):
             # Failed handshake (plaintext probe against the TLS port, port
-            # scan, stale client): drop this one connection and keep serving.
-            # Fail-open per project.md §1.2; never surface as a serving error.
+            # scan, stale client, or a handshake that outran the timeout
+            # above): drop this one connection and keep serving. Fail-open
+            # per project.md §1.2; never surface as a serving error.
             logger.debug(
                 "snagline sidecar: TLS handshake failed from %s:%s",
                 client_address[0],
@@ -706,6 +777,8 @@ class _TLSThreadingHTTPServer(ThreadingHTTPServer):
                 exc_info=True,
             )
             return
+        with contextlib.suppress(OSError):
+            tls_request.settimeout(None)
         # Annotated locally: typeshed binds this call's server parameter to
         # Self, which the subclass indirection here trips over.
         handler_class: Any = self.RequestHandlerClass
@@ -723,6 +796,7 @@ def make_server(
     ssl_context: ssl.SSLContext | None = None,
     certfile: str | None = None,
     keyfile: str | None = None,
+    read_timeout: float | None = None,
 ) -> ThreadingHTTPServer:
     """Construct a ready-to-``serve_forever()`` sidecar server.
 
@@ -730,15 +804,27 @@ def make_server(
     HTTPS directly (issue #120): connections are wrapped server-side via
     stdlib ``ssl`` with the handshake running on each connection's own
     worker thread. Without them the server is plain HTTP, exactly as before.
+
+    ``read_timeout`` bounds how long any single read on an accepted
+    connection may wait (issue #130); see ``make_handler`` for how it is
+    resolved. On a TLS listener the same budget also bounds the handshake,
+    which runs before the handler exists and so cannot be covered by the
+    handler's own timeout.
     """
     tls_context = _resolve_ssl_context(ssl_context, certfile, keyfile)
     handler = make_handler(
-        monitor, auth_token, max_body_bytes, max_risks, metrics_format
+        monitor, auth_token, max_body_bytes, max_risks, metrics_format, read_timeout
     )
     if tls_context is None:
         return ThreadingHTTPServer((host, port), handler)
     return _TLSThreadingHTTPServer(
-        (host, port), handler, snagline_ssl_context=tls_context
+        (host, port),
+        handler,
+        snagline_ssl_context=tls_context,
+        # Read back the value make_handler resolved rather than resolving a
+        # second time, so the handshake and the request share one budget even
+        # when it came from the environment.
+        snagline_handshake_timeout=handler.timeout,
     )
 
 
@@ -753,6 +839,7 @@ def serve(
     ssl_context: ssl.SSLContext | None = None,
     certfile: str | None = None,
     keyfile: str | None = None,
+    read_timeout: float | None = None,
 ) -> None:
     """Run the sidecar server in the foreground until interrupted."""
     tls_enabled = ssl_context is not None or certfile is not None
@@ -767,6 +854,7 @@ def serve(
         ssl_context,
         certfile,
         keyfile,
+        read_timeout,
     )
     logger.info(
         "snagline sidecar listening on %s://%s:%d (POST /events, GET /health)%s",

--- a/tests/server/test_read_timeout.py
+++ b/tests/server/test_read_timeout.py
@@ -1,0 +1,171 @@
+"""A stalled sender must not pin a sidecar handler thread (#130).
+
+``BaseHTTPRequestHandler`` inherits ``timeout = None``, so before this every
+``rfile.read(n)`` blocked until exactly n bytes arrived or the peer closed. A
+client could declare ``Content-Length: 500000``, write seven bytes and go
+quiet, holding one thread of the ``ThreadingHTTPServer`` for as long as it
+liked -- slowloris-style retention, repeatable from many connections. These
+tests pin the remedy: the connection is dropped and its thread released
+within the budget, senders that keep making progress are still served, and
+the knob resolves from argument, environment and default in that order.
+"""
+
+from __future__ import annotations
+
+import json
+import socket
+import threading
+import time
+
+from snagline.config import Config
+from snagline.monitor import Monitor
+from snagline.server.http_server import _resolve_read_timeout, make_handler, make_server
+
+_EVENT = {
+    "step_id": "0",
+    "episode_id": "ep-timeout",
+    "timestamp": 1718300000.0,
+    "action_type": "tool_call",
+    "action_signature": "aaaa1111bbbb2222",
+}
+
+
+def _start(**kwargs):
+    server = make_server(Monitor([], []), host="127.0.0.1", port=0, **kwargs)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def _head(length: int) -> bytes:
+    return (
+        "POST /events HTTP/1.0\r\n"
+        "Host: localhost\r\n"
+        "Content-Type: application/json\r\n"
+        f"Content-Length: {length}\r\n"
+        "\r\n"
+    ).encode()
+
+
+def test_stalled_sender_is_dropped_and_its_thread_released():
+    """The core regression: declare a big body, send a little, go silent."""
+    server, port = _start(read_timeout=0.5)
+    baseline = threading.active_count()
+    try:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        try:
+            sock.sendall(_head(500_000))
+            sock.sendall(b'{"a":1}')  # 7 bytes of a 500 KB promise, then quiet
+            started = time.perf_counter()
+            # The server closing its side is what ends this recv; before the
+            # fix it blocked until the client's own timeout instead.
+            leftover = sock.recv(65536)
+            elapsed = time.perf_counter() - started
+        finally:
+            sock.close()
+        assert leftover == b"", leftover  # closed, not answered
+        assert elapsed < 10.0  # the client timeout never had to fire
+        # Poll rather than sleep a fixed amount: the handler is torn down just
+        # after the socket closes, and CI schedulers are not prompt.
+        deadline = time.perf_counter() + 10.0
+        while threading.active_count() > baseline and time.perf_counter() < deadline:
+            time.sleep(0.02)
+        assert threading.active_count() <= baseline, "handler thread was not released"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_a_slow_but_progressing_sender_is_still_served():
+    """The budget is per read, so trickling a body over longer is fine.
+
+    Total transfer time here exceeds the timeout several times over; what
+    matters is that no single read waits that long.
+    """
+    raw = json.dumps(_EVENT).encode()
+    server, port = _start(read_timeout=0.3)
+    try:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        try:
+            sock.sendall(_head(len(raw)))
+            for index in range(0, len(raw), 16):
+                sock.sendall(raw[index : index + 16])
+                time.sleep(0.01)  # steady progress, well inside the budget
+            chunks: list[bytes] = []
+            while True:
+                data = sock.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+            response = b"".join(chunks)
+        finally:
+            sock.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 202"), response[:120]
+    assert b'"status": "ingested"' in response
+
+
+def test_well_formed_requests_are_unaffected_by_the_default_timeout():
+    raw = json.dumps(_EVENT).encode()
+    server, port = _start()  # default budget, nothing passed
+    try:
+        sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+        try:
+            sock.sendall(_head(len(raw)))
+            sock.sendall(raw)
+            chunks: list[bytes] = []
+            while True:
+                data = sock.recv(65536)
+                if not data:
+                    break
+                chunks.append(data)
+            response = b"".join(chunks)
+        finally:
+            sock.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    assert response.startswith(b"HTTP/1.0 202"), response[:120]
+
+
+def test_handler_class_carries_the_resolved_timeout():
+    assert make_handler(Monitor([], [])).timeout == Config().serve_read_timeout_s
+    assert make_handler(Monitor([], []), read_timeout=2.5).timeout == 2.5
+    # At or below zero is the documented opt-out: back to blocking forever.
+    assert make_handler(Monitor([], []), read_timeout=0).timeout is None
+    assert make_handler(Monitor([], []), read_timeout=-1).timeout is None
+
+
+def test_resolve_read_timeout_precedence(monkeypatch):
+    monkeypatch.delenv("SNAGLINE_SERVE_READ_TIMEOUT_S", raising=False)
+    assert _resolve_read_timeout(None) == Config().serve_read_timeout_s
+    assert _resolve_read_timeout(12.0) == 12.0
+
+    monkeypatch.setenv("SNAGLINE_SERVE_READ_TIMEOUT_S", "1.5")
+    assert _resolve_read_timeout(None) == 1.5
+    assert _resolve_read_timeout(12.0) == 12.0  # explicit still wins
+    monkeypatch.setenv("SNAGLINE_SERVE_READ_TIMEOUT_S", "0")
+    assert _resolve_read_timeout(None) is None
+
+    # Unusable env values are ignored by Config.from_env_overrides, so the
+    # default stands: configuration must never take the sidecar down.
+    monkeypatch.setenv("SNAGLINE_SERVE_READ_TIMEOUT_S", "soon")
+    assert _resolve_read_timeout(None) == Config().serve_read_timeout_s
+
+
+def test_resolve_read_timeout_survives_unusable_arguments():
+    assert _resolve_read_timeout(float("nan")) is None
+    assert _resolve_read_timeout("also-not-a-number") == Config().serve_read_timeout_s
+
+
+def test_resolve_read_timeout_survives_a_broken_environment(monkeypatch):
+    """A failing env lookup must fall back, not take the sidecar down."""
+
+    def _explode(*args, **kwargs):
+        raise RuntimeError("environment unavailable")
+
+    monkeypatch.setattr(Config, "from_env_overrides", classmethod(_explode))
+    assert _resolve_read_timeout(None) == Config().serve_read_timeout_s
+    assert _resolve_read_timeout(4.0) == 4.0  # explicit never consults the env

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -234,11 +234,14 @@ def test_main_serve_starts_server(monkeypatch):
     monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
     assert main(["serve"]) == 0
     assert started.get("ok") == ("127.0.0.1", 8787)
-    # Defaults: no token, 1 MB body cap, 1000 retained risks.
+    # Defaults: no token, 1 MB body cap, 1000 retained risks, and read_timeout
+    # left unset so http_server resolves it from env then its 30s default
+    # (issue #130) -- the CLI does not duplicate that default.
     assert started["kwargs"] == {
         "auth_token": None,
         "max_body_bytes": 1_000_000,
         "max_risks": 1000,
+        "read_timeout": None,
     }
 
 
@@ -268,6 +271,20 @@ def test_main_serve_passes_auth_token_and_limits(monkeypatch):
     assert started["auth_token"] == "s3cret"
     assert started["max_body_bytes"] == 4096
     assert started["max_risks"] == 7
+
+
+def test_main_serve_passes_read_timeout(monkeypatch):
+    """--read-timeout must reach serve(), including the 0 opt-out (#130)."""
+    started: dict = {}
+
+    def _fake_serve(monitor, host="127.0.0.1", port=8787, **kwargs):
+        started.update(kwargs)
+
+    monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
+    assert main(["serve", "--read-timeout", "5"]) == 0
+    assert started["read_timeout"] == 5.0
+    assert main(["serve", "--read-timeout", "0"]) == 0
+    assert started["read_timeout"] == 0.0
 
 
 def test_main_serve_reads_auth_token_from_the_environment(monkeypatch):

--- a/tests/test_server_tls.py
+++ b/tests/test_server_tls.py
@@ -14,6 +14,7 @@ import socket
 import ssl
 import subprocess
 import threading
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -157,6 +158,56 @@ def test_plaintext_probe_is_not_served_and_server_survives(tmp_path):
         assert body == {"status": "ok"}
     finally:
         probe.close()
+        server.shutdown()
+        server.server_close()
+
+
+@requires_openssl
+def test_silent_peer_does_not_hold_a_tls_worker_thread(tmp_path):
+    """The read timeout also bounds the handshake (#130).
+
+    ``setup()`` runs only after the connection is wrapped, so the handler's
+    own timeout cannot cover ``wrap_socket``. A peer that opens a socket and
+    never sends a ClientHello would otherwise hold its worker thread for as
+    long as it liked -- the same retention #130 closes for body reads.
+    """
+    server, _ = _start_tls_server(tmp_path, read_timeout=0.5)
+    host, port = server.server_address[0], server.server_address[1]
+    baseline = threading.active_count()
+    try:
+        assert server.snagline_handshake_timeout == 0.5
+        probe = socket.create_connection((host, port), timeout=10)
+        try:
+            started = time.perf_counter()
+            leftover = probe.recv(1024)  # ends when the server gives up
+            elapsed = time.perf_counter() - started
+        finally:
+            probe.close()
+        assert leftover == b"", leftover
+        assert elapsed < 10.0  # the client timeout never had to fire
+        deadline = time.perf_counter() + 10.0
+        while threading.active_count() > baseline and time.perf_counter() < deadline:
+            time.sleep(0.02)
+        assert threading.active_count() <= baseline, "worker thread was not released"
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+@requires_openssl
+def test_tls_handshake_timeout_opt_out_still_serves(tmp_path):
+    """``read_timeout=0`` is the documented opt-out, TLS included (#130).
+
+    With no budget configured the handshake is left unbounded, exactly as it
+    was before, and normal clients are served as usual.
+    """
+    server, base = _start_tls_server(tmp_path, read_timeout=0)
+    try:
+        assert server.snagline_handshake_timeout is None
+        status, body = _request_tls("GET", base, "/health")
+        assert status == 200
+        assert body == {"status": "ok"}
+    finally:
         server.shutdown()
         server.server_close()
 


### PR DESCRIPTION
Fixes #130

## Summary of Changes

`BaseHTTPRequestHandler` inherits `timeout = None`, so every `rfile.read(n)` in
the sidecar blocked until exactly `n` bytes arrived or the peer closed. A client
could declare `Content-Length: 500000`, write seven bytes and go quiet, holding
one thread of the `ThreadingHTTPServer` for as long as it liked -- slowloris
retention, repeatable from many connections at once. `--max-body-bytes` does not
help: the cap is on bytes that arrive, and here they never do.

The remedy is to set the handler class's `timeout`. `socketserver` already
applies it in `setup()` via `connection.settimeout()`, and `handle_one_request`
already converts the resulting `TimeoutError` into a log line plus
`close_connection = True`, so the connection is dropped and its thread returned
to the pool. The budget is **per read, not per request**, so a slow sender that
keeps making progress is still served no matter how long the whole transfer
takes.

Reproduction against this branch, on an ephemeral loopback port: declare 500 KB,
send 7 bytes, then go silent. `read_timeout=0` is the documented opt-out, so
that row is the pre-fix behavior.

```
read_timeout=0.5   -> socket closed by server after 0.50s; handler threads still alive: 0
read_timeout=0     -> client gave up after 3.00s (TimeoutError); handler threads still alive: 1
```

Resolution mirrors the existing `_resolve_metrics_format`: explicit argument,
then `$SNAGLINE_SERVE_READ_TIMEOUT_S`, then the built-in 30s default.

| Surface | Behavior |
| --- | --- |
| `serve()` / `make_server()` / `make_handler()` | new `read_timeout` keyword |
| `snagline serve --read-timeout N` | new flag; `0` waits indefinitely |
| `$SNAGLINE_SERVE_READ_TIMEOUT_S` | free, via the new `Config.serve_read_timeout_s` field |
| default | 30.0 |
| `<= 0` or `NaN` | disabled, i.e. exactly the pre-#130 behavior |
| unusable value (`"soon"`, a non-number) | warn and fall back to 30.0 |
| failing env lookup | fall back silently to 30.0 |

Nothing raises out of the resolver. Configuration must never take the sidecar
down (project.md §1.2), so every bad input path ends at the default.

## One judgement call worth reviewing

**The same budget also bounds the TLS handshake**, which is one line beyond the
issue's literal ask and is flagged in-code as such. `setup()` runs only *after*
`_TLSThreadingHTTPServer.finish_request` wraps the socket, so the handler's own
timeout cannot cover `wrap_socket`. Without this, a peer that opens a TCP
connection and never sends a ClientHello holds its worker thread indefinitely --
the identical retention #130 closes for body reads, reachable on any sidecar
started with `--certfile`. The timeout is applied around `wrap_socket` and then
cleared, so the wrapped connection is handed to the handler in the same state it
was before and `setup()` applies the per-read budget as usual. When the budget is
disabled the handshake is left untouched.

## Justification

The sidecar is documented as safe to expose to a proxy and to absorb buffered
telemetry from any host, and `docs/ATTACH_ANY_SYSTEM.md` already tells operators
to keep the body-size caps in sync as a hardening step. A single unauthenticated
TCP connection that costs the sender nothing and costs the sidecar a thread until
it decides to leave undercuts that. Thread exhaustion is worse than a dropped
request: it takes ingestion down for every well-behaved agent on the box, and
the fail-open design means those agents lose monitoring silently.

The fix is deliberately the smallest one that holds. No new dependency, no
rewritten I/O path, no threading of state through the handler -- one class
attribute the stdlib was already built to honor, plus the config/CLI wiring
needed to tune it, and the opt-out for anyone whose senders really are slower
than 30s per read.

## Kind of Contribution

Bug Fix

## Unit Tests

New `tests/server/test_read_timeout.py` (7 tests):

- `test_stalled_sender_is_dropped_and_its_thread_released` -- the core
  regression. Declares 500 KB, sends 7 bytes, asserts the server closes the
  socket (`recv()` returns `b""`, well inside the client's own 10s timeout) and
  that `threading.active_count()` returns to its baseline. The thread assertion
  polls rather than sleeping a fixed amount, since CI schedulers are not prompt.
- `test_a_slow_but_progressing_sender_is_still_served` -- 16-byte chunks with
  10ms gaps under a 0.3s budget. Total transfer exceeds the timeout several times
  over and still gets 202, pinning that the budget is per read.
- `test_well_formed_requests_are_unaffected_by_the_default_timeout` -- nothing
  passed, ordinary POST, 202.
- `test_handler_class_carries_the_resolved_timeout` -- default, explicit `2.5`,
  and the `0` / `-1` opt-out mapping to `None`.
- `test_resolve_read_timeout_precedence` -- argument beats env beats default;
  `"0"` disables; `"soon"` falls back.
- `test_resolve_read_timeout_survives_unusable_arguments` -- `NaN` disables, a
  string falls back.
- `test_resolve_read_timeout_survives_a_broken_environment` -- a raising
  `Config.from_env_overrides` falls back instead of propagating.

`tests/test_server_tls.py` (2 added):

- `test_silent_peer_does_not_hold_a_tls_worker_thread` -- opens a socket to the
  TLS listener, never sends a ClientHello, asserts the server gives up and the
  worker thread is released.
- `test_tls_handshake_timeout_opt_out_still_serves` -- with `read_timeout=0` the
  handshake budget is `None` and HTTPS still works.

`tests/test_cli.py` (1 added, 1 updated):

- `test_main_serve_passes_read_timeout` -- `--read-timeout 5` reaches `serve()`
  as `5.0`, and `--read-timeout 0` as `0.0` rather than being dropped as falsy.
- `test_main_serve_starts_server` asserts the exact kwargs dict forwarded to
  `serve()`, so it gained `"read_timeout": None`. The CLI deliberately passes
  `None` instead of duplicating the 30s default, so the default lives in exactly
  one place; the updated assertion has a comment saying so.

Every line and branch added by this PR is covered, with one exception: the single
`read_timeout` forwarding argument inside `serve()`'s body. `serve()` runs
`serve_forever()`, so every test monkeypatches it and its whole body
(`http_server.py:845-869`) is already absent from coverage on master. The
argument it forwards is asserted from the CLI side by
`test_main_serve_passes_read_timeout`.

## Execution Tests

Full suite, ruff, format and mypy as CI runs them:

```
632 passed, 2 skipped in 49.90s
Required test coverage of 80% reached. Total coverage: 88.96%

All checks passed!                             (ruff check src tests)
122 files already formatted                    (ruff format --check src tests)
Success: no issues found in 55 source files    (mypy src)
```

Plus the end-to-end reproduction quoted above, run against a real
`ThreadingHTTPServer` on an ephemeral port with both a live budget and the
opt-out, checking the observable symptom from the issue (a retained handler
thread) rather than only the timeout value.

Local note: `tests/test_server_tls.py` fails on this machine with
`HTTP Error 500: Internal Privoxy Error` unless `no_proxy='*'` is set -- a system
HTTP proxy intercepting `urlopen`. I confirmed with `git stash
--include-untracked` that those same tests fail identically on a clean
`upstream/master`, so it is environmental and not introduced here. All runs
reported above use `no_proxy='*'`.

## Docs

`docs/ATTACH_ANY_SYSTEM.md` gains a "Leave the read timeout on" bullet in the
hardening checklist, immediately after the `--max-body-bytes` bullet as the issue
asks. It states the default, the env var, that the budget is per read, why the
size cap does not cover this case, the `0` opt-out, and that the same budget
bounds the TLS handshake.

## Relationship to #176

This is the second of the two server-hardening issues, kept separate per the
note in #130 that it was filed on its own "so the drain fix stays revertible on
its own merits". #176 (Fixes #129) touches `do_POST` framing; this PR touches the
handler `timeout`, `Config`, and the CLI. They do not overlap and either can land
first -- #129's bounded drain sets and restores the socket timeout inside a single
call, so it neither depends on nor conflicts with this default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
