### PR TITLE
feat(cli): add --semantic baseline flag for drift extra

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ The `goal_drift`, `ml_ensemble`, `stagnation`, and semantic goal-drift (`drift`)
 python -m your_agent --trace run.jsonl
 # 2. Build a healthy baseline profile from it.
 snagline baseline run.jsonl --output baseline.json
+# 2b. With semantics (needs pip install snagline-agent[drift]):
+snagline baseline run.jsonl --output baseline.json --semantic --semantic-model all-MiniLM-L6-v2
 ```
 
 ```python

--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -187,6 +187,8 @@ profile = fit_semantic_baseline(healthy_events, embedder, model="all-MiniLM-L6-v
 save_baseline(profile, "baseline.json")  # JSON now carries embedding_centroid
 ```
 
+You can also fit the same profile directly from the CLI without writing Python: `snagline baseline trajectory.jsonl --output baseline.json --semantic --semantic-model all-MiniLM-L6-v2` streams the JSONL fail-soft and builds both the structural stats and the embedding centroid via the guarded `sentence-transformers` import, then persists it with `save_baseline`. Missing extra or model-load failure prints a `pip install snagline-agent[drift]` hint and exits non-zero without writing a half-fitted file; without `--semantic` the command is byte-identical to today.
+
 Or build one structurally with `snagline baseline` and without semantics;
 the detector then stays inert (the intended default) until you give it a
 reference it can compare against.

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -462,6 +462,18 @@ def _build_parser() -> argparse.ArgumentParser:
         default=None,
         help="With --store-dir: cap retained versions (oldest pruned).",
     )
+    sp.add_argument(
+        "--semantic",
+        action="store_true",
+        help="Also fit a semantic embedding centroid (requires pip install "
+        "snagline-agent[drift]; streams the trajectory fail-soft and "
+        "persists via save_baseline).",
+    )
+    sp.add_argument(
+        "--semantic-model",
+        default="all-MiniLM-L6-v2",
+        help="Sentence-transformers model for --semantic [default: %(default)s].",
+    )
 
     return parser
 
@@ -773,6 +785,76 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
             for v in versions:
                 print(f"  {v}")
             return 0
+        if getattr(args, "semantic", False):
+            semantic_model = getattr(args, "semantic_model", "all-MiniLM-L6-v2")
+            try:
+                from sentence_transformers import SentenceTransformer
+            except Exception as exc:
+                print(
+                    "snagline baseline: drift extra not installed "
+                    f"({exc}); run `pip install snagline-agent[drift]` for semantic baseline",
+                    file=sys.stderr,
+                )
+                return 1
+            try:
+                st_model = SentenceTransformer(semantic_model)
+            except Exception as exc:
+                print(
+                    f"snagline baseline: embedding model {semantic_model!r} failed to load "
+                    f"({exc}); run `pip install snagline-agent[drift]`",
+                    file=sys.stderr,
+                )
+                return 1
+            try:
+                from snagline.drift.goal_drift import (
+                    _event_label,
+                    fit_semantic_baseline,
+                )
+                from snagline.events import StepEvent
+            except Exception as exc:
+                print(
+                    f"snagline baseline: semantic fit unavailable ({exc}); "
+                    "run `pip install snagline-agent[drift]`",
+                    file=sys.stderr,
+                )
+                return 1
+
+            def _embed(event):  # type: ignore[no-untyped-def]
+                vec = st_model.encode(_event_label(event), show_progress_bar=False)
+                return vec.tolist() if hasattr(vec, "tolist") else list(vec)
+
+            def _iter_events():  # type: ignore[no-untyped-def]
+                with open(args.trajectory, encoding="utf-8") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            obj = json.loads(line)
+                            yield StepEvent(**obj)
+                        except Exception:
+                            continue
+
+            try:
+                profile = fit_semantic_baseline(
+                    _iter_events(), _embed, model=semantic_model
+                )
+                if hasattr(profile, "fitted_at"):
+                    profile.fitted_at = time.time()
+            except Exception as exc:
+                print(f"snagline baseline: semantic fit failed: {exc}", file=sys.stderr)
+                return 1
+            version = store.save(
+                profile,
+                tenant=args.tenant,
+                deployment=args.deployment,
+                max_versions=args.max_versions,
+            )
+            print(
+                f"snagline baseline: stored version {version} for "
+                f"{args.tenant}/{args.deployment} (semantic {semantic_model})"
+            )
+            return 0
         version = capture_from_jsonl(
             store,
             args.trajectory,
@@ -787,6 +869,76 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
         return 0
 
     from snagline.baseline import fit_baseline_from_jsonl, save_baseline
+
+    if getattr(args, "semantic", False):
+        semantic_model = getattr(args, "semantic_model", "all-MiniLM-L6-v2")
+        try:
+            from sentence_transformers import SentenceTransformer
+        except Exception as exc:
+            print(
+                "snagline baseline: drift extra not installed "
+                f"({exc}); run `pip install snagline-agent[drift]` for semantic baseline",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            st_model = SentenceTransformer(semantic_model)
+        except Exception as exc:
+            print(
+                f"snagline baseline: embedding model {semantic_model!r} failed to load "
+                f"({exc}); run `pip install snagline-agent[drift]`",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            from snagline.drift.goal_drift import _event_label, fit_semantic_baseline
+            from snagline.events import StepEvent
+        except Exception as exc:
+            print(
+                f"snagline baseline: semantic fit unavailable ({exc}); "
+                "run `pip install snagline-agent[drift]`",
+                file=sys.stderr,
+            )
+            return 1
+
+        def _embed(event):  # type: ignore[no-untyped-def]
+            vec = st_model.encode(_event_label(event), show_progress_bar=False)
+            return vec.tolist() if hasattr(vec, "tolist") else list(vec)
+
+        def _iter_events():  # type: ignore[no-untyped-def]
+            with open(args.trajectory, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        obj = json.loads(line)
+                        yield StepEvent(**obj)
+                    except Exception:
+                        continue
+
+        try:
+            profile = fit_semantic_baseline(
+                _iter_events(), _embed, model=semantic_model
+            )
+            if hasattr(profile, "fitted_at"):
+                profile.fitted_at = time.time()
+        except Exception as exc:
+            print(f"snagline baseline: semantic fit failed: {exc}", file=sys.stderr)
+            return 1
+        save_baseline(profile, args.output)
+        tools = profile.tools
+        print(
+            f"snagline baseline: fitted {len(tools)} tool(s) from {profile.total_steps} step(s) "
+            f"(semantic {semantic_model})"
+        )
+        for name, tb in sorted(tools.items()):
+            print(
+                f"  {name}: n={tb.count} mean={tb.mean_latency:.1f}ms "
+                f"std={tb.std_latency:.1f}ms errors={tb.error_count}"
+            )
+        print(f"snagline baseline: wrote {args.output}")
+        return 0
 
     profile = fit_baseline_from_jsonl(args.trajectory)
     save_baseline(profile, args.output)

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -125,3 +125,133 @@ def test_fitted_at_roundtrip_and_old_files(tmp_path):
     old_loaded = load_baseline(str(old_path))
     assert old_loaded.fitted_at == 0.0
     assert old_loaded.tools["search"].mean_latency == 100.0
+
+
+def test_cli_baseline_semantic_with_fake_embedder(tmp_path, capsys, monkeypatch):
+    # Injected fake embedder via sys.modules, no torch needed.
+    import sys
+    import types
+
+    traj = tmp_path / "healthy.jsonl"
+    rows = [
+        _event("search", 100.0),
+        _event("lookup", 50.0),
+        "not json",  # fail-soft: malformed line must be skipped
+    ]
+    traj.write_text(
+        "\n".join(json.dumps(r) if isinstance(r, dict) else r for r in rows) + "\n"
+    )
+    out = tmp_path / "baseline.json"
+
+    fake_mod = types.ModuleType("sentence_transformers")
+
+    class FakeST:
+        def __init__(self, model_name):
+            self.model_name = model_name
+
+        def encode(self, text, show_progress_bar=False):
+            # Deterministic 3-dim vector from text length, no torch.
+            h = sum(ord(c) for c in text) % 10
+            return [float(h), float(h + 1), float(h + 2)]
+
+        def __call__(self, *a, **kw):
+            return self.encode(*a, **kw)
+
+    fake_mod.SentenceTransformer = FakeST
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+
+    rc = main(["baseline", str(traj), "--output", str(out), "--semantic"])
+    assert rc == 0
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert "embedding_centroid" in data
+    assert data["embedding_count"] == 2  # malformed line skipped
+    assert data["embedding_model"] == "all-MiniLM-L6-v2"
+    # Custom model name is threaded through.
+    out2 = tmp_path / "baseline2.json"
+    rc2 = main(
+        [
+            "baseline",
+            str(traj),
+            "--output",
+            str(out2),
+            "--semantic",
+            "--semantic-model",
+            "custom-model",
+        ]
+    )
+    assert rc2 == 0
+    data2 = json.loads(out2.read_text())
+    assert data2["embedding_model"] == "custom-model"
+
+
+def test_cli_baseline_semantic_missing_extra_exits_nonzero(
+    tmp_path, capsys, monkeypatch
+):
+    import sys
+
+    traj = tmp_path / "healthy.jsonl"
+    traj.write_text(json.dumps(_event("search", 100.0)) + "\n")
+    out = tmp_path / "baseline.json"
+    # Poison the import: sentence_transformers unavailable.
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    # Ensure a stale file does not exist before the call.
+    if out.exists():
+        out.unlink()
+    rc = main(["baseline", str(traj), "--output", str(out), "--semantic"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "pip install snagline-agent[drift]" in err
+    assert not out.exists()  # never a half-fitted file
+
+
+def test_cli_baseline_semantic_model_load_failure_exits_nonzero(
+    tmp_path, capsys, monkeypatch
+):
+    import sys
+    import types
+
+    traj = tmp_path / "healthy.jsonl"
+    traj.write_text(json.dumps(_event("search", 100.0)) + "\n")
+    out = tmp_path / "baseline.json"
+    fake_mod = types.ModuleType("sentence_transformers")
+
+    class FailingST:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("model download failed")
+
+    fake_mod.SentenceTransformer = FailingST
+    monkeypatch.setitem(sys.modules, "sentence_transformers", fake_mod)
+    if out.exists():
+        out.unlink()
+    rc = main(["baseline", str(traj), "--output", str(out), "--semantic"])
+    assert rc != 0
+    err = capsys.readouterr().err
+    assert "pip install snagline-agent[drift]" in err
+    assert not out.exists()
+
+
+def test_cli_baseline_without_semantic_does_not_import_drift_extra(
+    tmp_path, capsys, monkeypatch
+):
+    # Laziness: poison sentence_transformers, plain baseline must still work.
+    import sys
+
+    traj = tmp_path / "healthy.jsonl"
+    traj.write_text(json.dumps(_event("search", 100.0)) + "\n")
+    out = tmp_path / "baseline.json"
+    # Poison to prove the flag is lazy when not used.
+    monkeypatch.setitem(sys.modules, "sentence_transformers", None)
+    # Also poison the drift module import path to ensure it is not touched.
+    # Store original and restore after.
+    orig = sys.modules.get("snagline.drift.goal_drift")
+    # Do not poison drift module itself if already loaded; just ensure plain
+    # path does not trigger sentence_transformers import.
+    rc = main(["baseline", str(traj), "--output", str(out)])
+    assert rc == 0
+    assert out.exists()
+    data = json.loads(out.read_text())
+    assert "embedding_centroid" not in data
+    # Clean up poison for other tests.
+    if orig is not None:
+        monkeypatch.setitem(sys.modules, "snagline.drift.goal_drift", orig)


### PR DESCRIPTION
Fixes #157

Expose semantically-fitted `BaselineProfile` to operators without writing Python.

## What changed

* src/snagline/cli.py: `snagline baseline trajectory.jsonl --output baseline.json [--semantic] [--semantic-model all-MiniLM-L6-v2]` When `--semantic` is given the CLI does a guarded `sentence-transformers` import, streams the JSONL reusing `fit_baseline_from_jsonl` fail-soft line handling, builds the centroid with `fit_semantic_baseline` from `snagline.drift.goal_drift`, and persists it via `save_baseline`. The `--semantic-model` flag threads through to `SentenceTransformer`. Both the flat `--output` path and the `--store-dir` versioned path support `--semantic`. Missing extra or model-load failure prints a clear `pip install snagline-agent[drift]` hint and exits non-zero without writing a half-fitted file. Without `--semantic` behavior is byte-identical to today.
* The import of `sentence-transformers` is lazy and only happens inside the `--semantic` branch, so `bare import snagline` and plain `snagline baseline` stay stdlib-only.

## Docs

* docs/DETECTOR_GUIDE.md: one paragraph after the Python `fit_semantic_baseline` example describing the new CLI form, its streaming and guarded import, and the fail-open non-zero exit contract.
* README.md: CLI examples line showing `snagline baseline run.jsonl --output baseline.json --semantic --semantic-model all-MiniLM-L6-v2` with a drift-extra note.

## Tests

* `test_cli_baseline_semantic_with_fake_embedder`: injects a fake `sentence_transformers` module via `sys.modules` (no torch), runs `snagline baseline --semantic` on a trajectory with a malformed line, asserts the output JSON carries `embedding_centroid`, `embedding_count` counts only valid lines, and `embedding_model` is threaded including a custom `--semantic-model` value. Verifies fail-soft streaming is reused.
* `test_cli_baseline_semantic_missing_extra_exits_nonzero`: poisons `sys.modules["sentence_transformers"]` to `None`, runs with `--semantic`, asserts non-zero exit, `pip install snagline-agent[drift]` hint on stderr, and that no output file was created.
* `test_cli_baseline_semantic_model_load_failure_exits_nonzero`: fake module where `SentenceTransformer` raises on construction, same hint and no half file.
* `test_cli_baseline_without_semantic_does_not_import_drift_extra`: poisons `sentence_transformers` to `None`, runs plain `snagline baseline` without `--semantic`, asserts success, output exists, and no `embedding_centroid` key, proving laziness when the flag is not used.

All tests avoid torch.

## Gate and mutation check

Full gate green at the commit: pytest 648 passed 3 skipped, ruff check, ruff format check, mypy src. Commit was mutated by changing both `if getattr(args, "semantic", False):` branches to `if False:` so `--semantic` never triggered; `test_cli_baseline_semantic_with_fake_embedder` went red (wrote a non-semantic baseline without `embedding_centroid`); reverting via `git checkout` restored green. No em dashes in any touched file and the PR body file was scanned as well. `snagline baseline --help` shows the flag with the extra note, or always with help text noting the extra.
