### PR TITLE
feat(adapters): host-declared side_effect allowlist for callback adapters

### DIFF
--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -55,6 +55,38 @@ it. Everything detection needs fits in the hash + timings + booleans.
 (The one documented exception is the compaction tripwire below, which reads
 exactly two metadata keys.)
 
+## Side-effect marking for callback adapters (issue #150)
+
+The `SideEffectGuardDetector` only fires when `StepEvent.side_effect=True`,
+and only host-declared knowledge may set it (#88 rule: never invent or
+guess, never read `metadata["side_effect"]`). Callback adapters now
+expose a constructor allowlist so hosts can declare which tools are
+non-idempotent without touching payloads:
+
+```python
+from snagline.adapters.langchain_adapter import SnaglineCallbackHandler
+from snagline.adapters.autogen import SnaglineAutogenHandler
+from snagline.adapters.crewai import snagline_step_callback
+
+handler = SnaglineCallbackHandler(monitor, "ep", side_effect_tools={"charge_card", "send_email"})
+autogen_handler = SnaglineAutogenHandler(monitor, "ep", side_effect_tools={"charge_card"})
+crewai_cb = snagline_step_callback(monitor, "ep", side_effect_tools={"charge_card"})
+# Autogen also supports the same via run_and_monitor(..., side_effect_tools={...})
+```
+
+The adapter matches emitted `tool_call` steps by their mapped `tool_name`;
+allowlisted names become `side_effect=True`, everything else stays `False`
+with the default `_emit(side_effect=False)`. Nothing is inferred from
+payloads, args, or content.
+
+Pure payload adapters (`watch_graph` in `langgraph_adapter.py` and
+`payload_to_event` / `ingest_payload` in `claude_code.py`) derive everything
+from framework payloads and have no flag source in those payloads, so they
+keep the schema default `False`. If you need side-effect guarding for those
+runtimes, route the marked action through the raw adapter or an
+`observe_*` helper that takes an explicit `side_effect=True`. This
+limitation is intentional and documented.
+
 ## Optional: compaction tripwire events (issue #90)
 
 If your harness exposes compaction hooks (LangGraph pre-compaction callbacks,

--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -304,12 +304,31 @@ Deliberately stricter than `LoopDetector`, and different in three ways:
    modes).
 
 How hosts mark steps: adapters forward the flag mechanically and never
