### PR TITLE
feat(server): expose GET /directive and the policy_errors metrics family

### DIFF
--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ if monitor.last_directive.action == "pause":
 
 Fail-open survives enforcement by construction: a callback exception is logged, counted under `metrics()["policy_errors"]`, and swallowed (unless `fail_open=False`); a webhook timeout, dead endpoint, malformed body, unknown action, or HTTP error leaves the directive at continue. Worst-case added latency per halting step is bounded by the explicit `halt_timeout_s` envelope (default 250ms) and is paid only by the dispatching thread -- other episodes keep ingesting. Measured numbers (Apple M1, CPython 3.14, 2026-08-26; run `python benchmarks/enforcement_benchmark.py`): observe baseline ~2 us/step, responding localhost endpoint ~264 us/step median, refused endpoint ~57 us/step, stalled endpoint ~252.7 ms/step, i.e. the full timeout budget plus a small epsilon.
 
-The equivalent for sidecar consumers: `snagline serve --halt-forward URL` runs the identical policy inside the HTTP sidecar (`--halt-timeout` and `--min-severity-for-halt` tune it). Configuration is 12-factor too: `SNAGLINE_POLICY`, `SNAGLINE_HALT_URL`, `SNAGLINE_HALT_TIMEOUT_S`, `SNAGLINE_MIN_SEVERITY_FOR_HALT`. Note `on_risk` is code-only: callables cannot arrive via env vars or config files.
+The equivalent for sidecar consumers: `snagline serve --halt-forward URL` runs the identical policy inside the HTTP sidecar (`--halt-timeout` and `--min-severity-for-halt` tune it). Non-Python hosts read the answer back with `GET /directive`, which returns `{"action": "continue"|"pause", "reason": ..., "timestamp": ...}` and is auth-gated like `GET /risks`. Configuration is 12-factor too: `SNAGLINE_POLICY`, `SNAGLINE_HALT_URL`, `SNAGLINE_HALT_TIMEOUT_S`, `SNAGLINE_MIN_SEVERITY_FOR_HALT`. Note `on_risk` is code-only: callables cannot arrive via env vars or config files.
 
 ## External Agent Bridges
 
@@ -527,6 +527,7 @@ snagline serve --host 127.0.0.1 --port 8787
 # POST /events              body: StepEvent JSON   -> 202, ingested
 # POST /hooks/claude-code   body: native hook payload -> 202, mapped + ingested
 # GET  /health                                     -> 200
