### PR TITLE
feat(baseline): record fitted_at so --max-age works with custom version ids

### DIFF
--- a/docs/RETRAIN_CADENCE.md
+++ b/docs/RETRAIN_CADENCE.md
@@ -59,6 +59,8 @@ Notes on this line:
   `2`/`3` mean nothing was stored, which is what you want cron mail or a
   `systemd` `on-failure` handler to catch.
 
+Age for the guard now comes from the profile's recorded `fitted_at` timestamp rather than inferring it from the version id, so custom ids like `v3` remain guardable; older stores without the field fall back to timestamp id parsing.
+
 ## systemd timer example
 
 Equivalent to the cron line, with catch-up on missed schedules:

--- a/src/snagline/baseline.py
+++ b/src/snagline/baseline.py
@@ -14,6 +14,7 @@ the same persisted profile later.
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass, field
 from typing import IO
 
@@ -117,6 +118,9 @@ class BaselineProfile:
 
     tools: dict[str, ToolBaseline] = field(default_factory=dict)
     total_steps: int = 0
+    fitted_at: float = (
+        0.0  # unix seconds when the profile was fitted; 0.0 means unknown (schema-v1)
+    )
     # Semantic reference (optional, drift extra): mean of per-step embeddings
     # over the healthy trajectory, how many steps contributed, and which
     # model produced them (provenance only; never logged with content).
@@ -140,6 +144,8 @@ class BaselineProfile:
             "total_steps": self.total_steps,
             "tools": {name: tb.to_dict() for name, tb in sorted(self.tools.items())},
         }
+        if self.fitted_at:
+            data["fitted_at"] = self.fitted_at
         # Emit semantic keys only when actually fitted so legacy structural
         # profiles keep their exact historical byte layout.
         if self.embedding_centroid is not None:
@@ -150,7 +156,10 @@ class BaselineProfile:
 
     @classmethod
     def from_dict(cls, data: dict) -> BaselineProfile:
-        profile = cls(total_steps=data.get("total_steps", 0))
+        profile = cls(
+            total_steps=data.get("total_steps", 0),
+            fitted_at=float(data.get("fitted_at", 0.0)),
+        )
         for name, tb in data.get("tools", {}).items():
             profile.tools[name] = ToolBaseline.from_dict(tb)
         centroid = data.get("embedding_centroid")
@@ -164,7 +173,7 @@ class BaselineProfile:
 def fit_baseline_from_jsonl(path: str) -> BaselineProfile:
     """Fit a ``BaselineProfile`` from a JSONL trajectory (mirrors replay's
     fail-soft line handling: malformed lines are skipped, not fatal)."""
-    profile = BaselineProfile()
+    profile = BaselineProfile(fitted_at=time.time())
     with open(path, encoding="utf-8") as fh:
         for _lineno, line in enumerate(fh, start=1):
             line = line.strip()

--- a/src/snagline/baseline_store.py
+++ b/src/snagline/baseline_store.py
@@ -207,6 +207,8 @@ class BaselineCollector:
     def commit(self, version: str | None = None) -> str | None:
         if self._store is None:
             return None
