### PR TITLE
chore: post-0.1.0 housekeeping — add [Unreleased] and bump to 0.1.1.dev0 (Fixes #197)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,10 @@ jobs:
           ver=$(python -c "import re, pathlib; t=pathlib.Path('pyproject.toml').read_text(); m=re.search(r'^version\s*=\s*\"([^\"]+)\"', t, re.M); print(m.group(1) if m else '')")
           echo "pyproject version: $ver"
           if [ -z "$ver" ]; then echo "could not parse version from pyproject.toml"; exit 1; fi
+          if [[ "$ver" == *".dev"* ]]; then
+            echo "dev version $ver, skipping tag check"
+            exit 0
+          fi
           if ! git rev-parse "v$ver" >/dev/null 2>&1; then
             echo "missing tag v$ver for pyproject version $ver"
             echo "create it with: git tag -a v$ver -m \"SNAGLINE $ver -- see CHANGELOG.md\" && git push origin v$ver"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- Nothing yet.
+
+### Fixed
+- Nothing yet.
+
 ## [0.1.0] - 2026-08-27
 
 This is the first tagged release. It comprises 87 merge commits on `origin/master`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "snagline"
-version = "0.1.0"
+version = "0.1.1.dev0"
 description = "Lightweight, dependency-free real-time failure detection for AI agents."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/snagline/__init__.py
+++ b/src/snagline/__init__.py
@@ -31,7 +31,7 @@ try:
 
     __version__ = version("snagline")
 except Exception:
-    __version__ = "0.1.0"
+    __version__ = "0.1.1.dev0"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Fixes #197 — post-0.1.0 housekeeping.

- CHANGELOG.md: add ## [Unreleased] above [0.1.0] per Keep-a-Changelog
- pyproject.toml: version 0.1.0 → 0.1.1.dev0
- src/snagline/__init__.py: fallback 0.1.0 → 0.1.1.dev0
- .github/workflows/ci.yml: version-tag-check now skips when version contains .dev (dev versions have no tag yet)

Gate: 694 passed / 3 skipped, ruff/mypy clean, no em dashes, version-tag-check now passes on master with dev version.

Refs #197, #105


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Updated the project version to 0.1.1.dev0.
  * Development builds can now proceed without requiring a matching release tag.
  * Release builds still validate that the corresponding tag exists.

* **Documentation**
  * Added an Unreleased section to the changelog for upcoming additions and fixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->