### PR TITLE
fix(monitor): bound per-episode state with LRU cap and fix clock retention

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,7 @@ the path variant below.
 | `SNAGLINE_HALT_URL` | `halt_url` | *(unset)* | Halt webhook endpoint; required when policy is halt_webhook |
 | `SNAGLINE_HALT_TIMEOUT_S` | `halt_timeout_s` | 0.25 | Halt webhook round-trip budget in seconds; timeout fails open to continue |
 | `SNAGLINE_MIN_SEVERITY_FOR_HALT` | `min_severity_for_halt` | 0.8 | Minimum risk score that pays the halt-webhook cost |
+| `SNAGLINE_MAX_LIVE_EPISODES` | `max_live_episodes` | 10000 | Per-episode LRU cap; when exceeded the least-recently-seen episode is evicted silently (no finalize). Explicit `end_episode` still frees immediately |
 
 A handful of variables sit outside `Config` because they are consumed
 directly by one component each:
@@ -594,7 +595,7 @@ snagline watch --file /var/log/agent/events.jsonl --follow
 | **FailureRisk** | The signal. Carries no raw content, no metadata. Just ids, score, trigger, detail, and timestamp. |
 | **Sink** | The escalation path: `emit(risk) -> None`. Fire-and-forget, never blocks ingest. |
 | **Action signature** | A one-way SHA-256 digest of the logical action. Volatile fields (timestamps, nonces, retry counters) must be excluded so retries look like retries, not unique actions. |
-| **Episode** | A logical unit of work (a single agent run, a user session). Per-episode state is isolated and can be cleared via `monitor.end_episode()`. |
+| **Episode** | A logical unit of work (a single agent run, a user session). Per-episode state is isolated and MUST be cleared via `monitor.end_episode()` when the episode is finished; otherwise the Monitor evicts the least-recently-seen episode once `max_live_episodes` (default 10000, env `SNAGLINE_MAX_LIVE_EPISODES`) is exceeded. Eviction is silent (no finalize risks) and retains only episode ids, never content. |
 | **Config** | All tunable thresholds in one dataclass. Sensible defaults ship so zero configuration works. |
 
 ## Architecture
@@ -625,7 +626,7 @@ from snagline import Monitor, StepEvent, FailureRisk, Config, make_signature, wa
 |:--|:--|
 | `Monitor` | Orchestrator. `Monitor.default()` returns a ready-to-use instance. |
 | `Monitor.ingest(event)` | Run all detectors against one event. Never raises (fail-open). |
-| `Monitor.end_episode(episode_id)` | Clear per-episode detector state. |
+| `Monitor.end_episode(episode_id)` | Clear per-episode detector state. MUST be called when an episode finishes; otherwise state is retained until LRU eviction. The retained count is exposed as `monitor.retained_episodes` and `snagline_monitor_retained_episodes` (prometheus) and `metrics()["retained_episodes"]`. |
 | `StepEvent` | Frozen dataclass. The canonical event schema. |
 | `FailureRisk` | Frozen dataclass. The detection signal. |
 | `Config` | Dataclass. All tunable thresholds. |

--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -31,6 +31,10 @@ class MyAdapter:
 
 When the run finishes, call `monitor.end_episode(episode_id)` so per-episode
 detector state (loop windows, CUSUM baselines) doesn't leak into the next run.
+If you never call it, the Monitor evicts the least-recently-seen episode once
+`max_live_episodes` (default 10000, env `SNAGLINE_MAX_LIVE_EPISODES`) is
+exceeded. Eviction is silent (no finalize risks) and the retained count is
+exposed as `monitor.retained_episodes`.
 If your framework is a context manager or generator, put that teardown in the
 `finally` - see `adapters/raw.py` and `adapters/langchain_adapter.py:close`.
 

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -149,6 +149,14 @@ def validate_policy(value: str) -> str:
     return normalized
 
 
