### PR TITLE
docs: correct README claims contradicted by the code and measurements

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ Existing monitoring approaches have gaps:
 - **LLM-based anomaly detection** requires embeddings, a real dependency, and is too expensive to run on every step.
 - **Manual log review** does not scale to week-long unattended runs.
 
-SNAGLINE asks a narrower question: can a zero-dependency, O(1) per-step monitor catch the most common failure modes (loops, error cascades, latency drift) in any agent, running on any framework, with sub-microsecond overhead?
+SNAGLINE asks a narrower question: can a zero-dependency, O(1) per-step monitor catch the most common failure modes (loops, error cascades, latency drift) in any agent, running on any framework, at microsecond-scale overhead?
 
-The answer is yes. SNAGLINE's tier-1 detectors are deterministic, O(1) amortized per step, run with no network calls and no LLM calls, and cost approximately 1 microsecond per `ingest()` call. They run cheaply enough to instrument every step of a production agent.
+The answer is yes. SNAGLINE's tier-1 detectors are deterministic, O(1) amortized per step, run with no network calls and no LLM calls, and cost a few microseconds per `ingest()` call (measured median 1.7--2.4 us/step on Apple silicon; see [Empirical Verification](#empirical-verification) and run `snagline bench` for your own hardware). They run cheaply enough to instrument every step of a production agent.
 
 ## Quick Start
 
@@ -143,9 +143,9 @@ in [docs/RETRAIN_CADENCE.md](docs/RETRAIN_CADENCE.md)).
 
 | Capability | What it gives you |
 |:--|:--|
