### PR TITLE
fix: persist Monitor time-axis clocks across snapshot/restore

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -749,10 +749,20 @@ class Monitor:
         for i, sink in enumerate(self._sinks):
             dump = getattr(sink, "dump_state", None)
             sinks[f"{i}:{type(sink).__name__}"] = dump() if callable(dump) else None
+        time_axis: dict[str, Any] = {}
+        for episode_id, clock in self._clocks.items():
+            time_axis[episode_id] = {
+                "last_ts": clock.last_ts,
+                "elapsed": clock.elapsed,
+                "idle_fired": clock.idle_fired,
+                "warned": clock.warned,
+                "breached": clock.breached,
+            }
         return {
             "format_version": SNAPSHOT_FORMAT_VERSION,
             "detectors": detectors,
             "sinks": sinks,
+            "time_axis": time_axis,
         }
 
     def snapshot(self, path: str) -> None:
@@ -831,6 +841,55 @@ class Monitor:
             key = f"{i}:{type(sink).__name__}"
             if callable(load) and dumped_sinks.get(key) is not None:
                 load(dumped_sinks[key])
+        time_axis_data = data.get("time_axis")
+        if isinstance(time_axis_data, dict):
+            # Restore clocks in order of last_ts ascending so most recent
+            # survives if we must evict under cap. Fall back to sorted keys
+            # for deterministic behavior when last_ts is missing.
+            try:
+                ordered = sorted(
+                    time_axis_data.items(),
+                    key=lambda kv: (
+                        float(kv[1].get("last_ts", 0.0))  # type: ignore[arg-type]
+                        if isinstance(kv[1], dict)
+                        else 0.0
+                    ),
+                )
+            except Exception:
+                ordered = sorted(time_axis_data.items())
+            for episode_id, clock_data in ordered:
+                if not isinstance(episode_id, str) or not isinstance(clock_data, dict):
+                    continue
+                try:
+                    last_ts = float(clock_data.get("last_ts", 0.0))
+                    elapsed = float(clock_data.get("elapsed", 0.0))
+                    idle_fired = bool(clock_data.get("idle_fired", False))
+                    warned = bool(clock_data.get("warned", False))
+                    breached = bool(clock_data.get("breached", False))
+                except Exception:
+                    logger.warning(
+                        "snagline: malformed time_axis entry for %r; ignored",
+                        episode_id,
+                    )
+                    continue
+                if elapsed < 0.0:
+                    elapsed = 0.0
+                clock = _EpisodeClock(last_ts)
+                clock.elapsed = elapsed
+                clock.idle_fired = idle_fired
+                clock.warned = warned
+                clock.breached = breached
+                with self._live_lock:
+                    if episode_id in self._live_episodes:
+                        self._live_episodes.move_to_end(episode_id)
+                    else:
+                        self._live_episodes[episode_id] = None
+                        if len(self._live_episodes) > self._max_live_episodes:
+                            evicted, _ = self._live_episodes.popitem(last=False)
+                            self._clocks.pop(evicted, None)
+                    self._clocks[episode_id] = clock
+            # If we evicted due to cap, live_snapshot entries not in time_axis
+            # are already accounted for; no further action needed.
 
     def restore(self, path: str, strict_names: bool = False) -> None:
         """Load a JSON snapshot written by :meth:`snapshot`."""

--- a/tests/test_server_mtls.py
+++ b/tests/test_server_mtls.py
@@ -208,9 +208,11 @@ def test_plain_and_server_tls_modes_unchanged_without_client_ca(tmp_path):
         tmp_path, ca_cert, ca_key, "127.0.0.1", "server"
     )
     ctx = _resolve_ssl_context(None, server_cert, server_key)
+    assert ctx is not None
     assert ctx.verify_mode == ssl.CERT_NONE
     # Explicit None client_ca must behave identically
     ctx2 = _resolve_ssl_context(None, server_cert, server_key, None)
+    assert ctx2 is not None
     assert ctx2.verify_mode == ssl.CERT_NONE
 
 
@@ -457,7 +459,7 @@ def test_plain_and_server_tls_modes_regression(tmp_path):
         assert status == 200
         assert json.loads(body) == {"status": "ok"}
         # Verify server context is not in mTLS mode
-        assert tls_plain.snagline_ssl_context.verify_mode == ssl.CERT_NONE
+        assert tls_plain.snagline_ssl_context.verify_mode == ssl.CERT_NONE  # type: ignore[attr-defined]
     finally:
         tls_plain.shutdown()
         tls_plain.server_close()


### PR DESCRIPTION
Fixes #172

Persist Monitor-level horizon time-axis state across restarts. `Monitor._clocks` (`_EpisodeClock` per episode: `last_ts`, `elapsed`, `idle_fired`, `warned`, `breached`) lives on the Monitor itself and was not captured by `snapshot()` / `restore()`, so every mid-episode restart reset elapsed to 0 and cleared latches, causing duplicate or missed `idle_gap` / `wall_clock_budget` risks.

Changes:
- `src/snagline/monitor.py`: add additive top-level `"time_axis"` key in `snapshot_dict()` serializing each clock as JSON-serializable dict, written atomically via `tmp+os.replace` with `SNAPSHOT_FORMAT_VERSION` unchanged; restore tolerantly in `restore_dict()` via `data.get("time_axis")`, tolerant in both directions (old snapshots without key restore into fresh clocks, newer snapshots loadable by older code which ignores unknown keys), restores clocks in `last_ts` order so most recent survives LRU eviction, respects same `max_live_episodes` LRU cap as #184 (evicts oldest via `OrderedDict.popitem`), validates types and clamps negative elapsed, and re-populates `_live_episodes` LRU.

Verification:
- Fresh venv `pip install -e ".[dev]"` then full gate: `pytest` 682 passed 3 skipped 88.0% coverage, `ruff check` pass, `ruff format --check` pass, `mypy src` pass
- Manual property test: fire `idle_gap` + budget warn + breach before snapshot, restore into fresh Monitor, continue within thresholds asserts nothing re-fires, half-consumed budget breaches at correct cumulative total (50->80 warn, 80->100 breach)
- Old snapshot without `time_axis` restores cleanly (clocks empty), `end_episode` clears restored clocks (`_clocks` and `_live_episodes` both popped), LRU cap respected (cap 2 with 3 episodes snapshot retains 2, restore with cap 2 retains <=2)
- No wall-clock reads: all persisted values derive from `StepEvent.timestamp`, region contract unchanged

Refs #92, #91, #149, #184