+        # Record fit time so --max-age works even with custom version ids.
+        self._profile.fitted_at = time.time()
         return self._store.save(
             self._profile,
             tenant=self._tenant,

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -644,10 +644,22 @@ def _newest_window(windows_dir: str) -> str | None:
 def _active_baseline_age(store, tenant: str, deployment: str) -> float | None:
     """Age in seconds of the newest stored version, or None if unknowable.
 
-    Version ids written by ``save()`` are wall-clock timestamps, so the id
-    doubles as the fit time. Non-numeric (custom) ids are skipped fail-open;
-    staleness is a warning aid, never a hard dependency.
+    Prefers the recorded ``fitted_at`` timestamp from the latest stored
+    profile, which is robust to custom version ids. Falls back to parsing
+    version ids as wall-clock timestamps for schema-v1 files without the
+    field. Non-numeric ids are skipped fail-open; staleness is a warning aid,
+    never a hard dependency.
     """
+    with suppress(Exception):
+        profile = store.load(tenant, deployment)
+        if profile is not None:
+            fitted = getattr(profile, "fitted_at", 0.0)
+            try:
+                fitted_f = float(fitted)
+            except (TypeError, ValueError):
+                fitted_f = 0.0
+            if fitted_f:
+                return max(0.0, time.time() - fitted_f)
     for version_id in reversed(store.list_versions(tenant, deployment)):
         try:
             fitted_at = float(version_id)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -104,3 +104,24 @@ def test_cli_baseline_command(tmp_path, capsys):
     assert "fitted 1 tool(s)" in out_text
     loaded = load_baseline(str(out))
     assert "search" in loaded.tools
+
+
+def test_fitted_at_roundtrip_and_old_files(tmp_path):
+    # New files carry fitted_at; old schema-v1 files without it load as 0.0.
+    traj = tmp_path / "h.jsonl"
+    traj.write_text(json.dumps(_event("search", 100.0)) + "\n")
+    profile = fit_baseline_from_jsonl(str(traj))
+    assert profile.fitted_at > 0
+    out = tmp_path / "baseline.json"
+    save_baseline(profile, str(out))
+    data = json.loads(out.read_text())
+    assert "fitted_at" in data
+    loaded = load_baseline(str(out))
+    assert loaded.fitted_at == profile.fitted_at
+    # Simulate a pre-128 file without the key.
+    old = {k: v for k, v in data.items() if k != "fitted_at"}
+    old_path = tmp_path / "old.json"
+    old_path.write_text(json.dumps(old))
+    old_loaded = load_baseline(str(old_path))
+    assert old_loaded.fitted_at == 0.0
+    assert old_loaded.tools["search"].mean_latency == 100.0

--- a/tests/test_baseline_retrain.py
+++ b/tests/test_baseline_retrain.py
@@ -194,13 +194,13 @@ def test_cli_retrain_windows_dir_picks_newest_by_mtime(tmp_path, capsys):
 
 def test_cli_retrain_max_age_warns_on_stale_baseline(tmp_path, capsys):
     store_dir = tmp_path / "store"
-    win_a = _window(tmp_path / "a.jsonl", "search", [100.0] * 3)
     win_b = _window(tmp_path / "b.jsonl", "search", [110.0] * 3)
     store = BaselineStore(str(store_dir))
-    # Fixed ancient version id: wall-clock unix time far in the past.
-    capture_from_jsonl(
-        store, win_a, tenant="acme", deployment="prod", version="1000000000.0"
-    )
+    # Stale baseline via fitted_at, not version id: robust to custom ids.
+    from snagline.baseline import BaselineProfile
+
+    stale = BaselineProfile(fitted_at=time.time() - 7200)
+    store.save(stale, tenant="acme", deployment="prod", version="v-stale")
 
     rc = main(
         [
@@ -333,6 +333,59 @@ def test_active_baseline_age_skips_non_numeric_ids(tmp_path):
     age = _active_baseline_age(store, "t", "d")
     assert age is not None
     assert 0.0 <= age < 60.0
+
+
+def test_active_baseline_age_prefers_fitted_at(tmp_path):
+    # Custom version id with a stale fitted_at must still warn (fails on master).
+    from snagline.baseline import BaselineProfile
+
+    store = BaselineStore(str(tmp_path / "store"))
+    p = BaselineProfile(fitted_at=time.time() - 7200)
+    store.save(p, tenant="t", deployment="d", version="v-custom")
+    age = _active_baseline_age(store, "t", "d")
+    assert age is not None
+    assert 7000 < age < 8000
+    # Fresh fitted_at must not warn even with a custom id.
+    fresh = BaselineProfile(fitted_at=time.time())
+    store2 = BaselineStore(str(tmp_path / "store2"))
+    store2.save(fresh, tenant="t", deployment="d", version="v-custom")
+    fresh_age = _active_baseline_age(store2, "t", "d")
+    assert fresh_age is not None
+    assert fresh_age < 5.0
+
+
+def test_cli_retrain_max_age_with_custom_version_and_stale_fitted_at(tmp_path, capsys):
+    from snagline.baseline import BaselineProfile
+
+    store_dir = tmp_path / "store"
+    win = _window(tmp_path / "w.jsonl", "search", [100.0] * 3)
+    store = BaselineStore(str(store_dir))
+    stale = BaselineProfile(fitted_at=time.time() - 7200)
+    store.save(stale, tenant="acme", deployment="prod", version="v-custom")
+    rc = main(
+        [
+            "baseline",
+            "retrain",
+            "--store-dir",
+            str(store_dir),
+            "--tenant",
+            "acme",
+            "--deployment",
+            "prod",
+            "--jsonl",
+            win,
+            "--max-age",
+            "3600",
+        ]
+    )
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "WARNING" in err
+    # Old schema file without fitted_at still loads via fallback to id parsing.
+    old_store = BaselineStore(str(tmp_path / "oldstore"))
+    prof = BaselineProfileStub()
+    old_store.save(prof, tenant="t", deployment="d", version="v-old")
+    assert _active_baseline_age(old_store, "t", "d") is None
 
 
 def test_legacy_flat_baseline_form_unchanged(tmp_path):


### PR DESCRIPTION
Fixes #128

Additive `fitted_at` on `BaselineProfile` so `--max-age` works with custom version ids.

## What changed

* src/snagline/baseline.py: new `fitted_at: float = 0.0` on `BaselineProfile`. Set to `time.time()` in `fit_baseline_from_jsonl` and in `BaselineCollector.commit` before persisting. Serialized conditionally in `to_dict` (only when non-zero) to keep legacy byte shape for empty profiles; `from_dict` reads `float(data.get("fitted_at", 0.0))` so schema-v1 files without the key load unchanged with `0.0` meaning unknown age.
* src/snagline/baseline_store.py: `BaselineCollector.commit` records `fitted_at` right before `store.save`.
* src/snagline/cli.py: `_active_baseline_age` now prefers `fitted_at` from the loaded latest profile when present and non-zero, falling back to parsing version ids as timestamps for old stores. Non-numeric ids are still skipped fail-open; staleness remains a warning aid.

## Tests

* `test_fitted_at_roundtrip_and_old_files`: a freshly fitted profile carries `fitted_at > 0` and round-trips through `save_baseline`/`load_baseline`; a simulated pre-128 JSON without `fitted_at` loads as `0.0` and still yields correct tool stats.
* `test_active_baseline_age_prefers_fitted_at`: a store seeded with `version="v-custom"` and `fitted_at = now - 7200` reports age ~7200s (the case that returned `None` on master); a fresh `fitted_at` with custom id reports age <5s.
* `test_cli_retrain_max_age_with_custom_version_and_stale_fitted_at`: `snagline baseline retrain` with `--max-age 3600` warns when the active profile's `fitted_at` is 2h old even though the version id is `v-custom`; old stub profiles without `fitted_at` still fall back to id parsing (custom-only returns `None`).
* Updated `test_cli_retrain_max_age_warns_on_stale_baseline` to drive staleness via `fitted_at` rather than an ancient timestamp version id, reflecting the new primary source.

## Docs

* docs/RETRAIN_CADENCE.md: one sentence noting age now comes from the recorded `fitted_at` timestamp and remains guardable with custom ids, with fallback to timestamp-id parsing for older stores.

## Gate and mutation check

Full gate green at the commit: pytest 647 passed 3 skipped, ruff check, ruff format check, mypy src. Commit was mutated by disabling the `fitted_at` branch in `_active_baseline_age` (`if fitted_f:` to `if False:`); `test_active_baseline_age_prefers_fitted_at` and `test_cli_retrain_max_age_with_custom_version_and_stale_fitted_at` went red; reverting via `git checkout` restored green. No em dashes in any touched file and the PR body file was scanned as well.
