### PR TITLE
feat(server): optional TTL expiry for episodes-active gauge

### DIFF
--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -156,6 +156,23 @@ enterprise-grade alerting. Concretely:
     releasing per-episode detector state), and answers `400` on malformed
     bodies without crashing or retaining anything beyond the id itself.
     Ending an unknown id is an idempotent no-op.
+
+    **Episode TTL expiry (#173):** When hosts cannot or forget to send the
+    end signal, the gauge would otherwise rely solely on cap eviction.
+    Configure an idle-based TTL so ids not seen for N seconds expire
+    automatically: `snagline serve --episode-ttl-seconds 3600` or
+    `SNAGLINE_EPISODE_TTL_SECONDS=3600` / `Config(episode_ttl_seconds=3600)`.
+    `0` or `None` disables (default, byte-identical to #123). Expiry uses
+    monotonic time, so NTP jumps cannot mass-expire or freeze entries; the
+    table stays ids-plus-a-float and the same `_MAX_TRACKED_EPISODES` cap
+    still bounds memory. Reseeing an id after expiry just re-registers it.
+    Trade-off: explicit `POST /episodes/end` is precise and immediate, while
+    TTL is self-healing for uncooperative or legacy senders but cannot
+    distinguish a quiet-but-still-running episode from a finished one; an
+    idle gap longer than the TTL looks like completion. Replay note:
+    replaying an old trajectory through a live sidecar will resurrect stale
+    ids regardless of TTL, so point replay at a metrics-disabled sidecar or
+    a throwaway port.
 11. Integration matrix document plus a prominent "10-line custom adapter"
     path. **Done:** `docs/INTEGRATION_MATRIX.md` (#49).
 

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -315,6 +315,15 @@ def _build_parser() -> argparse.ArgumentParser:
         "[default: 30]. Documented next to --max-body-bytes.",
     )
     p_serve.add_argument(
+        "--episode-ttl-seconds",
+        type=float,
+        default=None,
+        help="Expire ids from snagline_episodes_active not seen for this many seconds "
+        "(issue #173); 0 disables. Falls back to $SNAGLINE_EPISODE_TTL_SECONDS or "
+        "Config.episode_ttl_seconds [default: disabled]. Wall-clock TTL value but "
+        "monotonic expiry; replay traffic will resurrect stale ids.",
+    )
+    p_serve.add_argument(
         "--max-risks",
         type=int,
         default=1000,
@@ -1042,6 +1051,7 @@ def _cmd_serve(args: argparse.Namespace) -> int:
             max_body_bytes=args.max_body_bytes,
             max_risks=args.max_risks,
             read_timeout=args.read_timeout,
+            episode_ttl_seconds=args.episode_ttl_seconds,
             **tls_kwargs,
         )
     return 0

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -446,6 +446,15 @@ class Config:
     # Environment override SNAGLINE_MAX_LIVE_EPISODES.
     max_live_episodes: int = 10_000
 
+    # --- Sidecar episode TTL (issue #173) -----------------------------------
+    # When set, the sidecar's episodes-active gauge expires ids not seen for
+    # this many wall-clock seconds. None or 0 disables (default, byte-identical
+    # to pre-TTL behavior). Uses monotonic time so NTP jumps cannot
+    # mass-expire or freeze entries. Replay caveat: replaying old trajectories
+    # through a live sidecar will resurrect stale ids; docs note this.
+    # Environment override SNAGLINE_EPISODE_TTL_SECONDS.
+    episode_ttl_seconds: float | None = None
+
     def __post_init__(self) -> None:
         # Issue #119: invalid closed-set values are configuration errors and
         # must fail loudly here instead of being silently ignored downstream.

--- a/src/snagline/server/http_server.py
+++ b/src/snagline/server/http_server.py
@@ -80,6 +80,7 @@ import sys
 import threading
 import time
 from collections import OrderedDict, deque
+from collections.abc import Callable
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any
 from urllib.parse import parse_qs, urlsplit
@@ -196,6 +197,57 @@ def _resolve_read_timeout(explicit: float | None) -> float:
     return value
 
 
+def _resolve_episode_ttl(explicit: float | None) -> float | None:
+    """Pick the effective episode TTL for the sidecar gauge (issue #173).
+
+    Precedence: explicit argument, then ``SNAGLINE_EPISODE_TTL_SECONDS`` via
+    ``Config``, then the built-in ``Config`` default (None = disabled).
+    Malformed or non-positive values are logged and treated as disabled so a
+    bad knob never takes the sidecar down (fail-open). ``0`` explicitly
+    disables as well, keeping the default byte-identical behavior.
+    Uses wall-clock seconds for the TTL value but monotonic time for expiry
+    checks, so NTP jumps cannot mass-expire or freeze entries; docs note
+    replay traffic will resurrect stale ids.
+    """
+    candidate: Any = explicit
+    if candidate is None:
+        try:
+            candidate = Config.from_env_overrides().get("episode_ttl_seconds")
+        except Exception:
+            logger.debug(
+                "snagline: env lookup for episode_ttl_seconds failed",
+                exc_info=True,
+            )
+            candidate = None
+    if candidate is None:
+        candidate = Config().episode_ttl_seconds
+    if candidate is None:
+        return None
+    try:
+        value = float(candidate)
+    except (TypeError, ValueError):
+        logger.warning(
+            "snagline: invalid episode_ttl_seconds %r; TTL disabled",
+            candidate,
+        )
+        return None
+    if not math.isfinite(value):
+        logger.warning(
+            "snagline: episode_ttl_seconds %r must be finite; TTL disabled",
+            candidate,
+        )
+        return None
+    if value == 0:
+        return None
+    if value < 0:
+        logger.warning(
+            "snagline: episode_ttl_seconds %r must be positive; TTL disabled",
+            candidate,
+        )
+        return None
+    return value
+
+
 def _choose_metrics_format(
     query: dict[str, list[str]], accept_header: str | None, configured: str
 ) -> str:
@@ -243,7 +295,12 @@ class SidecarMetricsCollector:
     ingestion or serving.
     """
 
-    def __init__(self, max_episodes: int = _MAX_TRACKED_EPISODES) -> None:
+    def __init__(
+        self,
+        max_episodes: int = _MAX_TRACKED_EPISODES,
+        episode_ttl_seconds: float | None = None,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
         self._lock = threading.Lock()
         self._risks: dict[tuple[str, str], int] = {}
         self._events_total = 0
@@ -252,8 +309,13 @@ class SidecarMetricsCollector:
         # Episode id table: reseeing an id moves it to the end, so when the
         # cap bites we forget the episode quiet for the longest time, which
         # is the right approximation of "active" for a long-lived sidecar.
-        self._episodes: OrderedDict[str, None] = OrderedDict()
+        # With TTL enabled each id also carries a monotonic last-seen stamp;
+        # the table stays ids-plus-a-float, never content, and the same cap
+        # continues to bound memory (issue #173).
+        self._episodes: OrderedDict[str, float] = OrderedDict()
         self._max_episodes = max(1, int(max_episodes))
+        self._ttl = _resolve_episode_ttl(episode_ttl_seconds)
+        self._clock = clock or time.monotonic
 
     def emit(self, risk: Any) -> None:
         """AlertSink protocol entry point; counts one risk by label pair."""
@@ -264,6 +326,29 @@ class SidecarMetricsCollector:
         except Exception:
             logger.debug("snagline: metrics collector emit failed", exc_info=True)
 
+    def _expire_stale_locked(self) -> None:
+        """Remove ids not seen for longer than TTL (caller holds _lock)."""
+        if self._ttl is None:
+            return
+        try:
+            now = self._clock()
+            # OrderedDict keeps insertion order = last-seen order because
+            # record_ingest moves reseen ids to the end. Expired ids are
+            # exactly those at the front whose age exceeds TTL; we can stop
+            # at the first fresh entry. Bounded scan: at most one pass over
+            # the table per sweep, and sweep happens only on ingest and
+            # scrape, so amortized O(1) per step (project.md section 1.5).
+            expired: list[str] = []
+            for eid, last_seen in self._episodes.items():
+                if now - last_seen > self._ttl:
+                    expired.append(eid)
+                else:
+                    break
+            for eid in expired:
+                self._episodes.pop(eid, None)
+        except Exception:
+            logger.debug("snagline: TTL sweep failed", exc_info=True)
+
     def record_ingest(self, episode_id: str | None, elapsed_seconds: float) -> None:
         """Record one accepted event and its ingest wall time."""
         try:
@@ -273,10 +358,14 @@ class SidecarMetricsCollector:
                 self._ingest_sum += max(0.0, float(elapsed_seconds))
                 if episode_id is not None:
                     key = str(episode_id)
+                    now = self._clock()
                     self._episodes.pop(key, None)
-                    self._episodes[key] = None
+                    self._episodes[key] = now
+                    self._expire_stale_locked()
                     while len(self._episodes) > self._max_episodes:
                         self._episodes.popitem(last=False)
+                else:
+                    self._expire_stale_locked()
         except Exception:
             logger.debug("snagline: metrics record failed", exc_info=True)
 
@@ -300,6 +389,7 @@ class SidecarMetricsCollector:
     def snapshot(self) -> dict[str, Any]:
         """Return a consistent copy of the counters for rendering."""
         with self._lock:
+            self._expire_stale_locked()
             return {
                 "events_total": self._events_total,
                 "risks": sorted(self._risks.items()),
@@ -415,6 +505,7 @@ def make_handler(
     max_risks: int = 1000,
     metrics_format: str | None = None,
     read_timeout: float | None = None,
+    episode_ttl_seconds: float | None = None,
 ) -> type[BaseHTTPRequestHandler]:
     """Build a request-handler class bound to ``monitor``.
 
@@ -424,6 +515,9 @@ def make_handler(
     ``read_timeout`` sets the socket read timeout in seconds; when omitted
     ``SNAGLINE_SERVER_READ_TIMEOUT`` / ``Config.server_read_timeout`` decides,
     then the built-in 30 s default (see ``_resolve_read_timeout``).
+    ``episode_ttl_seconds`` sets the TTL for ``snagline_episodes_active`` ids;
+    when omitted ``SNAGLINE_EPISODE_TTL_SECONDS`` / ``Config.episode_ttl_seconds``
+    decides, then disabled (None) by default (see ``_resolve_episode_ttl``).
     """
     tracker = HookTracker()
 
@@ -802,7 +896,9 @@ def make_handler(
     _Handler.snagline_risks = deque(maxlen=max(1, max_risks))
     _Handler.snagline_auth = auth_token
     _Handler.snagline_max_body = max_body_bytes
-    _Handler.snagline_collector = SidecarMetricsCollector()
+    _Handler.snagline_collector = SidecarMetricsCollector(
+        episode_ttl_seconds=episode_ttl_seconds
+    )
     _attach_metrics_collector(monitor, _Handler.snagline_collector)
     _Handler.snagline_metrics_format = _resolve_metrics_format(metrics_format)
     _Handler.timeout = _resolve_read_timeout(read_timeout)
@@ -898,6 +994,7 @@ def make_server(
     max_risks: int = 1000,
     metrics_format: str | None = None,
     read_timeout: float | None = None,
+    episode_ttl_seconds: float | None = None,
     ssl_context: ssl.SSLContext | None = None,
     certfile: str | None = None,
     keyfile: str | None = None,
@@ -911,12 +1008,21 @@ def make_server(
     worker thread. Without them the server is plain HTTP, exactly as before.
     ``read_timeout`` bounds stalled body reads (issue #130); ``None`` resolves
     via ``SNAGLINE_SERVER_READ_TIMEOUT`` / ``Config.server_read_timeout``.
-    When ``client_ca`` is given the server requests a client certificate on
+    ``episode_ttl_seconds`` sets the TTL for ``snagline_episodes_active`` ids;
+    ``None`` resolves via ``SNAGLINE_EPISODE_TTL_SECONDS`` / ``Config.episode_ttl_seconds``
+    and defaults to disabled (see ``_resolve_episode_ttl``). When
+    ``client_ca`` is given the server requests a client certificate on
     every handshake and verifies it against that CA bundle (issue #145).
     """
     tls_context = _resolve_ssl_context(ssl_context, certfile, keyfile, client_ca)
     handler = make_handler(
-        monitor, auth_token, max_body_bytes, max_risks, metrics_format, read_timeout
+        monitor,
+        auth_token,
+        max_body_bytes,
+        max_risks,
+        metrics_format,
+        read_timeout,
+        episode_ttl_seconds,
     )
     if tls_context is None:
         return ThreadingHTTPServer((host, port), handler)
@@ -934,6 +1040,7 @@ def serve(
     max_risks: int = 1000,
     metrics_format: str | None = None,
     read_timeout: float | None = None,
+    episode_ttl_seconds: float | None = None,
     ssl_context: ssl.SSLContext | None = None,
     certfile: str | None = None,
     keyfile: str | None = None,
@@ -950,6 +1057,7 @@ def serve(
         max_risks=max_risks,
         metrics_format=metrics_format,
         read_timeout=read_timeout,
+        episode_ttl_seconds=episode_ttl_seconds,
         ssl_context=ssl_context,
         certfile=certfile,
         keyfile=keyfile,

--- a/tests/server/test_ttl_expiry.py
+++ b/tests/server/test_ttl_expiry.py
@@ -1,0 +1,153 @@
+"""TTL expiry for snagline_episodes_active ids (issue #173).
+
+Covers: TTL expiry fires, disabled TTL preserves old behavior, bounded memory,
+fail-open on malformed config, and monotonic clock usage.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+
+import pytest
+
+from snagline.server.http_server import SidecarMetricsCollector, _resolve_episode_ttl
+
+
+class FakeClock:
+    def __init__(self, start: float = 0.0) -> None:
+        self.now = start
+
+    def __call__(self) -> float:
+        return self.now
+
+    def advance(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_ttl_expiry_fires_without_end_signal() -> None:
+    clock = FakeClock(start=1000.0)
+    col = SidecarMetricsCollector(episode_ttl_seconds=10, clock=clock)
+    col.record_ingest("ep-1", 0.001)
+    assert col.snapshot()["episodes_active"] == 1
+    clock.advance(5)
+    # Still within window, reseeing keeps it alive.
+    col.record_ingest("ep-2", 0.001)
+    assert col.snapshot()["episodes_active"] == 2
+    clock.advance(6)  # ep-1 now 11s old, ep-2 6s old
+    # Lazy sweep on next ingest and on snapshot.
+    assert col.snapshot()["episodes_active"] == 1
+    # ep-1 should be gone, ep-2 remains.
+    assert "ep-1" not in col._episodes
+    assert "ep-2" in col._episodes
+
+
+def test_ttl_reseen_id_refreshes_and_survives() -> None:
+    clock = FakeClock(start=0.0)
+    col = SidecarMetricsCollector(episode_ttl_seconds=10, clock=clock)
+    col.record_ingest("ep-1", 0.001)
+    clock.advance(8)
+    col.record_ingest("ep-1", 0.001)  # refresh
+    clock.advance(8)  # 8s after refresh, still within TTL
+    assert col.snapshot()["episodes_active"] == 1
+    clock.advance(3)  # 11s after last see -> expire
+    assert col.snapshot()["episodes_active"] == 0
+
+
+def test_disabled_ttl_preserves_old_behavior() -> None:
+    # Default off: byte-identical to pre-TTL.
+    col = SidecarMetricsCollector()
+    assert col._ttl is None
+    col.record_ingest("ep-1", 0.001)
+    col.record_ingest("ep-2", 0.001)
+    assert col.snapshot()["episodes_active"] == 2
+    # Even after advancing a fake clock, collector without TTL never expires
+    # (we cannot advance its real monotonic clock, but we can check that
+    # explicit None stays disabled and that 0 also disables).
+    col2 = SidecarMetricsCollector(episode_ttl_seconds=0)
+    assert col2._ttl is None
+    col2.record_ingest("ep-1", 0.001)
+    assert col2.snapshot()["episodes_active"] == 1
+    # Explicit None also disabled.
+    col3 = SidecarMetricsCollector(episode_ttl_seconds=None)
+    assert col3._ttl is None
+
+
+def test_ttl_bounded_memory_and_ids_only() -> None:
+    clock = FakeClock()
+    col = SidecarMetricsCollector(max_episodes=3, episode_ttl_seconds=10, clock=clock)
+    for i in range(5):
+        col.record_ingest(f"ep-{i}", 0.001)
+    # Cap still bounds memory: at most 3 ids.
+    assert col.snapshot()["episodes_active"] <= 3
+    # Table stores ids-plus-a-float, never content.
+    for k, v in col._episodes.items():
+        assert isinstance(k, str)
+        assert isinstance(v, float)
+        assert "content" not in k.lower()
+
+
+def test_ttl_fail_open_on_malformed_env(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    # Malformed env values fall back to disabled with a warning, never crash.
+    # "not-a-number" fails to coerce in Config.from_env_overrides and is
+    # ignored there (logged as "ignoring bad env"), so TTL stays disabled.
+    monkeypatch.setenv("SNAGLINE_EPISODE_TTL_SECONDS", "not-a-number")
+    with caplog.at_level(logging.WARNING):
+        ttl = _resolve_episode_ttl(None)
+    assert ttl is None
+    # No crash, disabled is the correct fallback.
+    caplog.clear()
+    monkeypatch.setenv("SNAGLINE_EPISODE_TTL_SECONDS", "-5")
+    with caplog.at_level(logging.WARNING):
+        ttl = _resolve_episode_ttl(None)
+    assert ttl is None
+    assert any("must be positive" in r.message for r in caplog.records)
+    caplog.clear()
+    monkeypatch.setenv("SNAGLINE_EPISODE_TTL_SECONDS", "0")
+    ttl = _resolve_episode_ttl(None)
+    assert ttl is None  # 0 disables without warning
+    # Explicit valid value wins.
+    ttl = _resolve_episode_ttl(5.0)
+    assert ttl == 5.0
+    ttl = _resolve_episode_ttl(None)
+    # Env 0 still disabled, not 5.
+    assert ttl is None
+    monkeypatch.delenv("SNAGLINE_EPISODE_TTL_SECONDS", raising=False)
+    # Config direct: None disabled.
+    assert SidecarMetricsCollector(episode_ttl_seconds=None)._ttl is None
+    # Config with TTL set propagates.
+    assert SidecarMetricsCollector(episode_ttl_seconds=5)._ttl == 5.0
+
+
+def test_ttl_uses_monotonic_not_wall_clock(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Ensure expiry uses monotonic clock, not wall-clock time.
+    # We inject a fake monotonic clock and verify that wall-clock NTP jumps
+    # (time.time) do not affect expiry.
+    clock = FakeClock(start=1000.0)
+    col = SidecarMetricsCollector(episode_ttl_seconds=10, clock=clock)
+    col.record_ingest("ep-1", 0.001)
+    # Simulate NTP jump: time.time jumps but monotonic does not.
+    real_time = time.time
+    monkeypatch.setattr(time, "time", lambda: real_time() + 10000)
+    # Still within monotonic TTL, so still active.
+    assert col.snapshot()["episodes_active"] == 1
+    clock.advance(11)
+    assert col.snapshot()["episodes_active"] == 0
+
+
+def test_ttl_sweep_on_both_ingest_and_scrape() -> None:
+    clock = FakeClock(start=0.0)
+    col = SidecarMetricsCollector(episode_ttl_seconds=10, clock=clock)
+    col.record_ingest("ep-1", 0.001)
+    col.record_ingest("ep-2", 0.001)
+    clock.advance(11)
+    # No new ingest, but scrape (snapshot) must still expire.
+    snap = col.snapshot()
+    assert snap["episodes_active"] == 0
+    # Also render_prometheus must expire (it calls snapshot).
+    col.record_ingest("ep-3", 0.001)
+    clock.advance(11)
+    body = col.render_prometheus({})
+    assert "snagline_episodes_active 0" in body

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -236,12 +236,13 @@ def test_main_serve_starts_server(monkeypatch):
     monkeypatch.setattr("snagline.server.http_server.serve", _fake_serve)
     assert main(["serve"]) == 0
     assert started.get("ok") == ("127.0.0.1", 8787)
-    # Defaults: no token, 1 MB body cap, 1000 retained risks, 30 s timeout.
+    # Defaults: no token, 1 MB body cap, 1000 retained risks, 30 s timeout, no TTL.
     assert started["kwargs"] == {
         "auth_token": None,
         "max_body_bytes": 1_000_000,
         "max_risks": 1000,
         "read_timeout": None,
+        "episode_ttl_seconds": None,
     }
 
 

--- a/tests/test_server_mtls.py
+++ b/tests/test_server_mtls.py
@@ -195,7 +195,7 @@ def test_resolve_sets_verify_mode_only_when_client_ca_given(tmp_path):
     # With client_ca: verify_mode becomes CERT_REQUIRED and CA is loaded
     ctx_mtls = _resolve_ssl_context(None, server_cert, server_key, ca_cert)
     assert ctx_mtls is not None
-    assert ctx_mtls.verify_mode == ssl.CERT_REQUIRED
+    assert ctx_mtls.verify_mode == ssl.CERT_REQUIRED  # type: ignore[union-attr]
 
 
 def test_plain_and_server_tls_modes_unchanged_without_client_ca(tmp_path):
@@ -208,9 +208,11 @@ def test_plain_and_server_tls_modes_unchanged_without_client_ca(tmp_path):
         tmp_path, ca_cert, ca_key, "127.0.0.1", "server"
     )
     ctx = _resolve_ssl_context(None, server_cert, server_key)
+    assert ctx is not None
     assert ctx.verify_mode == ssl.CERT_NONE
     # Explicit None client_ca must behave identically
     ctx2 = _resolve_ssl_context(None, server_cert, server_key, None)
+    assert ctx2 is not None
     assert ctx2.verify_mode == ssl.CERT_NONE
 
 
@@ -457,7 +459,7 @@ def test_plain_and_server_tls_modes_regression(tmp_path):
         assert status == 200
         assert json.loads(body) == {"status": "ok"}
         # Verify server context is not in mTLS mode
-        assert tls_plain.snagline_ssl_context.verify_mode == ssl.CERT_NONE
+        assert tls_plain.snagline_ssl_context.verify_mode == ssl.CERT_NONE  # type: ignore[attr-defined]
     finally:
         tls_plain.shutdown()
         tls_plain.server_close()


### PR DESCRIPTION
Fixes #173

Optional TTL expiry for `snagline_episodes_active` ids so a long-lived sidecar that sees more than 10k episodes does not under-count quiet-but-still-running ones.

## Design

*   Config knob `Config.episode_ttl_seconds` (env `SNAGLINE_EPISODE_TTL_SECONDS`), default `None` disabled so existing behavior is byte-identical. `0` also disables. When set, the value is wall-clock seconds for the TTL but expiry checks use `time.monotonic()` so NTP jumps cannot mass-expire or freeze entries. Fail-open: malformed env values (non-numeric, non-finite, negative) log a warning and disable the TTL, never crash the sidecar.
*   `SidecarMetricsCollector` now stores per-id monotonic last-seen (`OrderedDict[str, float]`) alongside the id; the table stays ids-plus-a-float, never content, and the same `_MAX_TRACKED_EPISODES` cap still bounds memory. Lazy sweep on `record_ingest()` and on scrape render (`snapshot()` via `_expire_stale_locked()`) rather than a background thread, so amortized O(1) per step like every other project.md 1.5 path. Reseeing an id after expiry just re-registers it.
*   Plumbing: `make_handler` / `make_server` / `serve` accept `episode_ttl_seconds` and forward to the collector via `_resolve_episode_ttl` helper (same precedence as `read_timeout`/`metrics_format`: explicit > env > Config default > disabled). CLI `snagline serve --episode-ttl-seconds` added with help next to `--read-timeout`.
*   Docs: `docs/ATTACH_ANY_SYSTEM.md` next to the scrape config and `POST /episodes/end` curl example, including TTL vs explicit end trade-off (precise immediate vs self-healing for uncooperative senders) and replay caveat (replaying an old trajectory through a live sidecar will resurrect stale ids).

## Tests

*   `test_ttl_expiry_fires_without_end_signal` – TTL 10s, two ids, advance 11s, `snapshot()` drops the stale one without any `/episodes/end`.
*   `test_ttl_reseen_id_refreshes_and_survives` – refresh within window keeps it alive, then expiry after idle.
*   `test_disabled_ttl_preserves_old_behavior` – default `None`, `0`, and explicit `None` all keep old cap-only eviction.
*   `test_ttl_bounded_memory_and_ids_only` – cap still bounds, table never stores content.
*   `test_ttl_fail_open_on_malformed_env` – non-numeric, negative, zero, valid values all handled fail-open.
*   `test_ttl_uses_monotonic_not_wall_clock` – `time.time` jump does not expire.
*   `test_ttl_sweep_on_both_ingest_and_scrape` – expiry on `snapshot()` and `render_prometheus()` without new ingest.

Existing `tests/test_cli.py::test_main_serve_starts_server` updated to expect the new `episode_ttl_seconds` kwarg.

## Mutation check

After committing, changed `if now - last_seen > self._ttl:` to `if False:` in `http_server.py`. `test_ttl_expiry_fires_without_end_signal` went red (2 vs 1 active), `test_ttl_sweep_on_both_ingest_and_scrape` also red. Reverted via `git checkout` and both went green.

## Gate

pytest 689 passed 3 skipped, ruff check, ruff format --check, mypy src all green at the commit. No em dashes in code, docs, tests, or this body. Raw-socket style not needed for TTL (no new endpoint); unit tests with monotonic fake clock cover the contract.

## Zone

Only `server/http_server.py` (plus `config.py`/`cli.py` for the knob and docs) – no overlap with Agent 7's monitor time-axis persist (`_clocks`).