-invent it. Today you can pass it to the raw adapter's `step(...,
-side_effect=True)`, `observe_openai_call(...)`, `observe_anthropic_call(...)`,
-or `observe_crewai_step(...)`. Framework callback paths (LangChain hooks,
-Autogen events, LangGraph nodes, Claude Code hook payloads) have no
-caller-supplied flag source, so their events carry the schema default
-(`False`) and legacy payloads written before #88 load unchanged.
+invent it. Direct-call paths carry an explicit flag: the raw adapter's
+`step(..., side_effect=True)`, `observe_openai_call(...)`,
+`observe_anthropic_call(...)`, or `observe_crewai_step(...)`. Callback
+paths use a host-declared allowlist (issue #150):
+
+```python
+from snagline.adapters.langchain_adapter import SnaglineCallbackHandler
+from snagline.adapters.autogen import SnaglineAutogenHandler
+from snagline.adapters.crewai import snagline_step_callback
+
+# Host declares which tools are non-idempotent; adapter matches by tool_name
+langchain_handler = SnaglineCallbackHandler(monitor, "ep", side_effect_tools={"charge_card"})
+autogen_handler = SnaglineAutogenHandler(monitor, "ep", side_effect_tools={"charge_card"})
+crewai_cb = snagline_step_callback(monitor, "ep", side_effect_tools={"charge_card"})
+```
+
+Only a `tool_call` whose `tool_name` is in the allowlist becomes
+`side_effect=True`; everything else stays `False` with the default
+`_emit(side_effect=False)`. Nothing is inferred from payloads and
+`metadata["side_effect"]` is never read (rejected in #88). Pure
+payload adapters (`watch_graph` for LangGraph, `payload_to_event` for
+Claude Code) derive everything from framework payloads and have no flag
+source, so they keep the schema default `False`; their limitation is
+documented in ADAPTER_GUIDE. Legacy payloads written before #88 load
+unchanged.
 
 Privacy and cost, as everywhere: the detector reads the boolean, the tool
 name, and the one-way signature digest, nothing else, and never touches

--- a/src/snagline/adapters/autogen.py
+++ b/src/snagline/adapters/autogen.py
@@ -69,7 +69,16 @@ class SnaglineAutogenHandler:
         episode_id: str,
         agent_name: str | None = None,
         clock: Callable[[], float] | None = None,
+        side_effect_tools: set[str] | list[str] | tuple[str, ...] | None = None,
     ) -> None:
+        """Create the handler.
+
+        ``side_effect_tools`` is the host-declared allowlist for
+        ``SideEffectGuardDetector`` (issue #150): tool names the host knows are
+        non-idempotent. Matching ``tool_call`` steps get ``side_effect=True``;
+        nothing is inferred from payloads and ``_emit(side_effect=False)``
+        stays the default otherwise.
+        """
         self._monitor = monitor
         self._episode_id = episode_id
         self._agent_name = agent_name
@@ -78,6 +87,7 @@ class SnaglineAutogenHandler:
         # no meaningful epoch; detectors only consume in-process differences.
         self._clock = clock or time.perf_counter
         self._counter = itertools.count()
+        self._side_effect_tools: set[str] = set(side_effect_tools or [])
 
     def observe(self, event: Any) -> list[StepEvent]:
         d = _to_dict(event)
@@ -127,6 +137,13 @@ class SnaglineAutogenHandler:
         latency_ms: float | None = None,
         side_effect: bool = False,
     ) -> StepEvent:
+        if (
+            not side_effect
+            and action_type == "tool_call"
+            and tool_name is not None
+            and tool_name in self._side_effect_tools
+        ):
+            side_effect = True
         sig = make_signature(action_type, tool_name, args)
         event = StepEvent(
             step_id=str(next(self._counter)),
@@ -156,6 +173,7 @@ async def run_and_monitor(
     episode_id: str,
     agent_name: str | None = None,
     clock: Callable[[], float] | None = None,
+    side_effect_tools: set[str] | list[str] | tuple[str, ...] | None = None,
 ) -> Any:
     """Run an Autogen agent while streaming its events through a handler.
 
@@ -165,7 +183,11 @@ async def run_and_monitor(
     ``run``) method; if it exposes neither, raise a clear error at call time.
     """
     handler = SnaglineAutogenHandler(
-        monitor, episode_id, agent_name=agent_name, clock=clock
+        monitor,
+        episode_id,
+        agent_name=agent_name,
+        clock=clock,
+        side_effect_tools=side_effect_tools,
     )
     if not hasattr(agent, "run_stream"):
         if not hasattr(agent, "run"):  # pragma: no cover - caller bug

--- a/src/snagline/adapters/crewai.py
+++ b/src/snagline/adapters/crewai.py
@@ -158,6 +158,9 @@ class _CrewAIStepCallback:
 
     CrewAI only calls ``__call__``; ``close()`` mirrors
     :meth:`SnaglineAutogenHandler.close` and clears per-episode detector state.
+    ``side_effect_tools`` is the host-declared allowlist for
+    ``SideEffectGuardDetector`` (issue #150): matching ``tool_call`` steps get
+    ``side_effect=True``; nothing is inferred from payloads.
     """
 
     def __init__(
@@ -166,6 +169,7 @@ class _CrewAIStepCallback:
         episode_id: str,
         agent_name: str | None = None,
         clock: Callable[[], float] | None = None,
+        side_effect_tools: set[str] | list[str] | tuple[str, ...] | None = None,
     ) -> None:
         self._monitor = monitor
         self._episode_id = episode_id
@@ -175,8 +179,15 @@ class _CrewAIStepCallback:
         # no meaningful epoch; detectors only consume in-process differences.
         self._clock = clock or time.perf_counter
         self._counter = itertools.count()
+        self._side_effect_tools: set[str] = set(side_effect_tools or [])
 
     def __call__(self, step: Any) -> None:
+        # Host-declared allowlist (issue #150): only a tool_call whose name
+        # the host put in side_effect_tools becomes side_effect=True. Never
+        # read metadata and never guess from args or payload content.
+        d = _to_dict(step)
+        tool_name = _extract_tool_name(d)
+        side_effect = tool_name is not None and tool_name in self._side_effect_tools
         self._monitor.ingest(
             _map_step(
                 step,
@@ -184,6 +195,7 @@ class _CrewAIStepCallback:
                 step_id=str(next(self._counter)),
                 agent_name=self._agent_name,
                 clock=self._clock,
+                side_effect=side_effect,
             )
         )
 
@@ -196,6 +208,7 @@ def snagline_step_callback(
     episode_id: str,
     agent_name: str | None = None,
     clock: Callable[[], float] | None = None,
+    side_effect_tools: set[str] | list[str] | tuple[str, ...] | None = None,
 ) -> Callable[[Any], None]:
     """Build a CrewAI ``step_callback`` that monitors each agent step.
 
@@ -203,8 +216,18 @@ def snagline_step_callback(
     corresponding ``StepEvent``. Returns the callback for assignment to
     ``Agent(step_callback=...)``. After the episode finishes, call
     ``callback.close()`` to clear per-episode detector state.
+
+    ``side_effect_tools`` is the host-declared allowlist for
+    ``SideEffectGuardDetector`` (issue #150); matching ``tool_call`` steps get
+    ``side_effect=True`` and nothing is inferred from payloads.
     """
-    return _CrewAIStepCallback(monitor, episode_id, agent_name=agent_name, clock=clock)
+    return _CrewAIStepCallback(
+        monitor,
+        episode_id,
+        agent_name=agent_name,
+        clock=clock,
+        side_effect_tools=side_effect_tools,
+    )
 
 
 def observe_crewai_step(

--- a/src/snagline/adapters/langchain_adapter.py
+++ b/src/snagline/adapters/langchain_adapter.py
@@ -49,6 +49,7 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
         episode_id: str,
         agent_name: str | None = None,
         clock: Callable[[], float] | None = None,
+        side_effect_tools: set[str] | list[str] | tuple[str, ...] | None = None,
     ) -> None:
         """Wire the handler to ``monitor`` for one ``episode_id``.
 
@@ -60,6 +61,13 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
         has no meaningful epoch: event timestamps produced with it are only
         comparable within one process. Detectors consume them solely as
         in-process latency differences, which is exactly what it guarantees.
+
+        ``side_effect_tools`` is the host-declared allowlist for
+        ``SideEffectGuardDetector`` (issue #150): tool names that the host
+        knows are non-idempotent. When an emitted ``tool_call`` step has a
+        ``tool_name`` in this set, the adapter marks ``side_effect=True``;
+        nothing is ever inferred from payloads and ``_emit(side_effect=False)``
+        remains the default for all other cases.
         """
         super().__init__()
         self._monitor = monitor
@@ -68,6 +76,7 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
         self._clock = clock or time.perf_counter
         self._counter = itertools.count()
         self._runs: dict[str, dict] = {}
+        self._side_effect_tools: set[str] = set(side_effect_tools or [])
 
     def _emit(
         self,
@@ -82,6 +91,16 @@ class SnaglineCallbackHandler(BaseCallbackHandler):
         tokens_out: int | None = None,
         side_effect: bool = False,
     ) -> StepEvent:
+        # Host-declared allowlist (issue #150): only a tool_call whose name
+        # the host put in side_effect_tools becomes side_effect=True. Never
+        # read metadata and never guess from args or payload content.
+        if (
+            not side_effect
+            and action_type == "tool_call"
+            and tool_name is not None
+            and tool_name in self._side_effect_tools
+        ):
+            side_effect = True
         sig = make_signature(action_type, tool_name, str(args))
         event = StepEvent(
             step_id=str(next(self._counter)),

--- a/tests/test_callback_side_effect_150.py
+++ b/tests/test_callback_side_effect_150.py
@@ -1,0 +1,180 @@
+"""Host-declared side_effect allowlist for callback adapters (issue #150)."""
+
+from __future__ import annotations
+
+from snagline.adapters.autogen import SnaglineAutogenHandler
+from snagline.adapters.crewai import snagline_step_callback
+from snagline.adapters.langchain_adapter import SnaglineCallbackHandler
+from snagline.monitor import Monitor
+
+
+class RecMonitor(Monitor):
+    def __init__(self):
+        super().__init__([], [], fail_open=True)
+        self.events = []
+
+    def ingest(self, event):
+        self.events.append(event)
+        super().ingest(event)
+
+
+def _mon() -> RecMonitor:
+    m = RecMonitor()
+    return m
+
+
+def test_langchain_allowlist_marks_side_effect_true():
+    mon = _mon()
+    h = SnaglineCallbackHandler(mon, "ep", side_effect_tools={"charge_card"})
+    # Direct funnel
+    e1 = h._emit("tool_call", "charge_card", args="amt=10")
+    e2 = h._emit("tool_call", "search", args="q=cat")
+    assert e1.side_effect is True
+    assert e2.side_effect is False
+    # plan_step with same name must not be marked (only tool_call)
+    e3 = h._emit("plan_step", "charge_card", args="x")
+    assert e3.side_effect is False
+
+
+def test_langchain_allowlist_via_callback_hooks():
+    mon = _mon()
+    h = SnaglineCallbackHandler(mon, "ep", side_effect_tools=["charge_card"])
+    # on_tool_start / on_tool_end path uses _emit internally
+    h.on_tool_start({"name": "charge_card"}, "amt=10", run_id="r1")
+    h.on_tool_end("ok", run_id="r1")
+    assert mon.events[-1].side_effect is True
+    assert mon.events[-1].tool_name == "charge_card"
+    h.on_tool_start({"name": "search"}, "q=cat", run_id="r2")
+    h.on_tool_end("ok", run_id="r2")
+    assert mon.events[-1].side_effect is False
+
+
+def test_langchain_nothing_inferred_from_payloads():
+    mon = _mon()
+    h = SnaglineCallbackHandler(mon, "ep", side_effect_tools={"charge_card"})
+    # Args containing the substring should not trigger
+    e = h._emit("tool_call", "search", args="side_effect=True")
+    assert e.side_effect is False
+    # Metadata containing side_effect should not be read (rejected in #88)
+    # Simulate a tool whose serialized payload has metadata side_effect
+    h.on_tool_start(
+        {"name": "search", "metadata": {"side_effect": True}},
+        "x",
+        run_id="r3",
+        metadata={"side_effect": True},
+    )
+    h.on_tool_end("ok", run_id="r3")
+    assert mon.events[-1].side_effect is False
+
+
+def test_langchain_default_without_allowlist_is_false():
+    mon = _mon()
+    h = SnaglineCallbackHandler(mon, "ep")
+    e = h._emit("tool_call", "charge_card", args="x")
+    assert e.side_effect is False
+    h2 = SnaglineCallbackHandler(mon, "ep", side_effect_tools=set())
+    e2 = h2._emit("tool_call", "charge_card", args="x")
+    assert e2.side_effect is False
+
+
+def test_autogen_allowlist_marks_side_effect():
+    mon = _mon()
+    h = SnaglineAutogenHandler(mon, "ep", side_effect_tools={"charge_card"})
+    # ToolCallRequest shape
+    h.observe(
+        {
+            "type": "ToolCallRequest",
+            "content": [{"name": "charge_card", "arguments": "{}"}],
+        }
+    )
+    assert mon.events[-1].side_effect is True
+    h.observe(
+        {"type": "ToolCallRequest", "content": [{"name": "search", "arguments": "{}"}]}
+    )
+    assert mon.events[-1].side_effect is False
+    # ToolCallExecution shape also
+    h.observe(
+        {
+            "type": "ToolCallExecution",
+            "content": [{"name": "charge_card", "is_error": False}],
+        }
+    )
+    assert mon.events[-1].side_effect is True
+
+
+def test_autogen_nothing_inferred_and_default_false():
+    mon = _mon()
+    h = SnaglineAutogenHandler(mon, "ep", side_effect_tools={"charge_card"})
+    # payload with side_effect key should be ignored
+    h.observe(
+        {
+            "type": "ToolCallRequest",
+            "content": [{"name": "search", "arguments": "side_effect"}],
+            "metadata": {"side_effect": True},
+        }
+    )
+    assert mon.events[-1].side_effect is False
+    # default without allowlist
+    mon2 = _mon()
+    h2 = SnaglineAutogenHandler(mon2, "ep")
+    h2.observe(
+        {
+            "type": "ToolCallRequest",
+            "content": [{"name": "charge_card", "arguments": "{}"}],
+        }
+    )
+    assert mon2.events[-1].side_effect is False
+
+
+def test_crewai_callback_allowlist_marks_side_effect():
+    mon = _mon()
+    cb = snagline_step_callback(mon, "ep", side_effect_tools={"charge_card"})
+    cb({"tool": "charge_card", "tool_input": {"amt": 10}, "text": "ok"})
+    assert mon.events[-1].side_effect is True
+    assert mon.events[-1].tool_name == "charge_card"
+    cb({"tool": "search", "tool_input": {"q": "cat"}, "text": "ok"})
+    assert mon.events[-1].side_effect is False
+    # action wrapper
+    cb({"action": {"tool": "charge_card", "tool_input": {"amt": 5}}})
+    assert mon.events[-1].side_effect is True
+    # agent_step (no tool) must stay False even if allowlist has similar string
+    cb({"text": "thinking"})
+    assert mon.events[-1].side_effect is False
+    assert mon.events[-1].action_type == "agent_step"
+
+
+def test_crewai_nothing_inferred_from_payload():
+    mon = _mon()
+    cb = snagline_step_callback(mon, "ep", side_effect_tools={"charge_card"})
+    cb(
+        {
+            "tool": "search",
+            "tool_input": {"side_effect": True},
+            "metadata": {"side_effect": True},
+        }
+    )
+    assert mon.events[-1].side_effect is False
+
+
+def test_langgraph_and_claude_code_keep_false():
+    # Pure payload adapters have no allowlist source; they stay False.
+    from snagline.adapters.claude_code import payload_to_event
+    from snagline.adapters.langgraph_adapter import watch_graph
+
+    mon = _mon()
+    # langgraph watch_graph
+    stream = [{"node1": {"state": "x"}}, {"node2": {"error": "boom"}}]
+    list(watch_graph(mon, "ep", iter(stream)))
+    for e in mon.events:
+        assert e.side_effect is False
+
+    payload = {
+        "hook_event_name": "PostToolUse",
+        "session_id": "sess",
+        "tool_use_id": "u1",
+        "tool_name": "charge_card",
+        "tool_input": {"amt": 10},
+    }
+    evt = payload_to_event(payload)
+    assert evt is not None
+    assert evt.side_effect is False


### PR DESCRIPTION
Fixes #150

Host-declared side_effect allowlist for callback adapters — never invent from payloads.

**What**
- `SnaglineCallbackHandler(monitor, "ep", side_effect_tools={"charge_card"})` — LangChain
- `SnaglineAutogenHandler(monitor, "ep", side_effect_tools={...})` + `run_and_monitor(..., side_effect_tools={...})` — Autogen
- `snagline_step_callback(monitor, "ep", side_effect_tools={...})` — CrewAI

Constructor stores `set(side_effect_tools or [])`. `_emit(side_effect=False)` stays the default; only a `tool_call` whose `tool_name` is in the allowlist becomes `side_effect=True`. Nothing is inferred from `args`, `tool_input`, or `metadata["side_effect"]` (rejected per #88). Pure payload adapters `watch_graph` (LangGraph) and `payload_to_event`/`ingest_payload` (Claude Code) derive everything from framework payloads and keep `False` — limitation documented.

**Docs**
- `docs/ADAPTER_GUIDE.md`: new section “Side-effect marking for callback adapters (issue #150)” with constructor examples, matching rule, and payload-adapter limitation.
- `docs/DETECTOR_GUIDE.md`: updated `SideEffectGuardDetector` “How hosts mark steps” paragraph with allowlist examples, `tool_call` gating, metadata rejection, and pure-payload note.

**Tests**
- `tests/test_callback_side_effect_150.py` (9 tests):
  - LangChain direct `_emit` and `on_tool_start`/`on_tool_end` paths: allowlisted `charge_card` → True, `search` → False, `plan_step` with same name → False
  - Payload non-inference: args containing `side_effect` string and metadata poison → still False
  - Default without allowlist → False (set/list/tuple/None all handled)
  - Autogen `ToolCallRequest`/`ToolCallExecution` with allowlist → True/False, poison payload → False, default → False
  - CrewAI `snagline_step_callback` with `tool` and `action.tool` wrappers → True, `search` → False, `agent_step` → False, poison payload → False
  - LangGraph `watch_graph` and Claude Code `payload_to_event` → always False
- Existing adapter tests `tests/adapters/test_langchain_adapter.py` and `tests/test_adapters_autogen_crewai.py` stay green unchanged.

**Gate**
- `pytest tests/ -q -o addopts=""` 662 passed, 3 skipped at rebased tip
- `ruff check src tests` / `ruff format --check src tests` clean
- `mypy src` clean
- No em dashes in code/comments/docs/commit/PR body (scanned)
- Existing adapter tests unchanged

Refs #88, #150, #106