-| **Zero dependencies** | `pip install snagline-agent` works with nothing but Python 3.10+. Every framework adapter is an optional extra. |
+| **Zero dependencies** | The core needs nothing but Python 3.10+ -- `dependencies = []` in `pyproject.toml`, non-negotiable. Not yet published to PyPI: install with `pip install .` from a clone (see [Quick Start](#quick-start)). Every framework adapter is an optional extra. |
 | **Fail-open guarantee** | Detector/sink exceptions are caught, logged, and never propagated into the host agent. A monitoring library that can crash the thing it monitors is a non-starter. |
-| **Sub-microsecond overhead** | Median 1.9 us/step, p99 33.9 us/step over 200,000 synthetic steps. Cheap enough to run on every step of a week-long run. |
+| **Microsecond-scale overhead** | Median 2.43 us/step, p99 27.71 us/step over 200,000 synthetic steps. Cheap enough to run on every step of a week-long run. Numbers and provenance in [Empirical Verification](#automated-test-suite-and-benchmarks); reproduce with `snagline bench`. |
 | **Framework-agnostic core** | All detector and sink logic operates only on the canonical `StepEvent` schema. Framework-specific code lives in isolated adapter modules and nowhere else. |
 | **No content retention** | Detectors reason about hashes, timings, counts, and booleans -- never prompt or response content. Adoption blocker if left ambiguous. |
 | **Streaming-first, batch-capable** | Primary use is live monitoring of a running agent. The same event schema and detectors also work over an exported trajectory file for offline analysis. |
@@ -175,7 +175,7 @@ config = Config(
     # Latency anomaly (CUSUM) detector
     cusum_k=0.5,                  # slack parameter (sensitivity)
     cusum_h=5.0,                  # alarm threshold
-    cusum_min_samples=20,         # warm-up before alarming
+    cusum_min_samples=5,          # warm-up before alarming
     cusum_sigma_floor_abs=1.0,    # minimum sigma (ms) for constant baselines
     cusum_sigma_floor_rel=0.05,   # minimum sigma as fraction of mean
 
@@ -236,6 +236,12 @@ the path variant below.
 | `SNAGLINE_GOAL_DRIFT_SCORE_THRESHOLD` | `goal_drift_score_threshold` | 0.5 | Emit a goal-drift risk above this score |
 | `SNAGLINE_ML_ENSEMBLE_ENABLED` | `ml_ensemble_enabled` | False | Wrap detectors in MLOrchestrator (noisy-OR) |
 | `SNAGLINE_ML_ENSEMBLE_SCORE_THRESHOLD` | `ml_ensemble_score_threshold` | 0.5 | Emit a combined risk above this score |
+| `SNAGLINE_SEMANTIC_DRIFT_ENABLED` | `semantic_drift_enabled` | False | Enable the semantic goal-drift detector (needs the `drift` extra) |
+| `SNAGLINE_SEMANTIC_DRIFT_MODEL` | `semantic_drift_model` | all-MiniLM-L6-v2 | sentence-transformers model to load for structural-label embeddings |
+| `SNAGLINE_SEMANTIC_DRIFT_MIN_SAMPLES` | `semantic_drift_min_samples` | 10 | Live steps before semantic scoring starts |
+| `SNAGLINE_SEMANTIC_DRIFT_TOLERANCE` | `semantic_drift_tolerance` | 0.3 | Cosine deviation treated as noise |
+| `SNAGLINE_SEMANTIC_DRIFT_CUSUM_K` | `semantic_drift_cusum_k` | 0.05 | Slack subtracted per evaluation |
+| `SNAGLINE_SEMANTIC_DRIFT_CUSUM_H` | `semantic_drift_cusum_h` | 0.5 | Sustained-deviation alarm threshold |
 | `SNAGLINE_MAX_EPISODE_WALL_SECONDS` | `max_episode_wall_seconds` | None | Wall-clock budget per episode from event timestamps; unset disables |
 | `SNAGLINE_WARN_FRACTION` | `warn_fraction` | 0.8 | Fraction of the budget where the single pre-breach warning fires |
 | `SNAGLINE_IDLE_WARN_SECONDS` | `idle_warn_seconds` | None | Gap between consecutive ingests that fires one `idle_gap` risk |
@@ -265,6 +271,11 @@ the path variant below.
 | `SNAGLINE_MELTDOWN_HIGH_ENTROPY` | `meltdown_high_entropy` | 2.8 | Above this many bits the window is thrash |
 | `SNAGLINE_MELTDOWN_REARM_STEPS` | `meltdown_rearm_steps` | 10 | In-band steps before re-arming |
 | `SNAGLINE_SILENT_ABORT_ENABLED` | `silent_abort_enabled` | False | Silent-abort check at end of episode |
+| `SNAGLINE_SIDE_EFFECT_GUARD_ENABLED` | `side_effect_guard_enabled` | False | Enable SideEffectGuardDetector (duplicate non-idempotent actions) |
+| `SNAGLINE_SIDE_EFFECT_ALLOWED_REPEATS` | `side_effect_allowed_repeats` | 1 | Occurrences tolerated before firing `side_effect_duplicate` |
+| `SNAGLINE_SIDE_EFFECT_SCORE` | `side_effect_score` | 0.9 | Score for a duplicate side effect (routes as critical) |
+| `SNAGLINE_COMPACTION_TRIPWIRE_ENABLED` | `compaction_tripwire_enabled` | False | Enable the compaction tripwire (`governance_decay`) |
+| `SNAGLINE_COMPACTION_TRIPWIRE_GRACE_STEPS` | `compaction_tripwire_grace_steps` | 3 | Events a pin has to re-confirm itself after a compaction |
 | `SNAGLINE_CALIBRATION` | `calibration` | manual | manual, or auto to derive thresholds from a baseline |
 | `SNAGLINE_CALIBRATION_ALPHA` | `calibration_alpha` | 0.001 | False-alarm probability budget per window evaluation |
 | `SNAGLINE_CALIBRATION_BASELINE_PATH` | `calibration_baseline_path` | *(unset)* | Path to a saved BaselineProfile for auto calibration |
@@ -298,17 +309,28 @@ SNAGLINE is verified not just with unit tests, but against real LLM agents, live
 ### Automated Test Suite and Benchmarks
 
 ```
-tests : 531 passed, 2 skipped  (pytest, Python 3.14, 2026-08-26;
-skip = langchain integrations without optional extras)
+tests : 622 passed, 2 skipped  (pytest, CPython 3.13.5, commit f7857d1;
+        skip = langchain integrations without optional extras.
+        CI matrix is Python 3.10--3.13 on ubuntu/macos/windows.)
 bench : median 2.43 us/step, p99 27.71 us/step over 200,000 synthetic steps
         (measured 2026-08-26 on Apple M1, arm64, CPython 3.14.5;
-         earlier 1.91 / 33.90 on same hardware 2026-08-15)
+         earlier 1.91 / 33.90 on same hardware 2026-08-15;
+         independently reproduced at commit f7857d1 on Apple M4 /
+         CPython 3.13.5: median 1.70 us/step, p99 1.77 us/step)
 enforcement (issue #93): added latency per halting step, halt_timeout_s=250ms,
         Apple M1 / CPython 3.14 / 2026-08-26: responding localhost endpoint
         median 264 us/step, refused (dead) endpoint median 57 us/step,
         stalled endpoint median 252.7 ms/step = the full timeout envelope;
         observe baseline unchanged at ~2 us/step. Reproduce with
         python benchmarks/enforcement_benchmark.py
+```
+
+Reproduce the suite exactly as CI does:
+
+```bash
+pip install -e . --no-deps
+pip install pytest pytest-cov
+python -m pytest tests/ -q
 ```
 
 Coverage spans:
@@ -700,8 +722,8 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 
 ## Status and Limitations
 
-- **Tested**: 385 tests passing, 1 skipped (see [Verification Status](#empirical-verification)).
-- **Not on PyPI.** Install from a clone (see Quick Start).
+- **Tested**: 622 tests passing, 2 skipped, 88.88% line coverage (see [Empirical Verification](#automated-test-suite-and-benchmarks) for the exact command and environment).
+- **Not on PyPI.** Install from a clone (see Quick Start). The `snagline-agent[langchain]`-style names used elsewhere in this README are the extras this package declares; until it is published, install them from a clone as `pip install ".[langchain]"`.
 - **Overhead is measured, not asserted.** Run `snagline bench` to reproduce on your hardware.
 - **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline-agent[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.
 - **The latency anomaly detector requires warm-up.** It learns a baseline from `cusum_min_samples` (default 5) events before any alarm can fire. This prevents false positives on normal jitter but means the detector is blind during warm-up; a calibrated `BaselineProfile` (issue #101) removes the blind spot for tools it describes. With `cusum_refit_every` set, the frozen baseline is periodically re-checked against a parallel learner, so drift in the baseline itself becomes visible instead of being learned away silently.
@@ -721,6 +743,25 @@ Contributions are welcome. This project is open source under MIT and deliberatel
 - [docs/ADAPTER_GUIDE.md](docs/ADAPTER_GUIDE.md) -- wire any framework into SNAGLINE in an afternoon.
 - [docs/DETECTOR_GUIDE.md](docs/DETECTOR_GUIDE.md) -- the detector contract, constraints, and test shape.
 - [docs/FRAMEWORK_BRIDGES.md](docs/FRAMEWORK_BRIDGES.md) -- connect external agent processes via HTTP, command, or file bridges.
+
+### Local development setup
+
+The core has no runtime dependencies, but the test suite needs `pytest` and
+`pytest-cov` (`[tool.pytest.ini_options] addopts` enables coverage, so a bare
+`pytest` fails with an unrecognised `--cov` until the plugin is installed).
+There is no `dev` extra yet, so install the tooling the same way CI does:
+
+```bash
+pip install -e . --no-deps
+pip install pytest pytest-cov ruff mypy
+python -m pytest tests/ -q        # 622 passed, 2 skipped
+ruff check src tests && ruff format --check src tests
+mypy src
+```
+
+Optional extras add their own test legs: `pip install ".[langchain]"`
+un-skips the LangChain integration tests, and `pip install ".[ml]"` enables
+the ESN ensemble leg.
 
 Open an issue before submitting large PRs.
 


### PR DESCRIPTION
## Why

I went through the README claim by claim against the code and re-ran every measurement it cites, at `f7857d1`. Most of it holds up — the detection-accuracy table reproduces **exactly**, and the Quick Start's example output is byte-identical to what the snippet actually prints. Six claims did not hold, and four of them are the README contradicting *itself*.

That matters more here than in most projects: this README's credibility rests on lines like "Overhead is measured, not asserted" and "No rounding up, no cherry-picking." A reader who spot-checks the headline number and finds it off by 2.5x has no way to know the accuracy table is solid. This PR is only about closing that gap.

## What changed

| # | Claim | Reality | Evidence |
|--:|:--|:--|:--|
| 1 | "**Sub-microsecond** overhead", "approximately 1 microsecond per `ingest()`", Features cell "1.9 / 33.9 us" | The README's *own* verification block says median **2.43 us/step**. Three different numbers, one of them an order-of-magnitude-adjacent overclaim. | `benchmarks/overhead_benchmark.py` |
| 2 | "531 passed, 2 skipped" *and* "385 tests passing, 1 skipped" | Both stale and mutually contradictory. Actual: **622 passed, 2 skipped**, 88.88% coverage. | `python -m pytest tests/ -q` |
| 3 | "`pip install snagline-agent` works with nothing but Python 3.10+" | `https://pypi.org/pypi/snagline-agent/json` → **404**. Status says "Not on PyPI" three sections later. | `curl` |
| 4 | Config snippet: `cusum_min_samples=20` | Real default is **5** — and the env table 50 lines below already says 5. | `src/snagline/config.py:175` |
| 5 | "Every scalar field of `Config` doubles as a 12-factor environment variable" | **11 scalar fields absent** from the table: `semantic_drift_*` (6), `side_effect_*` (3), `compaction_tripwire_*` (2). Silently undiscoverable knobs. | `dataclasses.fields(Config)` vs README |
| 6 | Contributing links three guides, gives no test command | `addopts = "--cov=snagline"` + no `dev` extra ⇒ a bare `pytest` after `pip install .` dies on unrecognised `--cov`. New contributors must reverse-engineer `ci.yml`. | `pyproject.toml:90`, `ci.yml:54` |

For #1 I did **not** replace the maintainer's Apple M1 / CPython 3.14.5 figures — I kept them and added an independent reproduction alongside (Apple M4 / CPython 3.13.5: median **1.70 us/step**, p99 **1.77 us/step**), then pointed the Features table at the same numbers instead of a superseded pair. The honest headline is "microsecond-scale", which is still an excellent number and needs no inflation.

For #2 I recorded the interpreter I actually used. Worth flagging separately: the old note claimed **Python 3.14**, but `ci.yml` tests **3.10–3.13** and `pyproject.toml` classifiers stop at 3.13. I documented the CI matrix rather than assert anything about 3.14 I can't reproduce.

## Verification

Everything newly written into the README was run first, at this commit:

```
python -m pytest tests/ -q      → 622 passed, 2 skipped, coverage 88.88% (gate 80%)
ruff check src tests            → All checks passed!
ruff format --check src tests   → 121 files already formatted
mypy src                        → Success: no issues found in 55 source files
benchmarks/overhead_benchmark.py→ median 1.70 us/step, p99 1.77 us/step (Apple M4, CPython 3.13.5)
benchmarks/detection_accuracy.py→ macro-F1 1.000, 76 episodes, 0 healthy controls fired, exit 0
```

## Deliberately left alone

- **The detection-accuracy table.** It reproduces exactly — every trigger 4 TP / 0 FP / 0 FN, macro-F1 1.000, 0 healthy-control firings. No change warranted.
- **The Quick Start output.** I checked it byte for byte, expecting `"in last 12 steps"` from `loop_window_size=12`; the documented `"action repeated 3x in last 3 steps"` is correct, because the window is bounded by steps *seen*. Nice detail.
- **The M1 / CPython 3.14 benchmark figures.** Not mine to overwrite; I can't reproduce that environment, so I added to the record rather than replacing it.

## Note for the maintainer

Docs-only, no behavior change. Two follow-ups I did *not* do here, happy to file as issues or fold in if you'd prefer:

1. **Add a `dev` extra** to `pyproject.toml` (`pytest`, `pytest-cov`, `ruff`, `mypy`). This PR documents the CI workaround; a `dev` extra would make the workaround unnecessary and let the README just say `pip install -e ".[dev]"`.
2. **Add a docs-drift guard.** #2, #4 and #5 are all the same failure mode: a hand-maintained README diverging from the source of truth. A ~20-line test asserting that every scalar `Config` field appears in the README env table would have caught #5 the day it regressed, and would keep catching it.

Guidance says to open an issue before large PRs — this is docs-only and self-contained, so I went straight to a PR. Glad to split it per-claim if you'd rather review them separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
