### PR TITLE
fix(server): return 400 on malformed Content-Length instead of dropping

### DIFF
--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -407,10 +407,15 @@ def make_handler(
                 # kernel send RST and the sender can lose the 401 response
                 # entirely (same rationale as the over-cap drain, #121;
                 # observed over TLS where close timing shifts the race).
-                self._discard_overcap_body(int(self.headers.get("Content-Length") or 0))
+                declared = self._parse_content_length()
+                if declared is None:
+                    return
+                self._discard_overcap_body(declared)
                 self._respond(401, {"error": "unauthorized"})
                 return
-            length = int(self.headers.get("Content-Length") or 0)
+            length = self._parse_content_length()
+            if length is None:
+                return
             if length > self.snagline_max_body:
                 # Consume the over-cap body first: closing with megabytes
                 # unread makes the peer see EPIPE/reset instead of the 413
@@ -427,7 +432,7 @@ def make_handler(
             elif self.path == "/risks":
                 self._post_risks()
             else:
-                self._discard_overcap_body(int(self.headers.get("Content-Length") or 0))
+                self._discard_overcap_body(length)
                 self._respond(404, {"error": "not found"})
 
         def _post_risks(self) -> None:
@@ -439,6 +444,8 @@ def make_handler(
             malformed body is acknowledged (202) so the sender never retries.
             """
             body = self._read_body()
+            if body is None:
+                return
             try:
                 risk = json.loads(body.decode("utf-8"))
                 if not isinstance(risk, dict):
@@ -458,6 +465,8 @@ def make_handler(
 
         def _post_events(self) -> None:
             body = self._read_body()
+            if body is None:
+                return
             try:
                 obj = json.loads(body.decode("utf-8"))
             except (ValueError, json.JSONDecodeError):
@@ -509,6 +518,8 @@ def make_handler(
             the one that takes the sidecar down.
             """
             body = self._read_body()
+            if body is None:
+                return
             try:
                 payload = json.loads(body.decode("utf-8"))
             except (ValueError, json.JSONDecodeError):
@@ -558,6 +569,8 @@ def make_handler(
             retries noise.
             """
             body = self._read_body()
+            if body is None:
+                return
             try:
                 payload = json.loads(body.decode("utf-8"))
                 if not isinstance(payload, dict):
@@ -580,6 +593,33 @@ def make_handler(
                     "step_id": event.step_id if event else None,
                 },
             )
+
+        def _parse_content_length(self) -> int | None:
+            """Parse Content-Length, or None if malformed (already answered 400).
+
+            An absent Content-Length header is treated as length 0: the body
+            is silently empty, which is acceptable for these telemetry-only
+            endpoints. A present but non-numeric or negative value is answered
+            with 400 {"error": "invalid Content-Length"} and the caller
+            must return without reading any body bytes. Shared by ``do_POST``
+            and ``_read_body`` so every entry point fails the same way.
+            """
+            raw = self.headers.get("Content-Length")
+            if raw is None:
+                return 0
+            text = raw.strip() if isinstance(raw, str) else str(raw).strip()
+            if text == "":
+                self._respond(400, {"error": "invalid Content-Length"})
+                return None
+            try:
+                length = int(text)
+            except (ValueError, TypeError):
+                self._respond(400, {"error": "invalid Content-Length"})
+                return None
+            if length < 0:
+                self._respond(400, {"error": "invalid Content-Length"})
+                return None
+            return length
 
         def _discard_overcap_body(self, declared_length: int) -> None:
             """Read and throw away an over-cap body before replying 413.
@@ -608,8 +648,17 @@ def make_handler(
                     return  # client hung up early; nothing more to discard
                 remaining -= len(chunk)
 
-        def _read_body(self) -> bytes:
-            length = int(self.headers.get("Content-Length") or 0)
+        def _read_body(self) -> bytes | None:
+            """Read the request body, or None if Content-Length was malformed.
+
+            On malformed Content-Length the helper has already sent the 400
+            response; the caller must return immediately without sending
+            another response, otherwise the connection would see two status
+            lines.
+            """
+            length = self._parse_content_length()
+            if length is None:
+                return None
             return self.rfile.read(length)
 
         def _respond(self, code: int, payload: dict) -> None:

--- a/tests/server/test_content_length_129.py
+++ b/tests/server/test_content_length_129.py
@@ -1,0 +1,169 @@
+"""Malformed Content-Length must get 400, not a dropped connection (#129).
+
+Before the fix, ``int(self.headers.get(\"Content-Length\") or 0)`` raised
+``ValueError`` on ``Content-Length: abc``, the handler printed a traceback
+and the client saw an empty reply (connection dropped). The helper
+``_parse_content_length`` now catches the error and answers 400 without
+reading any body bytes, shared by ``do_POST`` and ``_read_body``.
+"""
+
+from __future__ import annotations
+
+import socket
+import threading
+import types
+
+from snagline.monitor import Monitor
+from snagline.server.http_server import make_handler, make_server
+
+
+def _start(auth_token: str | None = None):
+    """Start a sidecar on an ephemeral port; returns (server, port)."""
+    server = make_server(
+        Monitor([], []),
+        host="127.0.0.1",
+        port=0,
+        auth_token=auth_token,
+    )
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return server, int(server.server_address[1])
+
+
+def _raw_request(port: int, raw: bytes) -> bytes:
+    """Send one raw request and return the full wire response."""
+    sock = socket.create_connection(("127.0.0.1", port), timeout=10)
+    try:
+        sock.sendall(raw)
+        chunks: list[bytes] = []
+        sock.settimeout(5)
+        while True:
+            try:
+                data = sock.recv(65536)
+            except TimeoutError:
+                break
+            if not data:
+                break
+            chunks.append(data)
+        return b"".join(chunks)
+    finally:
+        sock.close()
+
+
+def test_malformed_content_length_gets_400_not_dropped_connection():
+    """Client must receive a 400 status line, not an empty reply."""
+    server, port = _start()
+    try:
+        for bad in [b"abc", b"-5", b"12.34", b""]:
+            raw = (
+                b"POST /events HTTP/1.0\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Type: application/json\r\n"
+                b"Content-Length: " + bad + b"\r\n"
+                b"\r\n"
+                b"{}"
+            )
+            response = _raw_request(port, raw)
+            assert response.startswith(b"HTTP/1.0 400"), (bad, response[:200])
+            assert b"invalid Content-Length" in response, (bad, response[:300])
+        # Server still alive afterwards.
+        ok = _raw_request(
+            port,
+            b"GET /health HTTP/1.0\r\nHost: localhost\r\n\r\n",
+        )
+        assert ok.startswith(b"HTTP/1.0 200"), ok[:120]
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_malformed_length_on_any_post_path_is_400():
+    """The helper is shared, so every POST path sees the same 400."""
+    server, port = _start()
+    try:
+        for path in [
+            b"/events",
+            b"/hooks/claude-code",
+            b"/risks",
+            b"/episodes/end",
+            b"/unknown",
+        ]:
+            raw = (
+                b"POST " + path + b" HTTP/1.0\r\n"
+                b"Host: localhost\r\n"
+                b"Content-Length: bad\r\n"
+                b"\r\n"
+            )
+            response = _raw_request(port, raw)
+            assert response.startswith(b"HTTP/1.0 400"), (path, response[:200])
+            assert b"invalid Content-Length" in response
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_absent_content_length_is_treated_as_zero():
+    """Absent header means length 0; body is silently empty (docstring)."""
+    server, port = _start()
+    try:
+        # No Content-Length at all, empty body -> _read_body reads 0 bytes,
+        # then the endpoint sees empty JSON and answers 400 invalid JSON,
+        # not 400 invalid Content-Length, and never crashes.
+        raw = b"POST /events HTTP/1.0\r\nHost: localhost\r\n\r\n"
+        response = _raw_request(port, raw)
+        assert response.startswith(b"HTTP/1.0 400"), response[:200]
+        assert b"invalid StepEvent JSON" in response
+        # Also via the helper directly: absent header returns 0.
+        handler_cls = make_handler(Monitor([], []))
+
+        class _FakeHeaders(dict):
+            def get(self, key, default=None):  # type: ignore[override]
+                return None if key == "Content-Length" else super().get(key, default)
+
+        fake = types.SimpleNamespace(headers=_FakeHeaders())
+        # bind helper as method
+        length = handler_cls._parse_content_length(fake)  # type: ignore[arg-type]
+        assert length == 0
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_malformed_length_does_not_block_subsequent_requests():
+    """A bad request must not pin the handler thread."""
+    server, port = _start()
+    try:
+        raw_bad = (
+            b"POST /events HTTP/1.0\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Length: not-a-number\r\n"
+            b"\r\n"
+            b"{}"
+        )
+        r1 = _raw_request(port, raw_bad)
+        assert r1.startswith(b"HTTP/1.0 400")
+
+        raw_ok = (
+            b"POST /events HTTP/1.0\r\n"
+            b"Host: localhost\r\n"
+            b"Content-Type: application/json\r\n"
+            b"Content-Length: 2\r\n"
+            b"\r\n"
+            b"{}"
+        )
+        r2 = _raw_request(port, raw_ok)
+        # Empty dict {} is not a valid StepEvent (missing fields) -> 400 invalid JSON,
+        # but the point is the server still responds cleanly, not dropped.
+        assert r2.startswith(b"HTTP/1.0 400")
+        assert b"invalid StepEvent" in r2
+    finally:
+        server.shutdown()
+        server.server_close()
+
+
+def test_parse_helper_docstring_mentions_absent_is_zero():
+    """Guard the docstring contract required by the issue."""
+    handler_cls = make_handler(Monitor([], []))
+    doc = handler_cls._parse_content_length.__doc__ or ""  # type: ignore[attr-defined]
+    assert "absent" in doc.lower()
+    assert "0" in doc


### PR DESCRIPTION
Fixes #129

## What

`do_POST` parsed `Content-Length` with bare `int(self.headers.get("Content-Length") or 0)`.
A non-numeric value (`abc`) raised `ValueError` inside the handler thread:
`socketserver` printed a traceback and the client saw an empty reply
(connection dropped) instead of a clean `400`.

This adds `Handler._parse_content_length()` shared by `do_POST` and
`_read_body`: absent header is treated as `0` (body silently empty,
documented in the helper docstring), non-numeric/empty/negative values
get `400 {"error": "invalid Content-Length"}` without reading any body
bytes. `do_POST` returns immediately on `None`; `_read_body` returns
`None` so its callers (`_post_events`, `_post_risks`, `_post_claude_hook`,
`_post_episodes_end`) return without sending a second status line.

## Acceptance evidence

- Raw-socket regression asserting the client RECEIVES the `400` status
  line: `test_malformed_content_length_gets_400_not_dropped_connection`
  (covers `abc`, `-5`, `12.34`, empty) and
  `test_malformed_length_on_any_post_path_is_400` (every POST path).
- Absent header is length `0`: `test_absent_content_length_is_treated_as_zero`
  (wire `400 invalid StepEvent JSON` path plus direct helper unit check)
  and docstring guard `test_parse_helper_docstring_mentions_absent_is_zero`.
- Server stays alive and bounded: `test_malformed_length_does_not_block_subsequent_requests`
  plus the existing `test_413_drain` suite still green.
- Full gate at this commit: `625 passed, 3 skipped` (coverage `88.81%`),
  `ruff check src tests` and `ruff format --check src tests` clean,
  `mypy src` clean.

## Mutation check (fix committed first, then mutated, then reverted)

- Disabled the `400` branch in `_parse_content_length` (return `0` on
  `ValueError`) -> `test_malformed_content_length_gets_400_not_dropped_connection`
  went red as expected.

Refs #106


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid or malformed `Content-Length` headers now receive a clear HTTP 400 response instead of causing the connection to be dropped.
  - Requests with missing, empty, negative, or non-numeric content lengths are handled consistently across POST endpoints.
  - Invalid requests no longer interfere with subsequent requests.
  - Body-processing endpoints now stop safely when request body acquisition fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->