### PR TITLE
fix(config): validate stagnation ranges centrally and document startup-abort contract

### DIFF
--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -258,6 +258,22 @@ episode).
 Enable it with `Config(stagnation_enabled=True)`. It ships opt-in so the
 zero-dependency preset and the published bench numbers are untouched.
 
+Validation contract (issue #132): `stagnation_window_size`,
+`stagnation_min_novelty`, and `stagnation_patience` are validated centrally
+in `Config` at construction and after env/file layering, following the same
+precedent as `log_format` (issue #119) and the horizon knobs (issue #92). An
+out-of-range value is a configuration error that aborts startup loudly with
+`ValueError` instead of running silently misconfigured. In particular
+`stagnation_min_novelty` must be within `(0.0, 1.0]`; `0.0` is rejected
+because the fire condition `novel_share < min_novelty` would then be
+unreachable (a share is always >= 0), i.e. a silently disabled detector. Use
+a small positive floor such as `0.01` when you need near-total staleness:
+with the default window of 50 the share moves in steps of 0.02, so `0.01`
+fires precisely when nothing in the window was new. This means
+`Monitor.default()` may raise `ValueError` during construction when handed an
+invalid config; runtime detection stays fail-open, only broken startup config
+fails.
+
 ### `SideEffectGuardDetector` (`side_effect_guard_enabled=True`, issue #88)
 
 `SideEffectGuardDetector(config=cfg)` watches steps the *host* marked as

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -149,6 +149,35 @@ def validate_policy(value: str) -> str:
     return normalized
 
 
+def _validated_stagnation(cfg: Config) -> None:
+    """Validate the stagnation-detector knobs (issue #132); raise when invalid.
+
+    Same contract as the horizon knobs (issue #92): an out-of-range value is a
+    configuration error and fails loudly at construction/resolve time instead
+    of silently disabling detection downstream. The one deliberate tightening
+    against ``StagnationDetector``'s old range: ``min_novelty=0.0`` used to be
+    accepted but made the fire condition unreachable (a novelty rate is always
+    >= 0, so ``rate < 0.0`` can never hold), i.e. a silently disabled safety
+    net. "Alert me when novelty hits exactly zero" needs a small positive floor
+    instead: with the default window of 50 the share moves in steps of 0.02,
+    so e.g. ``0.01`` fires precisely when nothing in the window was new.
+    """
+    if cfg.stagnation_window_size < 1:
+        raise ValueError(
+            f"stagnation_window_size must be >= 1; got {cfg.stagnation_window_size!r}"
+        )
+    if not 0.0 < cfg.stagnation_min_novelty <= 1.0:
+        raise ValueError(
+            "stagnation_min_novelty must be within (0.0, 1.0]; 0.0 would make "
+            "the fire condition unreachable and silently disable the detector; "
+            f"got {cfg.stagnation_min_novelty!r}"
+        )
+    if cfg.stagnation_patience < 1:
+        raise ValueError(
+            f"stagnation_patience must be >= 1; got {cfg.stagnation_patience!r}"
+        )
+
+
 @dataclass
 class Config:
     # Loop detector
@@ -232,10 +261,20 @@ class Config:
     # fresh signatures and evade exact matching while still being stuck.
     # Default off so the zero-dependency preset and the published bench
     # numbers are untouched.
+    #
+    # Validation contract (issue #132): these three knobs are range-checked in
+    # _validated_stagnation() at construction and after env/file layering, so
+    # an invalid value aborts startup loudly instead of silently disabling the
+    # detector. This means invalid monitoring config is a configuration error:
+    # Monitor.default() may raise ValueError during construction when handed
+    # one. Runtime detection stays fail-open (project.md §1.2); only startup
+    # with a broken config fails, and it fails with a message naming the knob.
     stagnation_enabled: bool = False
-    stagnation_window_size: int = 50  # steps per novelty window
-    stagnation_min_novelty: float = 0.05  # stale when fewer than this share new
-    stagnation_patience: int = 2  # consecutive stale windows before firing
+    stagnation_window_size: int = 50  # steps per novelty window; must be >= 1
+    stagnation_min_novelty: float = 0.05  # stale when fewer than this share new; must be within (0.0, 1.0]; 0.0 would make firing unreachable
+    stagnation_patience: int = (
+        2  # consecutive stale windows before firing; must be >= 1
+    )
 
     # Token-runaway detector (issue #84, opt-in). Sustained-burn CUSUM over
     # per-step token volume plus an optional hard per-episode budget envelope.
@@ -396,6 +435,9 @@ class Config:
         # Issue #92: same policy for the horizon-scale knobs. All default off,
         # so stock configurations never hit these checks.
         _validated_horizon(self)
+        # Issue #132: same policy for the stagnation knobs. The defaults are
+        # always valid, so stock configurations never hit these checks.
+        _validated_stagnation(self)
 
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
@@ -497,4 +539,9 @@ class Config:
         # Same re-validation for the horizon-scale knobs set from env/file
         # (issue #92): SNAGLINE_WARN_FRACTION=5 must fail loudly, not silently.
         _validated_horizon(cfg)
+        # Same re-validation for the stagnation knobs set from env/file
+        # (issue #132): SNAGLINE_STAGNATION_MIN_NOVELTY=99 must abort startup
+        # with a clear error, not crash later inside StagnationDetector or,
+        # worse, run silently mis-configured.
+        _validated_stagnation(cfg)
         return cfg

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -95,8 +95,15 @@ class StagnationDetector:
         self.patience = patience if patience is not None else cfg.stagnation_patience
         if self.window_size < 1:
             raise ValueError("window_size must be >= 1")
-        if not 0.0 <= self.min_novelty <= 1.0:
-            raise ValueError("min_novelty must be within [0.0, 1.0]")
+        # Mirrors Config._validated_stagnation (issue #132): 0.0 would make the
+        # fire condition unreachable, so the range is open at zero. Direct
+        # construction with explicit kwargs skips the Config check, hence the
+        # duplicate guard here.
+        if not 0.0 < self.min_novelty <= 1.0:
+            raise ValueError(
+                "min_novelty must be within (0.0, 1.0]; 0.0 would make the "
+                "fire condition unreachable and silently disable the detector"
+            )
         if self.patience < 1:
             raise ValueError("patience must be >= 1")
         self._windows: dict[str, _EpisodeWindow] = {}

--- a/tests/detectors/test_stagnation.py
+++ b/tests/detectors/test_stagnation.py
@@ -248,4 +248,54 @@ def test_invalid_constructor_arguments_raise():
     with pytest.raises(ValueError):
         StagnationDetector(min_novelty=1.5)
     with pytest.raises(ValueError):
+        StagnationDetector(min_novelty=0.0)  # unreachable fire condition
+    with pytest.raises(ValueError):
         StagnationDetector(patience=0)
+
+
+# --- Validation contract (issue #132) ----------------------------------------
+
+
+def test_config_rejects_degenerate_stagnation_values():
+    """Issue #132: degenerate stagnation settings are configuration errors.
+
+    They fail loudly at Config construction instead of silently disabling the
+    detector (min_novelty=0.0 made the fire condition unreachable because a
+    novelty rate is always >= 0)."""
+    with pytest.raises(ValueError, match="stagnation_window_size must be >= 1"):
+        Config(stagnation_window_size=0)
+    with pytest.raises(ValueError, match=r"stagnation_min_novelty must be within"):
+        Config(stagnation_min_novelty=0.0)
+    with pytest.raises(ValueError, match=r"stagnation_min_novelty must be within"):
+        Config(stagnation_min_novelty=-0.1)
+    with pytest.raises(ValueError, match=r"stagnation_min_novelty must be within"):
+        Config(stagnation_min_novelty=1.5)
+    with pytest.raises(ValueError, match="stagnation_patience must be >= 1"):
+        Config(stagnation_patience=0)
+
+
+def test_config_accepts_valid_stagnation_extremes():
+    cfg = Config(
+        stagnation_enabled=True,
+        stagnation_window_size=1,
+        stagnation_min_novelty=1.0,
+        stagnation_patience=1,
+    )
+    d = StagnationDetector(config=cfg)
+    risks = _feed(d, [_sig(0), _sig(0)])
+    assert len(risks) == 1 and risks[0].trigger == "stagnation"
+
+
+def test_valid_config_driven_detector_still_fires():
+    """Accepted-and-functional side of the contract: tuned-through-Config
+    knobs keep detecting (window 4 / 0.02 / 1 fires once novelty collapses)."""
+    cfg = Config(
+        stagnation_enabled=True,
+        stagnation_window_size=4,
+        stagnation_min_novelty=0.02,
+        stagnation_patience=1,
+    )
+    d = StagnationDetector(config=cfg)
+    seq = [_sig(i) for i in range(4)] + [_sig(0)] * 4
+    risks = _feed(d, seq)
+    assert risks and risks[0].trigger == "stagnation"

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from snagline.config import Config
 
 
@@ -157,3 +159,54 @@ def test_readme_configuration_snippet_matches_config_defaults():
         checked.add(name)
 
     assert "cusum_min_samples" in checked  # the field that motivated this guard
+
+
+def test_stagnation_env_override_out_of_range_aborts_startup():
+    """Issue #132 behavior B: SNAGLINE_STAGNATION_MIN_NOVELTY=99 coerces
+    cleanly but is out of range. The contract (option 1) is that invalid
+    monitoring config aborts startup loudly at construction/resolve time with
+    a clear error naming the knob, instead of crashing later inside
+    StagnationDetector or running silently mis-configured."""
+    env = {"SNAGLINE_STAGNATION_MIN_NOVELTY": "99"}
+    with pytest.raises(ValueError, match="stagnation_min_novelty"):
+        Config.from_env(environ=env)
+    with pytest.raises(ValueError, match="stagnation_min_novelty"):
+        Config.resolve(environ=env)
+    # The detector's own guard stays as defense in depth for direct use.
+    from snagline.detectors.stagnation import StagnationDetector
+
+    with pytest.raises(ValueError, match="min_novelty"):
+        StagnationDetector(config=Config(stagnation_min_novelty=0.5), min_novelty=99)
+
+
+def test_monitor_default_raises_on_invalid_config_but_not_stock():
+    """Pins the Monitor.default() raising contract for issue #132.
+
+    Construction-time validation means Monitor.default() MAY raise ValueError
+    when handed an invalid monitoring config: fail-fast startup beats a
+    silently disabled safety net. Runtime detection remains fail-open; only
+    broken startup config fails. Stock config must never raise."""
+    from snagline import Monitor
+
+    # An out-of-range env value is already rejected when the Config itself is
+    # built (see test_stagnation_env_override_out_of_range_aborts_startup).
+    # The path this test pins is a config that slips past construction (e.g.
+    # mutated afterwards) and reaches detector wiring inside default().
+    with pytest.raises(ValueError):
+        Config.from_env(environ={"SNAGLINE_STAGNATION_MIN_NOVELTY": "0"})
+    bad = Config(stagnation_enabled=True)
+    bad.stagnation_min_novelty = 0.0  # mutation bypasses __post_init__
+    with pytest.raises(ValueError):
+        Monitor.default(config=bad)
+    Monitor.default(config=Config())  # stock: must not raise
+
+
+def test_from_env_overrides_still_drops_uncoercible_values():
+    """Issue #66 semantics unchanged by the stagnation range checks (#132):
+    values that fail *coercion* are logged and dropped, not fatal. Only
+    cleanly-coerced out-of-range values are configuration errors."""
+    env = {"SNAGLINE_STAGNATION_MIN_NOVELTY": "not-a-number"}
+    overrides = Config.from_env_overrides(environ=env)
+    assert "stagnation_min_novelty" not in overrides
+    cfg = Config.from_env(environ=env)  # default survives
+    assert cfg.stagnation_min_novelty == 0.05


### PR DESCRIPTION
Fixes #132

## Decision: option 1, fail-fast central validation

Issue #132 offered three resolutions for Behavior A (min_novelty=0 silently disables) and B (out-of-range env values crash Monitor.default). This PR picks the recommended option 1: validate ranges once, centrally in Config, with clear errors and documentation that invalid monitoring config aborts startup loudly.

Argument:

* Central is the house precedent. log_format (issue #119), horizon knobs (issue #92), and policy (issue #93) already validate in Config.__post_init__ and re-validate in Config.resolve() after env/file layering. Stagnation should follow the same contract so operators see one consistent rule: a broken monitoring config is a configuration error, not a silent misbehavior.
* Startup abort beats silent disable. A ValueError during construction tells the operator exactly which knob is wrong and what range is allowed; a silently disabled detector tells them nothing until the incident it was meant to catch is missed. The fix is one edit to the config.
* Runtime stays fail-open. Project.md principle 2 concerns the monitoring path (ingest, sinks). Construction-time validation happens before any monitoring starts, so the fail-open guarantee for live detection is unchanged. Only broken startup fails, and it fails with a message naming the knob.
* Consistency for degenerate values. patience=0 and window_size=0 already raised ValueError in StagnationDetector; min_novelty=0 was the outlier that accepted but never fired. Aligning it removes the trap.

On min_novelty=0 specifically: 0.0 is now rejected with a message explaining the fire condition novel_share < min_novelty would then be unreachable (share is always >= 0) and pointing at a small positive floor. With the default window of 50 the share moves in steps of 0.02, so 0.01 fires precisely when nothing in the window was new, i.e. the practical equivalent of alert me when novelty hits zero without a special case. Keeping 0.0 accepted and documenting would leave the silently-disabled trap armed for anyone who does not read docs.

## What changed

* src/snagline/config.py: new _validated_stagnation(cfg) validating window_size >= 1, 0.0 < min_novelty <= 1.0, patience >= 1. Called in __post_init__ and re-applied in resolve() after env/file layering. Field comments now state the startup-abort contract and that Monitor.default() may raise ValueError during construction when handed an invalid config.
* src/snagline/detectors/stagnation.py: align direct-kwarg guard to 0.0 < min_novelty <= 1.0 with matching message for defense in depth when construction bypasses Config.
* docs/DETECTOR_GUIDE.md: Validation contract paragraph after the StagnationDetector opt-in line, same wording as the Config comments, including the 0.0 rationale and Monitor.default() note.

## Tests

* Accepted-and-functional: Config(stagnation_min_novelty=0.02, window_size=4, patience=1) through StagnationDetector fires once novelty collapses; valid extremes window_size=1, min_novelty=1.0, patience=1 construct and detect.
* Rejected-with-clear-error: Config(stagnation_window_size=0), Config(min_novelty=0.0), Config(min_novelty=-0.1), Config(min_novelty=1.5), Config(patience=0) each raise ValueError with match on the knob name; StagnationDetector(min_novelty=0.0) also raises.
* Env path: Config.from_env and Config.resolve with SNAGLINE_STAGNATION_MIN_NOVELTY=99 raise ValueError; coercion-drop for SNAGLINE_STAGNATION_MIN_NOVELTY=not-a-number still drops with warning and keeps the default 0.05, preserving issue #66 semantics.
* Pinned Monitor.default() contract: a config mutated post-construction to min_novelty=0.0 with stagnation_enabled=True makes Monitor.default() raise ValueError; stock Config() does not. Also verifies Config.from_env with 0 raises at build time.

All tests live in tests/detectors/test_stagnation.py and tests/test_config_loader.py.

## Gate and mutation check

Full gate green at the commit: pytest 642 passed 3 skipped, ruff check, ruff format check, mypy src. Commit already on the fix branch was mutated by relaxing the min_novelty check to 0.0 <= in src/snagline/config.py; running the targeted suite made test_config_rejects_degenerate_stagnation_values and test_monitor_default_raises_on_invalid_config_but_not_stock go red; reverting via git checkout restored green. No em dashes in any touched file, and the PR body file was scanned as well.

## Out of scope

No content retention changes; no extras touched; byte-identical without the flag.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added startup validation for stagnation detector settings.
  * Invalid window sizes, patience values, or novelty thresholds now fail clearly instead of allowing a misconfigured detector to run.
  * A minimum novelty of `0.0` is rejected because it would prevent stagnation detection from triggering.
  * Runtime detection remains fail-open after valid startup configuration.

* **Documentation**
  * Updated the detector guide with validation rules, recommended values, and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->