+# GET  /directive                                  -> 200, latest halt directive
 ```
 
 ### Claude Code integration

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -825,7 +825,8 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             f"snagline serve: halt forwarding enabled -> {cfg.halt_url} "
             f"(timeout {cfg.halt_timeout_s}s, min severity "
             f"{cfg.min_severity_for_halt}); directives land on "
-            "Monitor.last_directive (issue #93)",
+            "Monitor.last_directive and are readable at GET /directive "
+            "(issues #93, #169)",
             file=sys.stderr,
         )
     if not auth_token:

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -9,6 +9,7 @@ shell script, a Claude Code hook) can POST ``StepEvent`` JSON to:
     POST /episodes/end       body: {"episode_id": "<id>"}            -> monitor.end_episode()
     GET  /health                                                     -> 200 OK
     GET  /metrics                                                    -> Prometheus text exposition (v0.0.4)
+    GET  /directive                                                  -> the latest halt-webhook directive
 
 A host that knows an episode is over can signal it with ``POST
 /episodes/end`` carrying ``{"episode_id": "..."}`` (issue #123): the sidecar
@@ -47,6 +48,15 @@ clients sending ``Accept: application/json``, or when the sidecar is started
 with ``SNAGLINE_METRICS_FORMAT=classic`` (config key ``metrics_format``);
 ``?format=prometheus`` forces the new format back on per request.
 
+``GET /directive`` reports the newest halt-webhook directive as
+``{"action": "continue"|"pause", "reason": ..., "timestamp": ...}`` (issue
+#169). Without it, a sidecar started with ``--halt-forward URL`` had nowhere
+to publish the answer: the directive landed on the in-process
+``Monitor.last_directive`` and non-Python hosts, the whole point of server
+mode, could not read it. The resource exists as soon as the Monitor does and
+defaults to continue, so the endpoint always answers 200. It is auth-gated
+like ``GET /risks``, because a directive can pause the host.
+
 No framework, no third-party dependency -- this keeps the zero-dependency
 principle intact even for server mode. For high-throughput production use,
 front it with a real ASGI server / reverse proxy; that is the user's infra
@@ -74,7 +84,7 @@ from urllib.parse import parse_qs, urlsplit
 from snagline.adapters.claude_code import HookTracker, ingest_payload
 from snagline.config import Config
 from snagline.events import StepEvent
-from snagline.monitor import Monitor
+from snagline.monitor import HaltDirective, Monitor
 
 logger = logging.getLogger("snagline")
 
@@ -161,6 +171,20 @@ def _choose_metrics_format(
     return configured
 
 
+def _directive_payload(directive: Any) -> dict[str, Any]:
+    """Render a :class:`HaltDirective` as the ``GET /directive`` body.
+
+    Coerced rather than trusted: the handler holds whatever object the caller
+    passed as ``monitor``, and a body that cannot be serialized would turn a
+    read-only endpoint into a 500.
+    """
+    return {
+        "action": str(directive.action),
+        "reason": str(directive.reason),
+        "timestamp": float(directive.timestamp),
+    }
+
+
 class SidecarMetricsCollector:
     """Process-lifetime sidecar counters, renderable as Prometheus text.
 
@@ -240,10 +264,11 @@ class SidecarMetricsCollector:
     def render_prometheus(self, monitor_metrics: dict[str, int]) -> str:
         """Render the full exposition body (version 0.0.4 text format).
 
-        ``monitor_metrics`` is the ``Monitor.metrics()`` snapshot; those four
+        ``monitor_metrics`` is the ``Monitor.metrics()`` snapshot; those
         counters are exposed under ``snagline_monitor_*_total`` names so the
         sidecar view adds process-lifetime detail without renaming anything
-        the JSON endpoint already published.
+        the JSON endpoint already published. A key the snapshot does not
+        carry renders as 0, so an older Monitor still produces a valid body.
         """
         snap = self.snapshot()
         lines: list[str] = []
@@ -293,6 +318,12 @@ class SidecarMetricsCollector:
                 "sink_errors",
                 "snagline_monitor_sink_errors_total",
                 "Sink exceptions swallowed (fail-open).",
+            ),
+            (
+                "policy_errors",
+                "snagline_monitor_policy_errors_total",
+                "Enforcement faults swallowed fail-open (#93): callback raises"
+                " and halt-webhook timeout/error fallbacks.",
             ),
         )
         for key, name, help_text in monitor_families:
@@ -375,8 +406,29 @@ def make_handler(
                 self._serve_metrics(parse_qs(split.query))
             elif split.path == "/risks":
                 self._respond(200, {"risks": list(self.snagline_risks)})
+            elif split.path == "/directive":
+                self._serve_directive()
             else:
                 self._respond(404, {"error": "not found"})
+
+        def _serve_directive(self) -> None:
+            """Serve the newest halt-webhook directive (issue #169).
+
+            Read-only: the Monitor owns the directive and its lock, so this
+            renders whatever the public property hands back. A monitor that
+            predates enforcement, or any failure reading it, answers with the
+            default continue rather than raising -- the same fail-open the
+            webhook path itself takes on a timeout or a dead endpoint, and a
+            500 here would tell a polling host nothing it could act on.
+            """
+            try:
+                payload = _directive_payload(self.snagline_monitor.last_directive)
+            except Exception:
+                logger.debug(
+                    "snagline: directive unreadable, reporting continue", exc_info=True
+                )
+                payload = _directive_payload(HaltDirective())
+            self._respond(200, payload)
 
         def _serve_metrics(self, query: dict[str, list[str]]) -> None:
             """Serve either exposition format, failing open to an empty body.

--- a/tests/server/test_directive_endpoint.py
+++ b/tests/server/test_directive_endpoint.py
@@ -1,0 +1,203 @@
+"""``GET /directive`` exposes the halt-webhook answer over HTTP (#169).
+
+The enforcement layer (#93) lands the halt endpoint's ``{"action": ...}``
+response on the in-process ``Monitor.last_directive``, which non-Python hosts
+-- the entire audience for server mode -- had no way to read. These tests pin
+the endpoint's contract: it always answers 200 with a full directive, it
+reflects a real webhook round trip, it sits behind the token exactly like
+``GET /risks``, and it degrades to continue instead of 500 when the directive
+cannot be read at all.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import urllib.error
+import urllib.request
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+from snagline.events import StepEvent
+from snagline.monitor import Monitor
+from snagline.risk import FailureRisk
+from snagline.server.http_server import make_server
+
+
+class _FixedRiskDetector:
+    """Emits one high-score risk on every observe(), so a halt always fires."""
+
+    name = "fixed_risk"
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            0.95,
+            "loop",
+            "synthetic risk",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        pass
+
+
+class _PauseEndpoint:
+    """A local halt endpoint that answers pause, as #93's contract allows."""
+
+    def __init__(self) -> None:
+        class _Handler(BaseHTTPRequestHandler):
+            def log_message(self, format: str, *args) -> None:  # noqa: A002
+                pass
+
+            def do_POST(self) -> None:  # noqa: N802 - http.server naming
+                self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                data = json.dumps(
+                    {"action": "pause", "reason": "budget exceeded"}
+                ).encode()
+                self.send_response(200)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(data)))
+                self.end_headers()
+                self.wfile.write(data)
+
+        self._server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+        self._server.daemon_threads = True
+        self.url = f"http://127.0.0.1:{self._server.server_port}/halt"
+        self._thread = threading.Thread(target=self._server.serve_forever, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._server.shutdown()
+        self._server.server_close()
+        self._thread.join(timeout=2)
+
+
+def _start(monitor, **kwargs):
+    server = make_server(monitor, host="127.0.0.1", port=0, **kwargs)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, f"http://127.0.0.1:{server.server_address[1]}"
+
+
+def _get(base: str, path: str, headers: dict | None = None):
+    """GET and return (status, parsed body); HTTPError codes included."""
+    req = urllib.request.Request(base + path, headers=headers or {}, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=5) as resp:
+            return int(resp.status), json.loads(resp.read())
+    except urllib.error.HTTPError as exc:
+        return int(exc.code), json.loads(exc.read())
+
+
+def _event(step_id: str = "s1") -> dict:
+    return {
+        "step_id": step_id,
+        "episode_id": "ep-directive",
+        "timestamp": 1718300000.0,
+        "action_type": "tool_call",
+        "action_signature": "aaaa1111bbbb2222",
+    }
+
+
+def test_directive_defaults_to_continue():
+    """The resource exists as soon as the Monitor does: 200, never 404."""
+    server, base = _start(Monitor([], []))
+    try:
+        status, body = _get(base, "/directive")
+        assert status == 200
+        assert body == {"action": "continue", "reason": "", "timestamp": 0.0}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_directive_reports_a_pause_after_a_halt_round_trip():
+    """The regression this endpoint exists for: a pause is now readable."""
+    endpoint = _PauseEndpoint()
+    monitor = Monitor(
+        [_FixedRiskDetector()],
+        [],
+        policy="halt_webhook",
+        halt_url=endpoint.url,
+    )
+    server, base = _start(monitor)
+    try:
+        before_status, before = _get(base, "/directive")
+        assert before_status == 200
+        assert before["action"] == "continue"
+
+        request = urllib.request.Request(
+            base + "/events",
+            data=json.dumps(_event()).encode(),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as resp:
+            assert resp.status == 202
+
+        status, body = _get(base, "/directive")
+        assert status == 200
+        assert body["action"] == "pause"
+        assert body["reason"] == "budget exceeded"
+        # The timestamp is when the directive was received, so it is set now.
+        assert body["timestamp"] > 0.0
+    finally:
+        server.shutdown()
+        server.server_close()
+        endpoint.stop()
+
+
+def test_directive_is_behind_the_token_when_one_is_set():
+    """A directive can pause the host, so it must never be world-readable."""
+    server, base = _start(Monitor([], []), auth_token="secret")
+    try:
+        assert _get(base, "/directive")[0] == 401
+        assert _get(base, "/directive", {"Authorization": "Bearer wrong"})[0] == 401
+        ok_status, body = _get(base, "/directive", {"Authorization": "Bearer secret"})
+        assert ok_status == 200
+        assert body["action"] == "continue"
+        # X-Snagline-Token is accepted here too, as on every other endpoint.
+        assert _get(base, "/directive", {"X-Snagline-Token": "secret"})[0] == 200
+        # /health stays open, so a probe cannot be broken by adding this route.
+        assert _get(base, "/health")[0] == 200
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+class _UnreadableDirectiveMonitor:
+    """A monitor whose directive cannot be read, e.g. one predating #93."""
+
+    def __init__(self) -> None:
+        self.metrics_calls = 0
+
+    @property
+    def last_directive(self):
+        raise AttributeError("no directive on this monitor")
+
+    def metrics(self) -> dict:
+        self.metrics_calls += 1
+        return {}
+
+
+def test_directive_fails_open_to_continue_instead_of_500():
+    """Fail-open, as everywhere else: a broken read reports continue."""
+    server, base = _start(_UnreadableDirectiveMonitor())
+    try:
+        status, body = _get(base, "/directive")
+        assert status == 200
+        assert body == {"action": "continue", "reason": "", "timestamp": 0.0}
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_unknown_get_paths_still_404():
+    """Adding a route must not turn the fallthrough into a match."""
+    server, base = _start(Monitor([], []))
+    try:
+        assert _get(base, "/directives")[0] == 404
+        assert _get(base, "/directive/latest")[0] == 404
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tests/server/test_metrics_prometheus.py
+++ b/tests/server/test_metrics_prometheus.py
@@ -65,6 +65,22 @@ def _step(index, sig, episode="ep-metrics", error=False):
     }
 
 
+class _AlwaysRiskDetector:
+    """Emits one risk per step, so the enforcement tail runs every time."""
+
+    name = "always_risk"
+
+    def observe(self, event):
+        from snagline.risk import FailureRisk
+
+        return FailureRisk(
+            event.episode_id, event.step_id, 0.95, "loop", "synthetic", event.timestamp
+        )
+
+    def reset(self, episode_id: str) -> None:
+        pass
+
+
 def _parse_samples(body: str) -> dict:
     """Parse exposition lines into {(name, labels): value}, asserting shape.
 
@@ -100,6 +116,7 @@ def test_empty_monitor_serves_valid_prometheus():
             "snagline_monitor_risks_emitted_total",
             "snagline_monitor_detector_errors_total",
             "snagline_monitor_sink_errors_total",
+            "snagline_monitor_policy_errors_total",
         ):
             assert f"# HELP {family} " in body, family
             assert f"# TYPE {family} " in body, family
@@ -109,6 +126,7 @@ def test_empty_monitor_serves_valid_prometheus():
         assert samples[("snagline_ingest_seconds_count", "")] == 0.0
         assert samples[("snagline_ingest_seconds_sum", "")] == 0.0
         assert samples[("snagline_monitor_detector_errors_total", "")] == 0.0
+        assert samples[("snagline_monitor_policy_errors_total", "")] == 0.0
         # No risk samples at all on an empty monitor.
         assert not any(name == "snagline_risks_total" for name, _ in samples)
     finally:
@@ -209,6 +227,7 @@ def test_classic_format_stays_available_for_old_clients():
             "risks_emitted",
             "detector_errors",
             "sink_errors",
+            "policy_errors",
         ):
             assert key in parsed
 
@@ -306,3 +325,37 @@ def test_collector_counts_risks_per_label_pair():
         samples[("snagline_risks_total", 'trigger="error_cascade",severity="critical"')]
         == 1.0
     )
+
+
+def test_policy_errors_family_grows_on_an_enforcement_fault():
+    """Issue #169: enforcement faults were invisible to scrapes.
+
+    ``policy_errors`` counts what #93 swallows fail-open -- a raising
+    callback here -- and that is precisely what an operator needs to see when
+    a halt path starts dying, so it must reach the exposition body and not
+    only the JSON one.
+    """
+
+    def _boom(risk) -> None:
+        raise RuntimeError("callback is down")
+
+    monitor = Monitor(
+        [_AlwaysRiskDetector()],
+        [],
+        policy="callback",
+        on_risk=_boom,
+    )
+    server = make_server(monitor, host="127.0.0.1", port=0)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    base = f"http://127.0.0.1:{server.server_address[1]}"
+    try:
+        _post(base, _step(0, "sig-policy"))
+        _post(base, _step(1, "sig-policy"))
+        samples = _parse_samples(_get(base, "/metrics")[2])
+        assert samples[("snagline_monitor_policy_errors_total", "")] == 2.0
+        # The JSON body has always carried it; both must agree.
+        assert (
+            json.loads(_get(base, "/metrics?format=classic")[2])["policy_errors"] == 2
+        )
+    finally:
+        _stop(server)


### PR DESCRIPTION
Fixes #169

## Summary of Changes

#93 shipped the enforcement layer without touching `server/http_server.py`, by
deliberate zone ownership. This closes the two gaps that left for sidecar
consumers of `snagline serve --halt-forward URL`.

**1. `GET /directive`.** The halt webhook's answer landed on the in-process
`Monitor.last_directive` and nothing published it, so a non-Python host -- the
entire audience for server mode -- could not learn that the endpoint said
`"pause"`. That is the point of the feature for those consumers, and it was
unreachable. The endpoint renders the directive as
`{"action": "continue"|"pause", "reason": str, "timestamp": float}`.

**2. `snagline_monitor_policy_errors_total`.** `MonitorMetrics` gained a fifth
counter in #166 (swallowed callback raises plus halt-webhook timeout/error
fallbacks), but the exposition rendered only the original four families. A halt
endpoint starting to die was invisible to scrapes, which is precisely when an
operator needs to see it. The JSON body had it all along, so only the text
exposition needed the fifth `monitor_families` entry.

Before and after, same script (`Monitor([], [])`, ephemeral loopback port):

| | master (`f7857d1`) | this branch |
| --- | --- | --- |
| `GET /directive` | `404 {"error": "not found"}` | `200 {"action": "continue", "reason": "", "timestamp": 0.0}` |
| `policy_errors` in `/metrics` | absent | present |
| `policy_errors` in `?format=classic` | present | present (unchanged) |

## Contract details

- **Auth-gated like `GET /risks`.** A directive can pause the host, so it goes
  through the same `_authorized()` path: 401 without a token, `Bearer` and
  `X-Snagline-Token` both accepted, and `GET /health` stays open so liveness
  probes are unaffected by the new route.
- **Always 200, never 404.** The resource exists as soon as the Monitor does and
  starts at continue, so a polling host does not have to distinguish "no
  directive yet" from "wrong URL".
- **Read-only and fail-open.** It reads the public thread-safe
  `monitor.last_directive` property, never the private attribute, and adds no
  locking of its own. If that read fails at all -- a monitor predating
  enforcement, a duck-typed object -- it reports the default continue and logs at
  debug rather than raising into the handler loop. A 500 would tell a polling
  host nothing it could act on, and it is the same fail-open the webhook path
  already takes on a timeout or a dead endpoint.
- **Payload coerced, not trusted.** `make_handler` holds whatever object the
  caller passed as `monitor`, so the three fields go through `str`/`str`/`float`;
  a body that cannot be serialized would turn a read-only endpoint into a 500.
- **Older snapshots still render.** `monitor_metrics.get(key, 0)` means a
  `Monitor.metrics()` dict without `policy_errors` produces a valid body with a
  zero sample instead of a `KeyError`.

## Justification

`snagline serve --halt-forward URL` exists so that hosts which are not Python
libraries can be paused by the same enforcement policy the in-process API
offers. Landing the directive only on a Python attribute means the sidecar can
decide to pause an agent it has no way of telling. That is not a partial
feature, it is a control path that terminates in a dead end -- and the
workaround, reaching into the Monitor object, is unavailable to exactly the
consumers server mode is for.

The metrics half is smaller but of the same kind: enforcement is the one
subsystem allowed to affect the host's behavior, so its fault counter is the one
an operator least wants to be missing from a dashboard. Both changes are
additive; nothing existing is renamed or reshaped.

## Kind of Contribution

New Feature

## Unit Tests

New `tests/server/test_directive_endpoint.py` (5 tests):

- `test_directive_defaults_to_continue` -- a fresh Monitor answers 200 with the
  full default directive, pinning that the resource exists before any webhook
  round trip.
- `test_directive_reports_a_pause_after_a_halt_round_trip` -- the regression this
  endpoint exists for. A local halt endpoint answers `pause`; a risk is driven
  through the sidecar's own `POST /events`; `GET /directive` reports continue
  before and `pause` with the endpoint's reason after, with a set timestamp.
- `test_directive_is_behind_the_token_when_one_is_set` -- both sides: 401 with no
  token and with a wrong one, 200 with `Bearer` and with `X-Snagline-Token`, and
  `/health` still open.
- `test_directive_fails_open_to_continue_instead_of_500` -- a monitor whose
  `last_directive` raises still gets a 200 continue.
- `test_unknown_get_paths_still_404` -- `/directives` and `/directive/latest`
  remain 404, so adding a route did not turn the fallthrough into a prefix match.

`tests/server/test_metrics_prometheus.py` (1 test, 3 assertions extended):

- `test_policy_errors_family_grows_on_an_enforcement_fault` -- a raising callback
  under `policy="callback"`, two ingested steps, and the counter reads exactly
  2.0 in the exposition body and 2 in `?format=classic`, so the two bodies are
  pinned to agree.
- The existing family-presence, zero-value, and classic-key assertions gained
  `policy_errors`, which is where a future rename would be caught.
- `test_collector_counts_risks_per_label_pair` already passes a snapshot without
  the new key, so it now also covers the "older Monitor" path for free.

Every added line and branch in `http_server.py` is covered: none of the new
ranges appear in coverage's miss list, which is otherwise identical to master's.

## Execution Tests

End to end through the real CLI, not the test harness: a halt endpoint answering
`pause`, `python -m snagline.cli serve --port N --auth-token s3cret
--halt-forward URL --min-severity-for-halt 0.5` as a subprocess, three identical
signatures to pass the loop detector's threshold of 3, then the directive read
back over HTTP the way a non-Python host would.

```
no token       -> (401, '{"error": "unauthorized"}')
before         -> (200, '{"action": "continue", "reason": "", "timestamp": 0.0}')
after          -> (200, '{"action": "pause", "reason": "loop detected", "timestamp": 1787759218.4418151}')
metrics        -> snagline_monitor_policy_errors_total 0
```

The `policy_errors 0` line is the point of that last check: the family is present
and correctly zero on a run where the halt endpoint answered every request.

Full gate:

```
628 passed, 2 skipped in 49.64s
Required test coverage of 80% reached. Total coverage: 88.95%

All checks passed!                             (ruff check src tests)
122 files already formatted                    (ruff format --check src tests)
Success: no issues found in 55 source files    (mypy src)
```

Local note: `tests/test_server_tls.py` needs `no_proxy='*'` on this machine or a
system HTTP proxy intercepts `urlopen` and returns 500. Those failures reproduce
on a clean `upstream/master`, so they are environmental; all runs above use
`no_proxy='*'`.

## Docs

- README sidecar endpoint list gains `GET /directive`, and the enforcement
  paragraph now says non-Python hosts read the answer back there, with the body
  shape and the auth note.
- `http_server.py`'s module docstring gains the route in its endpoint table plus
  a paragraph on why it exists and why it is auth-gated.
- The `snagline serve` halt-forwarding banner now points at `GET /directive`
  instead of only naming `Monitor.last_directive`, so an operator reading startup
  output learns the endpoint exists.

No change to `docs/ATTACH_ANY_SYSTEM.md`: its reverse-proxy configs use
`location /` rather than a path allowlist, so nothing there needed updating for a
new route.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