+def _validated_max_live_episodes(cfg: Config) -> None:
+    """Validate the per-episode cap (issue #184); raise when invalid."""
+    if cfg.max_live_episodes < 1:
+        raise ValueError(
+            f"max_live_episodes must be >= 1; got {cfg.max_live_episodes!r}"
+        )
+
+
 def _validated_stagnation(cfg: Config) -> None:
     """Validate the stagnation-detector knobs (issue #132); raise when invalid.
 
@@ -427,6 +435,17 @@ class Config:
     # latency_anomaly risk before the new baseline is adopted. 0 disables.
     cusum_refit_every: int = 0
 
+    # --- Per-episode retention cap (issue #184) -----------------------------
+    # Long-lived monitors (especially the sidecar) must not grow without
+    # bound when hosts never call end_episode. The cap is a safety net:
+    # explicit end_episode still frees immediately; eviction only fires
+    # when the number of distinct live episodes would otherwise exceed this.
+    # LRU by last-seen is the safe policy: a genuinely active episode is
+    # by definition recently seen, so it cannot be evicted out from under
+    # itself. Eviction is silent (no finalize risks) and fail-open.
+    # Environment override SNAGLINE_MAX_LIVE_EPISODES.
+    max_live_episodes: int = 10_000
+
     def __post_init__(self) -> None:
         # Issue #119: invalid closed-set values are configuration errors and
         # must fail loudly here instead of being silently ignored downstream.
@@ -438,6 +457,7 @@ class Config:
         # Issue #132: same policy for the stagnation knobs. The defaults are
         # always valid, so stock configurations never hit these checks.
         _validated_stagnation(self)
+        _validated_max_live_episodes(self)
 
     # --- 12-factor configuration (project.md §5.4, ATTACH_ANY_SYSTEM P0) -----
     @classmethod
@@ -544,4 +564,5 @@ class Config:
         # with a clear error, not crash later inside StagnationDetector or,
         # worse, run silently mis-configured.
         _validated_stagnation(cfg)
+        _validated_max_live_episodes(cfg)
         return cfg

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -20,6 +20,7 @@ import os
 import threading
 import time
 import urllib.request
+from collections import OrderedDict
 from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
@@ -214,6 +215,17 @@ class Monitor:
         self._warn_fraction = cfg.warn_fraction
         self._idle_warn_seconds = cfg.idle_warn_seconds
         self._clocks: dict[str, _EpisodeClock] = {}
+        # Per-episode retention cap (issue #184): bounded LRU of live episode
+        # ids. Every ingest touches the entry; when the cap is exceeded the
+        # least-recently-seen id is evicted silently (no finalize risks) via
+        # the same teardown as end_episode. Explicit end_episode still frees
+        # immediately; this is the safety net for hosts that never call it.
+        # No content retention: keys are episode ids only.
+        self._max_live_episodes: int = int(getattr(cfg, "max_live_episodes", 10_000))
+        if self._max_live_episodes < 1:
+            self._max_live_episodes = 10_000
+        self._live_episodes: OrderedDict[str, None] = OrderedDict()
+        self._live_lock = threading.Lock()
         # A faulty detector or sink must not spam the logs on every single step
         # (issue #14) -- log each distinct fault exactly once.
         self._fault_lock = threading.Lock()
@@ -314,6 +326,21 @@ class Monitor:
         wall clock, so replay stays deterministic. The dispatch tail belongs to
         the sinks/policy layer and is left untouched by time-axis logic.
         """
+        # Per-episode retention cap (issue #184): touch LRU and evict if over
+        # cap. Done outside the episode lock so eviction of a different id
+        # does not deadlock. LRU by last-seen is safe: an active episode is
+        # by definition recently seen and cannot be evicted out from under
+        # itself. Eviction is silent (no finalize) and fail-open.
+        evicted: str | None = None
+        with self._live_lock:
+            if event.episode_id in self._live_episodes:
+                self._live_episodes.move_to_end(event.episode_id)
+            else:
+                self._live_episodes[event.episode_id] = None
+                if len(self._live_episodes) > self._max_live_episodes:
+                    evicted, _ = self._live_episodes.popitem(last=False)
+        if evicted is not None and evicted != event.episode_id:
+            self._evict_episode(evicted)
         risks: list[FailureRisk] = []
         with self._state.episode_lock(event.episode_id):
             # Time-axis head (issue #92): computed from StepEvent timestamps at
