### PR TITLE
fix(continuum): rate-limit poll storage warnings to one per outage

### DIFF
--- a/src/snagline/adapters/continuum_adapter.py
+++ b/src/snagline/adapters/continuum_adapter.py
@@ -139,8 +139,21 @@ class ContinuumAdapter:
         #: action key -> epoch seconds of the observed claim, for latency pairing
         self._pending_claims: dict[str, float] = {}
         self._stop = threading.Event()
+        # Rate-limited read-failure logging (issue #171): mirror
+        # Monitor._log_fault_once so a down DB does not spam every interval.
+        self._read_failed = False
+        self._consecutive_failures = 0
 
     # -- public API -------------------------------------------------------- #
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Number of consecutive read failures since the last success.
+
+        Exposed for host alerting without scraping logs (issue #171).
+        Resets to 0 on the next successful poll.
+        """
+        return self._consecutive_failures
 
     def poll(self) -> int:
         """Read and ingest every entry after the cursor. Returns count ingested.
@@ -156,12 +169,23 @@ class ContinuumAdapter:
                 self._storage.read_events(self._run_id, after_sequence=self._cursor)
             )
         except Exception:
-            logger.warning(
-                "snagline continuum adapter: read failed for run %s; will retry",
-                self._run_id,
-                exc_info=True,
-            )
+            self._consecutive_failures += 1
+            if not self._read_failed:
+                logger.warning(
+                    "snagline continuum adapter: read failed for run %s; will retry",
+                    self._run_id,
+                    exc_info=True,
+                )
+                self._read_failed = True
             return 0
+        if self._read_failed:
+            logger.info(
+                "snagline continuum adapter: read recovered for run %s after %d failure(s)",
+                self._run_id,
+                self._consecutive_failures,
+            )
+            self._read_failed = False
+        self._consecutive_failures = 0
         count = 0
         for entry in entries:
             if self.push(entry):

--- a/tests/adapters/test_continuum_adapter.py
+++ b/tests/adapters/test_continuum_adapter.py
@@ -382,3 +382,67 @@ def test_modules_import_without_continuum(monkeypatch: pytest.MonkeyPatch) -> No
     sink_mod = importlib.import_module("snagline.sinks.continuum_sink")
     assert adapter_mod.ContinuumAdapter is not None
     assert sink_mod.ContinuumSink is not None
+
+
+def test_poll_rate_limits_storage_warnings(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Persistent outage logs once then suppresses repeats (issue #171)."""
+    storage = FakeStorage([make_perception(1)])
+    storage.fail_reads = True
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        for _ in range(5):
+            assert adapter.poll() == 0
+        warnings = [
+            r for r in caplog.records if "read failed for run run-1" in r.message
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].levelname == "WARNING"
+        assert adapter.consecutive_failures == 5
+    # Recovery logs exactly once and resets the counter.
+    storage.fail_reads = False
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="snagline"):
+        assert adapter.poll() == 1
+        recoveries = [
+            r for r in caplog.records if "read recovered for run run-1" in r.message
+        ]
+        assert len(recoveries) == 1
+        assert "after 5 failure" in recoveries[0].message
+        assert adapter.consecutive_failures == 0
+    # Next poll with no new data must not log another recovery.
+    caplog.clear()
+    with caplog.at_level(logging.INFO, logger="snagline"):
+        adapter.poll()
+        assert not [r for r in caplog.records if "read recovered" in r.message]
+
+
+def test_poll_logs_new_warning_after_recovery(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Intermittent failure after recovery surfaces a new warning (issue #171)."""
+    storage = FakeStorage([make_perception(1)])
+    storage.fail_reads = True
+    monitor = RecordingMonitor()
+    adapter = ContinuumAdapter(monitor, storage, "run-1", start_at_tail=False)
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        adapter.poll()
+        assert len([r for r in caplog.records if "read failed" in r.message]) == 1
+    storage.fail_reads = False
+    with caplog.at_level(logging.INFO, logger="snagline"):
+        adapter.poll()
+        assert len([r for r in caplog.records if "read recovered" in r.message]) == 1
+    # New outage after recovery must log a fresh warning.
+    storage.fail_reads = True
+    caplog.clear()
+    with caplog.at_level(logging.WARNING, logger="snagline"):
+        adapter.poll()
+        warnings = [r for r in caplog.records if "read failed" in r.message]
+        assert len(warnings) == 1
+        assert adapter.consecutive_failures == 1
+    # Fail-open still holds throughout.
+    storage.fail_reads = False
+    assert adapter.poll() == 0  # no new entries, but read succeeded
+    assert adapter.consecutive_failures == 0


### PR DESCRIPTION
Fixes #171

Rate-limit `ContinuumAdapter.poll()` storage-outage warnings so a down CONTINUUM does not spam logs every interval.

## Problem

`poll()` logged `logger.warning("... read failed for run %s; will retry ...")` on every failing call. With `poll_forever(interval=1s)` and a down DB for an hour that is ~3600 identical tracebacks per watched run. `Monitor._log_fault_once()` already solved the same noise for detectors and sinks; the adapter never got one.

## Solution

Mirror `Monitor._log_fault_once` inside the adapter. Track `_read_failed` and `_consecutive_failures` per adapter instance:

* First read failure logs at WARNING with traceback then suppresses repeats while failure persists.
* Next successful poll logs one INFO recovery line with the failure count and resets the counter.
* `consecutive_failures` is exposed as a read-only property for host alerting without scraping logs.
* Fail-open unchanged: no exceptions propagate either way; `test_storage_error_is_swallowed_fail_open` stays green.

## Tests

* `test_poll_rate_limits_storage_warnings`: FakeStorage whose `read_events` raises 5 times, assert caplog has exactly 1 warning and `consecutive_failures == 5`, then one INFO recovery after success and counter reset, then no second recovery on empty poll.
* `test_poll_logs_new_warning_after_recovery`: recovery followed by a new failure logs a fresh warning and resets again. Also verifies fail-open throughout.

Existing 15 adapter tests remain green.

## Mutation check

After committing, mutated `if not self._read_failed:` to `if False:` in `continuum_adapter.py`. `test_poll_rate_limits_storage_warnings` went red (0 warnings vs expected 1); `test_poll_logs_new_warning_after_recovery` also red. Reverted via `git checkout` and both tests went green. Proves the rate-limit branch is exercised.

## Gate

pytest 653 passed 3 skipped, ruff check, ruff format --check, mypy src all green at the commit. No em dashes in code, docs, or this body.
