### PR TITLE
fix: rename distribution from snagline-agent to snagline (Fixes #104)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,6 @@
 name: Release
 
-# Publishes snagline-agent to PyPI when a version tag is pushed, or via
+# Publishes snagline to PyPI when a version tag is pushed, or via
 # manual dispatch. Never runs on pushes to master, so normal development
 # does not trigger a publish. See issue #104.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,10 +66,10 @@ over 200,000 synthetic steps. Detection accuracy measured on this checkout:
   with wall-clock budget (`wall_clock_budget`), `idle_warn_seconds`
   (`idle_gap`), window auto-scaling (`window_scale_steps`, `max_window`),
   `HeartbeatSink` and `snagline watch --follow --heartbeat` liveness file.
-- **ML extra: ESN ensemble** (`ml/esn_ensemble.py`, `snagline-agent[ml]`,
+- **ML extra: ESN ensemble** (`ml/esn_ensemble.py`, `snagline[ml]`,
   one-class ESN + CUSUM + Mahalanobis baseline) (PR #135).
 - **Drift extra: semantic goal-drift** (`drift/goal_drift.py`,
-  `snagline-agent[drift]`, sentence-transformers, PR #81 / 09ae888).
+  `snagline[drift]`, sentence-transformers, PR #81 / 09ae888).
 - **Auto-calibration** from `BaselineProfile` (`calibration="auto"`,
   `CalibrationPlan`, `resolve_baseline_profile`) (PR #138).
 - **Scheduled baseline retrain** `snagline baseline retrain` contract with
@@ -101,7 +101,7 @@ over 200,000 synthetic steps. Detection accuracy measured on this checkout:
 - Claude Code hook adapter via `HookTracker` / `payload_to_event`
   (`adapters/claude_code.py`) with latency derivation (PR #71, #64).
 - **CONTINUUM bridge** adapter + sink (`adapters/continuum_adapter.py`,
-  `sinks/continuum_sink.py`, extra `snagline-agent[continuum]`, duck-typed
+  `sinks/continuum_sink.py`, extra `snagline[continuum]`, duck-typed
   against verified `read_events` / `last_sequence` API) (PR #164, #79).
 
 #### Server (sidecar, stdlib `http.server`)

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The answer is yes. SNAGLINE's tier-1 detectors are deterministic, O(1) amortized
 Zero third-party dependencies. Install from PyPI:
 
 ```bash
-pip install snagline-agent
+pip install snagline
 ```
 
 Or from source:
@@ -122,7 +122,7 @@ The `goal_drift`, `ml_ensemble`, `stagnation`, and semantic goal-drift (`drift`)
 python -m your_agent --trace run.jsonl
 # 2. Build a healthy baseline profile from it.
 snagline baseline run.jsonl --output baseline.json
-# 2b. With semantics (needs pip install snagline-agent[drift]):
+# 2b. With semantics (needs pip install snagline[drift]):
 snagline baseline run.jsonl --output baseline.json --semantic --semantic-model all-MiniLM-L6-v2
 ```
 
@@ -140,7 +140,7 @@ config = Config(
 monitor = Monitor.default(config=config)
 ```
 
-The `drift` extra adds semantic drift on top of the same `BaselineProfile` (issue #81, `pip install snagline-agent[drift]`). Fit it from the same healthy trajectory with `fit_semantic_baseline` (`snagline/drift/goal_drift.py`), then enable it with `Config(semantic_drift_enabled=True, goal_drift_baseline=profile)`. Import is lazy and any model load or inference failure leaves it inert, logged and fail-open. With `ml_ensemble_enabled` and `semantic_drift_enabled` together the semantic signal joins the ESN ensemble inside the same noisy-OR `MLOrchestrator`.
+The `drift` extra adds semantic drift on top of the same `BaselineProfile` (issue #81, `pip install snagline[drift]`). Fit it from the same healthy trajectory with `fit_semantic_baseline` (`snagline/drift/goal_drift.py`), then enable it with `Config(semantic_drift_enabled=True, goal_drift_baseline=profile)`. Import is lazy and any model load or inference failure leaves it inert, logged and fail-open. With `ml_ensemble_enabled` and `semantic_drift_enabled` together the semantic signal joins the ESN ensemble inside the same noisy-OR `MLOrchestrator`.
 
 With `ml_ensemble_enabled`, `Monitor.default()` wraps the base detectors in a single `MLOrchestrator` instead of exposing them individually, so there is no double counting. All advanced detectors are documented in [docs/DETECTOR_GUIDE.md](docs/DETECTOR_GUIDE.md).
 
@@ -153,7 +153,7 @@ in [docs/RETRAIN_CADENCE.md](docs/RETRAIN_CADENCE.md)).
 
 | Capability | What it gives you |
 |:--|:--|
-| **Zero dependencies** | The core needs nothing but Python 3.10+ -- `dependencies = []` in `pyproject.toml`, non-negotiable. Published to PyPI as `snagline-agent` (`pip install snagline-agent`, or `pip install .` from a clone, see [Quick Start](#quick-start)). Every framework adapter is an optional extra. |
+| **Zero dependencies** | The core needs nothing but Python 3.10+ -- `dependencies = []` in `pyproject.toml`, non-negotiable. Published to PyPI as `snagline` (`pip install snagline`, or `pip install .` from a clone, see [Quick Start](#quick-start)). Every framework adapter is an optional extra. |
 | **Fail-open guarantee** | Detector/sink exceptions are caught, logged, and never propagated into the host agent. A monitoring library that can crash the thing it monitors is a non-starter. |
 | **Microsecond-scale overhead** | Median 2.43 us/step, p99 27.71 us/step over 200,000 synthetic steps. Cheap enough to run on every step of a week-long run. Numbers and provenance in [Empirical Verification](#automated-test-suite-and-benchmarks); reproduce with `snagline bench`. |
 | **Framework-agnostic core** | All detector and sink logic operates only on the canonical `StepEvent` schema. Framework-specific code lives in isolated adapter modules and nowhere else. |
@@ -448,11 +448,11 @@ SNAGLINE plugs into agent frameworks without becoming one. Six adapters ship in 
 | Adapter | Module | Install | Notes |
 |:--|:--|:--|:--|
 | Raw Python loop | `raw.py` | (built-in) | Context manager + decorator. Stdlib only, always available. The most-used adapter. |
-| LangChain | `langchain_adapter.py` | `pip install snagline-agent[langchain]` | `SnaglineCallbackHandler` subclassing `BaseCallbackHandler`. |
-| LangGraph | `langgraph_adapter.py` | `pip install snagline-agent[langgraph]` | `watch_graph` pass-through iterator wrapping `graph.stream(...)`. |
+| LangChain | `langchain_adapter.py` | `pip install snagline[langchain]` | `SnaglineCallbackHandler` subclassing `BaseCallbackHandler`. |
+| LangGraph | `langgraph_adapter.py` | `pip install snagline[langgraph]` | `watch_graph` pass-through iterator wrapping `graph.stream(...)`. |
 | Claude Code | `claude_code.py` | (built-in) | Maps native hook payloads via `ingest_payload`. Works over HTTP sidecar or file bridge. |
-| Autogen | `autogen.py` | `pip install snagline-agent[autogen]` | `SnaglineAutogenHandler` + `run_and_monitor` wrapping `agent.run_stream`. Duck-typed, no hard Autogen version pin. |
-| CrewAI | `crewai.py` | `pip install snagline-agent[crewai]` | `snagline_step_callback` for `Agent(step_callback=...)`, plus `observe_crewai_step`. Duck-typed, no hard CrewAI version pin. |
+| Autogen | `autogen.py` | `pip install snagline[autogen]` | `SnaglineAutogenHandler` + `run_and_monitor` wrapping `agent.run_stream`. Duck-typed, no hard Autogen version pin. |
+| CrewAI | `crewai.py` | `pip install snagline[crewai]` | `snagline_step_callback` for `Agent(step_callback=...)`, plus `observe_crewai_step`. Duck-typed, no hard CrewAI version pin. |
 
 Each adapter translates framework-specific events into `StepEvent`s and calls `monitor.ingest()`. None of them contain detection logic.
 
@@ -737,12 +737,12 @@ SNAGLINE sits at the overlap of real-time monitoring, anomaly detection, and rel
 ## Status and Limitations
 
 - **Tested**: 622 tests passing, 2 skipped, 88.88% line coverage (see [Empirical Verification](#automated-test-suite-and-benchmarks) for the exact command and environment).
-- **On PyPI as `snagline-agent` 0.1.0** (`pip install snagline-agent`; clone still works via `pip install .` see Quick Start). The `snagline-agent[langchain]`-style names used elsewhere in this README are the extras this package declares.
+- **On PyPI as `snagline` 0.1.0** (`pip install snagline`; clone still works via `pip install .` see Quick Start). The `snagline[langchain]`-style names used elsewhere in this README are the extras this package declares.
 - **Overhead is measured, not asserted.** Run `snagline bench` to reproduce on your hardware.
-- **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline-agent[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.
+- **Framework adapters are optional extras; sinks ship in core.** The LangChain, LangGraph, Autogen, and CrewAI adapters are optional installs (`pip install snagline[langchain]`, etc.). The console, webhook, Slack, PagerDuty, and dedup sinks are zero-dependency stdlib and always available.
 - **The latency anomaly detector requires warm-up.** It learns a baseline from `cusum_min_samples` (default 5) events before any alarm can fire. This prevents false positives on normal jitter but means the detector is blind during warm-up. The default was deliberately lowered from 20 to 5 (issue #9) so tools called only a handful of times are still monitored; the frozen baseline plus sigma floors keep a single large spike alarmable right after warm-up instead of requiring several sustained ones. A calibrated `BaselineProfile` (issue #101) removes the blind spot for tools it describes. With `cusum_refit_every` set, the frozen baseline is periodically re-checked against a parallel learner, so drift in the baseline itself becomes visible instead of being learned away silently.
 - **Idle detection and the silence hole.** In-band detectors can never see a hung host: no events means no `observe()` calls, so a deadlocked tool or an OOM-stopped worker produces no signal at all. The opt-in time axis narrows this from inside (`idle_warn_seconds` fires one `idle_gap` risk when consecutive ingests drift too far apart, derived from event timestamps so replay stays deterministic), but only while events were flowing to snagline in the first place. For full coverage pair it with `snagline watch --heartbeat PATH` plus an external watcher (cron, systemd timer, k8s probe): the heartbeat file's mtime going stale is the externally detectable "host is silent" signal.
-- **Goal-drift without the drift extra is structural only.** The built-in detector compares per-tool error rate, latency, and tool-name sets. Semantic (embedding) drift needs `pip install snagline-agent[drift]` (sentence-transformers, issue #81) and a baseline fitted with `fit_semantic_baseline`; without it the semantic side stays inert, logged and fail-open.
+- **Goal-drift without the drift extra is structural only.** The built-in detector compares per-tool error rate, latency, and tool-name sets. Semantic (embedding) drift needs `pip install snagline[drift]` (sentence-transformers, issue #81) and a baseline fitted with `fit_semantic_baseline`; without it the semantic side stays inert, logged and fail-open.
 - **No automatic repair.** Detection and escalation only. Repair is a distinct, harder problem.
 - **Alert spam under sustained anomalies.** The loop and error-cascade detectors emit a risk on every step while the triggering condition holds. Wrap a sink in `DedupSink` to suppress repeats within a cooldown window ([#4](https://github.com/Cyrax321/SNAGLINE/issues/4)).
 - **Slack delivery is fire-and-forget.** `SlackSink` posts to an incoming webhook with a short timeout; it never raises and never blocks `ingest()` for long.

--- a/docs/ADAPTER_GUIDE.md
+++ b/docs/ADAPTER_GUIDE.md
@@ -144,7 +144,7 @@ to protect constraints it cannot see. Enable it with
 Both the Autogen and CrewAI adapters are duck-typed: they read event objects via
 `model_dump()` with attribute/dict fallbacks, so they import without the
 framework installed and never hard-couple to a specific release. The CONTINUUM
-adapter (`pip install snagline-agent[continuum]`, issue #79) is duck-typed the
+adapter (`pip install snagline[continuum]`, issue #79) is duck-typed the
 same way: it calls only the verified public read pair
 (`read_events(run_id, *, after_sequence=0, upto=None)` + `last_sequence(run_id)`)
 and never imports `continuum`. It maps `PERCEPTION_OBSERVED` to an observation,

--- a/docs/ATTACH_ANY_SYSTEM.md
+++ b/docs/ATTACH_ANY_SYSTEM.md
@@ -69,7 +69,7 @@ enterprise-grade alerting. Concretely:
 - Config is a Python dataclass; no env/yml/toml loader, no secrets management
   (not 12-factor).
 - Not on PyPI (`version = 0.1.0`, README says "Not on PyPI"). `pip install
-  snagline-agent` does not work yet.
+  snagline` does not work yet.
 - No self-observability: no metrics endpoint, no health check, no structured
   logs for the monitor itself.
 
@@ -96,7 +96,7 @@ enterprise-grade alerting. Concretely:
    from env/yml with secret handling (12-factor).
    - **Done (code side):** PyPI-ready metadata + verified `python -m build`
      sdist/wheel (#37); `Config.from_env` / `load_file` / `resolve` 12-factor
-     loader (#30) wired into the CLI (#36). Actual `pip install snagline-agent`
+     loader (#30) wired into the CLI (#36). Actual `pip install snagline`
      upload still needs a PyPI token (not performed automatically).
 
 ### P1 (production readiness)

--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -157,7 +157,7 @@ running centroid of embedded structural labels against the persisted
   `h=0.5`). After firing the accumulator re-arms, so persistent drift
   re-alarms later. Fewer than `semantic_drift_min_samples` (default 10)
   live steps never fire.
-* **Extra and laziness:** `pip install snagline-agent[drift]`
+* **Extra and laziness:** `pip install snagline[drift]`
   (`sentence-transformers`). The package imports without the extra; the
   transformer is loaded lazily, exactly once, on first use. An injectable
   `embedder=callable(StepEvent) -> Sequence[float]` bypasses the heavy
@@ -187,7 +187,7 @@ profile = fit_semantic_baseline(healthy_events, embedder, model="all-MiniLM-L6-v
 save_baseline(profile, "baseline.json")  # JSON now carries embedding_centroid
 ```
 
-You can also fit the same profile directly from the CLI without writing Python: `snagline baseline trajectory.jsonl --output baseline.json --semantic --semantic-model all-MiniLM-L6-v2` streams the JSONL fail-soft and builds both the structural stats and the embedding centroid via the guarded `sentence-transformers` import, then persists it with `save_baseline`. Missing extra or model-load failure prints a `pip install snagline-agent[drift]` hint and exits non-zero without writing a half-fitted file; without `--semantic` the command is byte-identical to today.
+You can also fit the same profile directly from the CLI without writing Python: `snagline baseline trajectory.jsonl --output baseline.json --semantic --semantic-model all-MiniLM-L6-v2` streams the JSONL fail-soft and builds both the structural stats and the embedding centroid via the guarded `sentence-transformers` import, then persists it with `save_baseline`. Missing extra or model-load failure prints a `pip install snagline[drift]` hint and exits non-zero without writing a half-fitted file; without `--semantic` the command is byte-identical to today.
 
 Or build one structurally with `snagline baseline` and without semantics;
 the detector then stays inert (the intended default) until you give it a

--- a/docs/INTEGRATION_MATRIX.md
+++ b/docs/INTEGRATION_MATRIX.md
@@ -80,7 +80,7 @@ test running the real `ActionLedger`.
 | `PagerDutySink` | PagerDuty Events API v2 | stdlib |
 | `DedupSink` | cooldown/dedup wrapper (issue #4) | stdlib |
 | `BatchingSink` | async, rate-limited dispatch | stdlib |
-| `ContinuumSink` (issue #79) | escalates via CONTINUUM `ActionLedger.flag_for_review` -> `REQUIRES_REVIEW`; needs a resolvable action key per risk | stdlib core; `snagline-agent[continuum]` extra for the lazy import |
+| `ContinuumSink` (issue #79) | escalates via CONTINUUM `ActionLedger.flag_for_review` -> `REQUIRES_REVIEW`; needs a resolvable action key per risk | stdlib core; `snagline[continuum]` extra for the lazy import |
 
 CLI: `snagline watch --sink {console,webhook,slack,pagerduty}` (plus
 `--cooldown-seconds`, `--min-severity`). Wrap any sink in `DedupSink` and/or

--- a/examples/langchain_example.py
+++ b/examples/langchain_example.py
@@ -1,7 +1,7 @@
 """Runnable demo: SNAGLINE watching a REAL LangChain run via the callback handler.
 
 Requires langchain-core (optional extra):
-    pip install snagline-agent[langchain]
+    pip install snagline[langchain]
     PYTHONPATH=src python3 examples/langchain_example.py
 
 Four identical prompts are sent to a (fake) chat model; the repeated message
@@ -23,7 +23,7 @@ def main() -> None:
     except ImportError:
         print(
             "This example needs langchain-core. Install it with:\n"
-            "    pip install snagline-agent[langchain]",
+            "    pip install snagline[langchain]",
             file=sys.stderr,
         )
         return

--- a/examples/real_agent_demo.py
+++ b/examples/real_agent_demo.py
@@ -21,7 +21,7 @@ Model selection:
       tool-call sequence for the chosen chaos mode, so the run is fully
       deterministic and needs no API key.
 
-Requires: pip install snagline-agent[langchain]
+Requires: pip install snagline[langchain]
 
 Run:
     PYTHONPATH=src python3 examples/real_agent_demo.py --mode healthy
@@ -172,7 +172,7 @@ def main() -> None:
     if not LANGCHAIN_AVAILABLE:
         print(
             "This example needs langchain-core. Install it with:\n"
-            "    pip install snagline-agent[langchain]",
+            "    pip install snagline[langchain]",
             file=sys.stderr,
         )
         return

--- a/examples/real_agent_executor_demo.py
+++ b/examples/real_agent_executor_demo.py
@@ -19,7 +19,7 @@ Modes (which detector each one is meant to trip):
     error     -> error_cascade (tool always raises)
     latency   -> latency_anomaly (a tool's latency shifts from fast to slow)
 
-Requires: pip install langchain  (and snagline-agent[langchain])
+Requires: pip install langchain  (and snagline[langchain])
 
 Run:
     PYTHONPATH=src python3 examples/real_agent_executor_demo.py --mode loop
@@ -132,7 +132,7 @@ def main() -> None:
     if not LANGCHAIN_AGENT_AVAILABLE:
         print(
             "This example needs langchain (>=1.x). Install it with:\n"
-            "    pip install langchain snagline-agent[langchain]",
+            "    pip install langchain snagline[langchain]",
             file=sys.stderr,
         )
         return

--- a/examples/real_time_llm_demo.py
+++ b/examples/real_time_llm_demo.py
@@ -12,7 +12,7 @@ Modes:
   latency  -> a single tool with variable latency (triggers latency_anomaly)
 
 Requirements:
-  * pip install langchain langchain-openai snagline-agent[langchain]
+  * pip install langchain langchain-openai snagline[langchain]
     (or langchain-anthropic)
   * For OpenAI/Anthropic: export OPENAI_API_KEY / ANTHROPIC_API_KEY
   * For OpenRouter (OpenAI-compatible, free models): 

--- a/project.md
+++ b/project.md
@@ -61,7 +61,7 @@ top of it, not around it:
 1. **Zero mandatory dependencies in core.** `import snagline` must work with
    nothing but the Python standard library. Every framework integration,
    every ML detector, every notification sink beyond console/webhook is an
-   optional extra (`pip install snagline-agent[langchain]`, etc.).
+   optional extra (`pip install snagline[langchain]`, etc.).
 2. **Fail-open, always.** If a detector or sink raises an exception, it is
    caught, logged, and ignored; it must never propagate into the host
    agent and never block or slow the agent's actual work. A monitoring
@@ -189,10 +189,10 @@ snagline/
  │       │   ├── latency_anomaly.py   # Welford + CUSUM, stdlib `statistics` only
  │       │   ├── goal_drift.py        # OPT-IN: live vs healthy BaselineProfile (built)
  │       │   └── ml_ensemble.py       # OPT-IN: MLOrchestrator noisy-OR (built; model= hook)
- │       ├── ml/                      # optional extra: snagline-agent[ml] (research path, NOT YET BUILT)
+ │       ├── ml/                      # optional extra: snagline[ml] (research path, NOT YET BUILT)
  │       │   ├── __init__.py
  │       │   └── esn_ensemble.py      # echo-state-network detector
- │       ├── drift/                   # optional extra: snagline-agent[drift] (research path, NOT YET BUILT)
+ │       ├── drift/                   # optional extra: snagline[drift] (research path, NOT YET BUILT)
  │       │   ├── __init__.py
  │       │   └── goal_drift.py        # semantic-drift (sentence-transformers) detector
 │       ├── sinks/
@@ -200,17 +200,17 @@ snagline/
 │       │   ├── base.py              # AlertSink protocol
 │       │   ├── console.py           # default, zero dep
 │       │   ├── webhook.py           # stdlib urllib, zero dep
-│       │   ├── continuum_sink.py    # optional extra: snagline-agent[continuum]
-│       │   └── slack.py             # optional extra: snagline-agent[slack]
+│       │   ├── continuum_sink.py    # optional extra: snagline[continuum]
+│       │   └── slack.py             # optional extra: snagline[slack]
 │       ├── adapters/
 │       │   ├── __init__.py
 │       │   ├── raw.py               # context manager + decorator, zero dep
-│       │   ├── langchain_adapter.py  # optional extra: snagline-agent[langchain]
-│       │   ├── langgraph_adapter.py  # optional extra: snagline-agent[langgraph]
+│       │   ├── langchain_adapter.py  # optional extra: snagline[langchain]
+│       │   ├── langgraph_adapter.py  # optional extra: snagline[langgraph]
  │       │   ├── autogen_adapter.py    # built as adapters/autogen.py (duck-typed)
  │       │   ├── crewai_adapter.py     # built as adapters/crewai.py (duck-typed)
-│       │   ├── openai_adapter.py     # optional extra: snagline-agent[openai]
-│       │   ├── anthropic_adapter.py  # optional extra: snagline-agent[anthropic]
+│       │   ├── openai_adapter.py     # optional extra: snagline[openai]
+│       │   ├── anthropic_adapter.py  # optional extra: snagline[anthropic]
 │       │   ├── claude_code_adapter.py # optional; verify current hooks API first: see §6.7
 │       │   └── continuum_adapter.py  # reads CONTINUUM Storage by sequence
 │       └── server/                   # optional sidecar mode for non-Python agents
@@ -664,7 +664,7 @@ hard-couple to a release.
 - CrewAI: `snagline_step_callback()` returns the `Agent(step_callback=...)`
   hook; `observe_crewai_step()` is the manual equivalent.
 
-Install with `pip install snagline-agent[autogen]` / `[crewai]`.
+Install with `pip install snagline[autogen]` / `[crewai]`.
 
 ### 6.5 `openai_adapter.py`, `anthropic_adapter.py`
 
@@ -810,7 +810,7 @@ snagline bench                                        # runs overhead_benchmark.
 
 ```toml
 [project]
-name = "snagline-agent"
+name = "snagline"
 requires-python = ">=3.10"
 dependencies = []   # core: zero required deps, non-negotiable
 
@@ -825,7 +825,7 @@ continuum  = []   # depends on CONTINUUM's actual package name/version; confirm 
 ml         = ["numpy>=1.24", "scikit-learn>=1.3"]
 drift      = ["sentence-transformers>=2.2"]
 slack      = ["httpx>=0.27"]
-all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,continuum,ml,drift,slack]"]
+all        = ["snagline[langchain,langgraph,autogen,crewai,openai,anthropic,continuum,ml,drift,slack]"]
 ```
 
 MIT license (matches the open-source, low-friction-adoption goal; avoid
@@ -972,7 +972,7 @@ when the optional langchain extra is absent).
   calling `ActionLedger.flag_for_review` so the action lands as
   `REQUIRES_REVIEW`; requires a resolvable action key (`key_from_risk`) and
   drops unmapped risks rather than inventing ledger facts. Fail-open.
-- **Extra**: `snagline-agent[continuum]` names the real `continuum-agent`
+- **Extra**: `snagline[continuum]` names the real `continuum-agent`
   distribution; core stays zero-dependency either way.
 - **Verification honesty**: unit tests use a fake storage implementing only
   the verified surface; one skip-guarded test drives the real

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "snagline-agent"
+name = "snagline"
 version = "0.1.0"
 description = "Lightweight, dependency-free real-time failure detection for AI agents."
 readme = "README.md"
@@ -46,7 +46,7 @@ drift      = ["sentence-transformers>=2.2"]          # semantic goal-drift (issu
 dev        = ["pytest", "pytest-cov==7.1.0", "ruff==0.16.3", "mypy"]
 # Slack and PagerDuty sinks ship in the core and use only the stdlib, so they
 # need no extra dependency; the `all` extra pulls in the framework/SDK extras.
-all        = ["snagline-agent[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift,continuum]"]
+all        = ["snagline[langchain,langgraph,autogen,crewai,openai,anthropic,ml,drift,continuum]"]
 
 [project.scripts]
 snagline = "snagline.cli:main"

--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -29,7 +29,7 @@ from snagline.risk import FailureRisk, TriggerType
 try:
     from importlib.metadata import version
 
-    __version__ = version("snagline-agent")
+    __version__ = version("snagline")
 except Exception:
     __version__ = "0.1.0"
 

--- a/src/snagline/adapters/autogen.py
+++ b/src/snagline/adapters/autogen.py
@@ -1,4 +1,4 @@
-"""Autogen adapter (optional extra: ``pip install snagline-agent[autogen]``).
+"""Autogen adapter (optional extra: ``pip install snagline[autogen]``).
 
 Turns Autogen agent events into ``StepEvent``s and feeds them to a ``Monitor``.
 Autogen is async-first; the most stable integration point is the event stream

--- a/src/snagline/adapters/continuum_adapter.py
+++ b/src/snagline/adapters/continuum_adapter.py
@@ -1,4 +1,4 @@
-"""CONTINUUM ledger adapter (optional extra: ``pip install snagline-agent[continuum]``).
+"""CONTINUUM ledger adapter (optional extra: ``pip install snagline[continuum]``).
 
 "Free telemetry": reads a CONTINUUM run's hash-chained event log through its
 existing public ``Storage`` API and translates entries into SNAGLINE

--- a/src/snagline/adapters/crewai.py
+++ b/src/snagline/adapters/crewai.py
@@ -1,4 +1,4 @@
-"""CrewAI adapter (optional extra: ``pip install snagline-agent[crewai]``).
+"""CrewAI adapter (optional extra: ``pip install snagline[crewai]``).
 
 Turns CrewAI agent steps into ``StepEvent``s and feeds them to a ``Monitor``.
 CrewAI agents accept a ``step_callback`` that receives each agent step as it is

--- a/src/snagline/adapters/langchain_adapter.py
+++ b/src/snagline/adapters/langchain_adapter.py
@@ -1,4 +1,4 @@
-"""LangChain adapter (optional extra: ``pip install snagline-agent[langchain]``).
+"""LangChain adapter (optional extra: ``pip install snagline[langchain]``).
 
 Turns a LangChain run into ``StepEvent``s and feeds them to a ``Monitor``. This
 is the highest-leverage framework integration (project.md §13 step 5) -- most

--- a/src/snagline/adapters/langgraph_adapter.py
+++ b/src/snagline/adapters/langgraph_adapter.py
@@ -1,4 +1,4 @@
-"""LangGraph adapter (optional extra: ``pip install snagline-agent[langgraph]``).
+"""LangGraph adapter (optional extra: ``pip install snagline[langgraph]``).
 
 Wraps ``graph.stream(...)`` -- LangGraph's public streaming API -- and turns
 each node update into a ``StepEvent`` for the Monitor (project.md §6.3).

--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -483,7 +483,7 @@ def _build_parser() -> argparse.ArgumentParser:
         "--semantic",
         action="store_true",
         help="Also fit a semantic embedding centroid (requires pip install "
-        "snagline-agent[drift]; streams the trajectory fail-soft and "
+        "snagline[drift]; streams the trajectory fail-soft and "
         "persists via save_baseline).",
     )
     sp.add_argument(
@@ -809,7 +809,7 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
             except Exception as exc:
                 print(
                     "snagline baseline: drift extra not installed "
-                    f"({exc}); run `pip install snagline-agent[drift]` for semantic baseline",
+                    f"({exc}); run `pip install snagline[drift]` for semantic baseline",
                     file=sys.stderr,
                 )
                 return 1
@@ -818,7 +818,7 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
             except Exception as exc:
                 print(
                     f"snagline baseline: embedding model {semantic_model!r} failed to load "
-                    f"({exc}); run `pip install snagline-agent[drift]`",
+                    f"({exc}); run `pip install snagline[drift]`",
                     file=sys.stderr,
                 )
                 return 1
@@ -831,7 +831,7 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
             except Exception as exc:
                 print(
                     f"snagline baseline: semantic fit unavailable ({exc}); "
-                    "run `pip install snagline-agent[drift]`",
+                    "run `pip install snagline[drift]`",
                     file=sys.stderr,
                 )
                 return 1
@@ -894,7 +894,7 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
         except Exception as exc:
             print(
                 "snagline baseline: drift extra not installed "
-                f"({exc}); run `pip install snagline-agent[drift]` for semantic baseline",
+                f"({exc}); run `pip install snagline[drift]` for semantic baseline",
                 file=sys.stderr,
             )
             return 1
@@ -903,7 +903,7 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
         except Exception as exc:
             print(
                 f"snagline baseline: embedding model {semantic_model!r} failed to load "
-                f"({exc}); run `pip install snagline-agent[drift]`",
+                f"({exc}); run `pip install snagline[drift]`",
                 file=sys.stderr,
             )
             return 1
@@ -913,7 +913,7 @@ def _cmd_baseline(args: argparse.Namespace) -> int:
         except Exception as exc:
             print(
                 f"snagline baseline: semantic fit unavailable ({exc}); "
-                "run `pip install snagline-agent[drift]`",
+                "run `pip install snagline[drift]`",
                 file=sys.stderr,
             )
             return 1

--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -238,7 +238,7 @@ class Config:
     # episode's running embedding centroid against the persisted
     # BaselineProfile's embedding_centroid through cosine distance. A CUSUM
     # over the deviation keeps it silent unless the divergence is sustained.
-    # Requires ``pip install snagline-agent[drift]`` AND a baseline fitted with
+    # Requires ``pip install snagline[drift]`` AND a baseline fitted with
     # snagline.drift.fit_semantic_baseline; anything missing degrades fail-open
     # to an inert, logged detector and the zero-dep preset is untouched.
     semantic_drift_enabled: bool = False

--- a/src/snagline/drift/__init__.py
+++ b/src/snagline/drift/__init__.py
@@ -1,6 +1,6 @@
 """Optional ``drift`` extra: semantic goal-drift detection (issue #81).
 
-Provides ``pip install snagline-agent[drift]`` (sentence-transformers). This
+Provides ``pip install snagline[drift]`` (sentence-transformers). This
 subpackage is never imported by core code paths unless
 ``Config.semantic_drift_enabled`` is set; ``import snagline`` works with
 nothing but the standard library (project.md section 1.1). Even this module

--- a/src/snagline/drift/goal_drift.py
+++ b/src/snagline/drift/goal_drift.py
@@ -277,7 +277,7 @@ class SemanticGoalDriftDetector:
             except Exception as exc:
                 logger.warning(
                     "snagline: drift extra unavailable (%s); run "
-                    "`pip install snagline-agent[drift]` for semantic "
+                    "`pip install snagline[drift]` for semantic "
                     "goal-drift",
                     exc,
                 )

--- a/src/snagline/ml/esn_ensemble.py
+++ b/src/snagline/ml/esn_ensemble.py
@@ -1,6 +1,6 @@
 """Optional echo-state-network + CUSUM ensemble detector (the ``ml`` extra).
 
-Part of the optional ``ml`` extra: ``pip install snagline-agent[ml]`` (numpy
+Part of the optional ``ml`` extra: ``pip install snagline[ml]`` (numpy
 and scikit-learn). Core code never imports this module unconditionally:
 ``import snagline`` works with nothing but the standard library, and
 ``Monitor.default()`` only attempts the guarded import when
@@ -47,7 +47,7 @@ try:
 except ImportError as _exc:  # pragma: no cover - exercised via guard tests
     raise ImportError(
         "snagline.ml.esn_ensemble requires the optional 'ml' extra: "
-        "pip install snagline-agent[ml]"
+        "pip install snagline[ml]"
     ) from _exc
 
 from snagline.baseline import BaselineProfile

--- a/src/snagline/sinks/continuum_sink.py
+++ b/src/snagline/sinks/continuum_sink.py
@@ -20,7 +20,7 @@ Risks with no resolvable action key are dropped with a log line rather than
 fabricated onto the ledger: an invented key would either raise inside
 CONTINUUM or, worse, attach SNAGLINE's opinion to the wrong action.
 
-Optional extra ``snagline-agent[continuum]``. The ``continuum`` import is
+Optional extra ``snagline[continuum]``. The ``continuum`` import is
 lazy and guarded: constructing the sink without CONTINUUM installed raises a
 helpful ``ImportError`` naming the extra (host setup error), while runtime
 ``emit()`` failures are caught and logged -- monitoring must never break the
@@ -52,7 +52,7 @@ def _default_ledger_factory(storage: Any, run_id: str) -> Any:
     except ImportError as exc:  # pragma: no cover - exercised via fake factory
         raise ImportError(
             "ContinuumSink needs CONTINUUM's ActionLedger; install the "
-            "'snagline-agent[continuum]' extra or pass ledger_factory="
+            "'snagline[continuum]' extra or pass ledger_factory="
             "for a duck-typed replacement"
         ) from exc
     return ActionLedger(storage, run_id)

--- a/tests/sinks/test_continuum_sink.py
+++ b/tests/sinks/test_continuum_sink.py
@@ -116,7 +116,7 @@ def test_missing_continuum_raises_helpful_importerror(
 ) -> None:
     monkeypatch.setitem(__import__("sys").modules, "continuum", None)
     monkeypatch.setitem(__import__("sys").modules, "continuum.actions", None)
-    with pytest.raises(ImportError, match=r"snagline-agent\[continuum\]"):
+    with pytest.raises(ImportError, match=r"snagline\[continuum\]"):
         ContinuumSink(object(), "run-1")
 
 

--- a/tests/test_baseline.py
+++ b/tests/test_baseline.py
@@ -201,7 +201,7 @@ def test_cli_baseline_semantic_missing_extra_exits_nonzero(
     rc = main(["baseline", str(traj), "--output", str(out), "--semantic"])
     assert rc != 0
     err = capsys.readouterr().err
-    assert "pip install snagline-agent[drift]" in err
+    assert "pip install snagline[drift]" in err
     assert not out.exists()  # never a half-fitted file
 
 
@@ -227,7 +227,7 @@ def test_cli_baseline_semantic_model_load_failure_exits_nonzero(
     rc = main(["baseline", str(traj), "--output", str(out), "--semantic"])
     assert rc != 0
     err = capsys.readouterr().err
-    assert "pip install snagline-agent[drift]" in err
+    assert "pip install snagline[drift]" in err
     assert not out.exists()
 
 

--- a/tests/test_drift_goal_drift.py
+++ b/tests/test_drift_goal_drift.py
@@ -377,7 +377,7 @@ def test_default_loader_missing_extra_is_inert_with_pip_hint(monkeypatch, caplog
         for ev in _healthy(15, episode="q"):
             assert det.observe(ev) is None
     assert any(
-        "snagline-agent[drift]" in r.message
+        "snagline[drift]" in r.message
         for r in caplog.records
         if r.levelno >= logging.WARNING
     )

--- a/tests/test_ml_extra_guard.py
+++ b/tests/test_ml_extra_guard.py
@@ -45,7 +45,7 @@ def test_esn_module_raises_helpful_importerror_without_numpy(monkeypatch):
     try:
         importlib.import_module("snagline.ml.esn_ensemble")
     except ImportError as exc:
-        assert "snagline-agent[ml]" in str(exc)
+        assert "snagline[ml]" in str(exc)
     else:
         raise AssertionError("esn_ensemble imported without numpy")
 


### PR DESCRIPTION
Fixes #104 — lock PyPI name to `snagline`.

**Why snagline-agent → snagline:**
- `snagline-agent` is verbose and the `[continuum]` extra reads like the distribution is `continuum-agent`.
- PyPI check at 2026-08-27: `https://pypi.org/pypi/snagline/json` → 404 (available), `snagline-agent` also 404 but longer. GitHub search `snagline` in:name → 2 repos total, `snagwatch`/`pysnagline` 0 — `snagline` is clean on the complete web and matches `import snagline` exactly. User locked `snagline` as `pip install snagline` → `import snagline`.

**What changed (29 files):**
- `pyproject.toml`: `name = "snagline"`, `all = ["snagline[..."]`, `__init__.py`: `version("snagline")`
- `README.md`, `project.md`, `CHANGELOG.md`, `docs/*`, `examples/*`, `src/snagline/*`, `tests/*`: every `snagline-agent` → `snagline` (preserving `snagline[extra]` bracket form, keeping `continuum-agent` separate where it names the real distribution)

**Verification (at 55152b9):**
- `python -m build` → `snagline-0.1.0-py3-none-any.whl` (was `snagline_agent-...`) + sdist, 61 files
- `twine check dist/*` → PASSED for both
- Fresh venv `pip install dist/snagline-0.1.0-py3-none-any.whl` → `import snagline` ok, `snagline --help` shows `replay,bench,watch,serve,hook,baseline`
- Full gate: 694 passed / 3 skipped, ruff check + format clean, mypy src clean, no em dashes

**After merge:** move tag `v0.1.0` from `bb6ffdc` to new HEAD and publish via `release.yml` (trusted publishing). The rename must land before the real PyPI upload or the name on PyPI would be wrong.

Refs #104