@@ -356,6 +383,12 @@ class Monitor:
           breach (mirrors TokenRunawayDetector's envelope ordering).
         """
         out: list[FailureRisk] = []
+        # Inert unless one of the opt-in horizon knobs is set (issue #92). When
+        # both are None the time axis claims to be inert, so do not retain
+        # per-episode clocks at all (issue #184: _clocks grew even with the
+        # feature off). No content retention beyond ids.
+        if self._max_wall_seconds is None and self._idle_warn_seconds is None:
+            return out
         try:
             clock = self._clocks.get(event.episode_id)
             if clock is None:
@@ -534,7 +567,19 @@ class Monitor:
     def metrics(self) -> dict:
         """Return a snapshot of self-observability counters (P3, item 10)."""
         with self._metrics_lock:
-            return self._metrics.as_dict()
+            data = self._metrics.as_dict()
+        # Issue #184: expose retained-episode count so the leak is observable
+        # rather than inferred from RSS. Count is live LRU size (ids only).
+        with self._live_lock:
+            data["live_episodes"] = len(self._live_episodes)
+            data["retained_episodes"] = len(self._live_episodes)
+        return data
+
+    @property
+    def retained_episodes(self) -> int:
+        """Number of live episode ids currently retained (issue #184)."""
+        with self._live_lock:
+            return len(self._live_episodes)
 
     def add_sink(self, sink: AlertSink) -> None:
         """Register one more sink at runtime (issue #122).
@@ -577,6 +622,44 @@ class Monitor:
         """
         self.ingest(event)
 
+    def _evict_episode(self, episode_id: str) -> None:
+        """Silent LRU eviction for the retention cap (issue #184).
+
+        Same teardown as ``end_episode`` but without ``finalize`` risks: an
+        episode that vanished because the host never called ``end_episode``
+        should not suddenly emit a ``silent_abort`` risk long after the fact.
+        Fail-open throughout, never propagates even with ``fail_open=False``
+        for eviction (the cap is a safety net, not a judgment point).
+        """
+        # Race: pop selected this id as LRU, but another thread may have
+        # re-added it before we acquire its episode lock. If it is back in
+        # the live set, keep its fresh state.
+        with self._live_lock:
+            if episode_id in self._live_episodes:
+                return
+        try:
+            with self._state.episode_lock(episode_id):
+                self._clocks.pop(episode_id, None)
+                for detector in self._detectors:
+                    try:
+                        detector.reset(episode_id)
+                    except Exception:
+                        self._log_fault_once(
+                            f"detector {getattr(detector, 'name', repr(detector))} "
+                            "reset raised during eviction; ignoring (fail-open)"
+                        )
+                release = getattr(self._state, "release", None)
+                if callable(release):
+                    try:
+                        release(episode_id)
+                    except Exception:
+                        self._log_fault_once(
+                            f"state backend {type(self._state).__name__} release "
+                            "raised during eviction; ignoring (fail-open)"
+                        )
+        except Exception:
+            self._log_fault_once(f"eviction of {episode_id!r} raised; ignoring")
+
     def end_episode(self, episode_id: str) -> None:
         """Signal that ``episode_id`` has finished; judge it, then clear state.
 
@@ -594,6 +677,10 @@ class Monitor:
         never propagated (unless ``fail_open=False``). Dispatch happens
         outside the episode lock, mirroring ``ingest``.
         """
+        # Keep LRU honest: freeing here means the gauge and retained count
+        # drop at once, not when the cap eventually evicts.
+        with self._live_lock:
+            self._live_episodes.pop(episode_id, None)
         finalized: list[FailureRisk] = []
         with self._state.episode_lock(episode_id):
             # Time-axis state (issue #92) is per-episode like detector state;
@@ -911,4 +998,7 @@ class Monitor:
         monitor._max_wall_seconds = cfg.max_episode_wall_seconds
         monitor._warn_fraction = cfg.warn_fraction
         monitor._idle_warn_seconds = cfg.idle_warn_seconds
+        # Per-episode retention cap (issue #184): ensure the resolved cap
+        # wins over the default-constructed one from __init__.
+        monitor._max_live_episodes = int(cfg.max_live_episodes)
         return monitor

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -377,6 +377,16 @@ class SidecarMetricsCollector:
             lines.append(f"# HELP {name} {help_text}")
             lines.append(f"# TYPE {name} counter")
             lines.append(f"{name} {monitor_metrics.get(key, 0)}")
+        # Issue #184: retained-episode count so the leak is observable rather
+        # than inferred from RSS. Gauge, not counter; ids only.
+        retained = monitor_metrics.get(
+            "retained_episodes", monitor_metrics.get("live_episodes", 0)
+        )
+        lines.append(
+            "# HELP snagline_monitor_retained_episodes Current live episode ids retained by Monitor (issue #184)."
+        )
+        lines.append("# TYPE snagline_monitor_retained_episodes gauge")
+        lines.append(f"snagline_monitor_retained_episodes {retained}")
         return "\n".join(lines) + "\n"
 
 

--- a/tests/test_per_episode_cap.py
+++ b/tests/test_per_episode_cap.py
@@ -1,0 +1,161 @@
+"""Per-episode retention cap (issue #184).
+
+The Monitor must not grow without bound when hosts never call end_episode.
+A bounded LRU of live episode ids evicts the least-recently-seen id once
+max_live_episodes is exceeded. Explicit end_episode still frees immediately
+and the cap is only the safety net. Clocks are not retained when the horizon
+feature is off, and the retained count is observable via metrics.
+"""
+
+from __future__ import annotations
+
+from snagline import Config, Monitor, StepEvent, make_signature
+
+
+def _event(episode_id: str, step_id: str = "0", ts: float = 0.0) -> StepEvent:
+    return StepEvent(
+        step_id=step_id,
+        episode_id=episode_id,
+        timestamp=ts,
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", "t", "x"),
+        tool_name="t",
+    )
+
+
+def test_cap_evicts_lru_and_frees_detector_state() -> None:
+    mon = Monitor.default(config=Config(max_live_episodes=3), sinks=[])
+    for eid in ["a", "b", "c"]:
+        mon.ingest(_event(eid, ts=0))
+    assert mon.retained_episodes == 3
+    # Touch a so it becomes most recent; b becomes LRU.
+    mon.ingest(_event("a", step_id="1", ts=1))
+    assert list(mon._live_episodes.keys()) == ["b", "c", "a"]
+    # Next new episode evicts b, not a.
+    mon.ingest(_event("d", ts=2))
+    assert mon.retained_episodes == 3
+    assert "b" not in mon._live_episodes
+    assert "a" in mon._live_episodes
+    # Detector state for evicted id is gone.
+    for det in mon._detectors:
+        if hasattr(det, "_windows"):
+            assert "b" not in det._windows  # type: ignore[attr-defined]
+        if hasattr(det, "_stats"):
+            # Latency detector keyed by (episode, tool)
+            assert not any(k[0] == "b" for k in det._stats)  # type: ignore[attr-defined]
+
+
+def test_cap_gauge_drops_and_detector_freed() -> None:
+    mon = Monitor.default(config=Config(max_live_episodes=2), sinks=[])
+    mon.ingest(_event("x", ts=0))
+    mon.ingest(_event("y", ts=1))
+    assert mon.metrics()["retained_episodes"] == 2
+    mon.ingest(_event("z", ts=2))
+    assert mon.metrics()["retained_episodes"] == 2
+    assert mon.metrics()["live_episodes"] == 2
+
+
+def test_explicit_end_still_frees_immediately() -> None:
+    mon = Monitor.default(config=Config(max_live_episodes=10), sinks=[])
+    mon.ingest(_event("ep1", ts=0))
+    mon.ingest(_event("ep2", ts=1))
+    assert mon.retained_episodes == 2
+    mon.end_episode("ep1")
+    assert mon.retained_episodes == 1
+    assert "ep1" not in mon._live_episodes
+    # Re-ingesting a freed id works and creates fresh state.
+    mon.ingest(_event("ep1", ts=2))
+    assert mon.retained_episodes == 2
+
+
+def test_clocks_not_retained_when_horizon_off() -> None:
+    mon = Monitor.default(
+        config=Config(
+            max_live_episodes=100, max_episode_wall_seconds=None, idle_warn_seconds=None
+        ),
+        sinks=[],
+    )
+    for i in range(50):
+        mon.ingest(_event(f"ep-{i}", ts=float(i)))
+    assert len(mon._clocks) == 0
+    assert mon.retained_episodes == 50
+
+
+def test_clocks_bounded_with_cap_when_horizon_on() -> None:
+    mon = Monitor.default(
+        config=Config(
+            max_live_episodes=10, max_episode_wall_seconds=1000, idle_warn_seconds=10
+        ),
+        sinks=[],
+    )
+    for i in range(20):
+        mon.ingest(_event(f"ep-{i}", ts=float(i)))
+    assert len(mon._clocks) == 10
+    assert mon.retained_episodes == 10
+
+
+def test_retained_metric_exposed_and_prometheus_renders() -> None:
+    from snagline.server.http_server import SidecarMetricsCollector
+
+    mon = Monitor.default(config=Config(max_live_episodes=5), sinks=[])
+    for i in range(7):
+        mon.ingest(_event(f"ep-{i}", ts=float(i)))
+    metrics = mon.metrics()
+    assert metrics["retained_episodes"] == 5
+    col = SidecarMetricsCollector()
+    body = col.render_prometheus(metrics)
+    assert "snagline_monitor_retained_episodes 5" in body
+
+
+def test_eviction_is_silent_no_finalize_risk() -> None:
+    class Sink:
+        def __init__(self) -> None:
+            self.risks: list = []
+
+        def emit(self, risk) -> None:
+            self.risks.append(risk)
+
+    sink = Sink()
+    mon = Monitor.default(
+        config=Config(max_live_episodes=1, silent_abort_enabled=True), sinks=[sink]
+    )
+    mon.ingest(_event("ep1", ts=0))
+    # ep1 would be silent_abort if explicitly ended
+    mon.ingest(_event("ep2", ts=1))  # evicts ep1 silently
+    assert len(sink.risks) == 0
+    mon.end_episode("ep2")
+    assert len(sink.risks) == 1
+    assert sink.risks[0].trigger == "silent_abort"
+
+
+def test_bounded_memory_repro() -> None:
+    # Repro from issue: 10k distinct episodes without end_episode must stay bounded.
+    mon = Monitor.default(config=Config(max_live_episodes=10000), sinks=[])
+    for e in range(10_000):
+        mon.ingest(
+            StepEvent(
+                step_id=f"{e}-0",
+                episode_id=f"ep-{e}",
+                timestamp=1000.0 + e,
+                action_type="tool_call",
+                action_signature=make_signature("tool_call", "search", str(e)),
+                tool_name="search",
+                latency_ms=100.0,
+                error=False,
+            )
+        )
+    assert mon.retained_episodes == 10000
+    assert len(mon._live_episodes) == 10000
+    # One more should not grow
+    mon.ingest(
+        StepEvent(
+            step_id="extra",
+            episode_id="ep-extra",
+            timestamp=20000.0,
+            action_type="tool_call",
+            action_signature=make_signature("tool_call", "search", "extra"),
+            tool_name="search",
+            latency_ms=100.0,
+        )
+    )
+    assert mon.retained_episodes == 10000


### PR DESCRIPTION
Fixes #184

Monitor retained every episode id never explicitly ended in `_clocks` plus every detector's per-episode dict, with no cap, no TTL, and no eviction. `end_episode` freed correctly, but nothing forced it to happen, so a long-lived sidecar grew without bound. The `snagline_episodes_active` gauge is LRU capped at 10000, so it saturated while real retained state kept climbing and the leak was invisible from metrics. `_clocks` also grew even when the horizon feature was off, contradicting its own inert claim.

Chosen fix: bounded LRU registry of live episode ids in Monitor, keyed by last-seen, with a config knob `max_live_episodes` (default 10000 to match the existing metrics cap, env `SNAGLINE_MAX_LIVE_EPISODES`). Every `ingest` touches the id as most-recent; when the cap would be exceeded the least-recently-seen id is evicted silently via the same teardown as `end_episode` but without `finalize` risks. Explicit `end_episode` still frees immediately; the cap is the safety net, not the primary path. LRU by last-seen is safe because a genuinely active episode is by definition recently seen and cannot be evicted out from under itself. A fixed TTL would need more care and is left for later if needed. Guard `_clocks` behind the horizon knobs so the inert claim holds, and expose retained count as `monitor.retained_episodes`, `metrics()["retained_episodes"]` and prometheus gauge `snagline_monitor_retained_episodes` so the leak is observable rather than inferred from RSS. No content retention beyond ids and timestamps.

Docs: README now says MUST be cleared via `end_episode` or it will be evicted, documents the new knob and metric; ADAPTER_GUIDE updated.

Verification after fix (same repro as issue, `Monitor.default(config=Config(max_live_episodes=10000), sinks=[])`, `tracemalloc` current):

Cap 10000, horizon OFF (default), bounded vs previously linear:

| episodes | retained | _clocks | det entries | heap |
|---:|---:|---:|---:|---:|
| 100 | 100 | 0 | 200 | 0.49 MB |
| 1000 | 1000 | 0 | 2000 | 2.28 MB |
| 10000 | 10000 | 0 | 20000 | 22.23 MB |
| 20000 | 10000 | 0 | 20000 | 24.17 MB |

Previously 10000 = 36.58 MB linear and 20000 would be ~70 MB unbounded; now 20000 plateaus at 10000 retained. With cap 100, 1000 episodes stays at 100 retained, 0.26 MB. With horizon ON and cap 100, both `_clocks` and retained stay at 100 for 200 and 500 episodes.

Tests: `tests/test_per_episode_cap.py` covers cap eviction fires, LRU ordering (touch moves to end, oldest evicted), gauge drops via `metrics()["retained_episodes"]`, detector state freed for evicted ids, explicit `end_episode` still frees immediately and allows re-ingest, `_clocks` not retained when horizon off and bounded with cap when on, retained metric exposed and prometheus renders, eviction silent (no `silent_abort` on evict) and explicit end still judges.

Gate: `pytest -q -o addopts=""` 659 passed, 3 skipped; `ruff check src tests` passed; `ruff format --check` passed; `mypy src` passed.

Mutation checks (commit fix first, then mutate committed file, then `git checkout --`):

1. Disabled LRU eviction (`if len(...) > max` to `if False and ...`): `test_cap_evicts_lru_and_frees_detector_state` and `test_bounded_memory_repro` went red (retained 10001 vs 10000).
2. Disabled `_clocks` guard (`if max_wall is None and idle is None: return` to `if False and ...`): `test_clocks_not_retained_when_horizon_off` went red (len 50 vs 0).

Refs #184, Refs #1, Refs #18, Refs #67, Refs #92, Refs #123
