### PR TITLE
docs: document time-axis persistence in snapshot/restore (Fixes #205)

### DIFF
--- a/docs/DETECTOR_GUIDE.md
+++ b/docs/DETECTOR_GUIDE.md
@@ -405,7 +405,7 @@ cannot.
 
 Detectors that implement the duck-typed `dump_state()` / `load_state(state)`
 pair (`detectors.base.StatefulDetector`; JSON-compatible data only, never
-pickle) participate in `Monitor.snapshot(path)` / `Monitor.restore(path)`.
+pickle) participate in `Monitor.snapshot(path)` / `Monitor.restore(path)`, and Monitor-level time-axis clocks (`_EpisodeClock` per episode_id) are captured alongside them under `"time_axis"` and restored tolerantly (issue #172).
 Snapshots are written atomically (tmp + `os.replace`). Restore is a
 setup-time operation: a version or strict-composition mismatch raises rather
 than failing open -- a monitor that silently starts blank is exactly the quiet

--- a/project.md
+++ b/project.md
@@ -411,8 +411,11 @@ class Monitor:
 
 **Snapshot / restore (issue #91).** `Monitor.snapshot(path)` writes a
 versioned JSON payload: snapshot-format constant, per-detector
-`dump_state()` output for every `StatefulDetector`, and `DedupSink`
-cooldowns under its default key function. Writes are atomic (tmp file +
+`dump_state()` output for every `StatefulDetector`, `DedupSink`
+cooldowns under its default key function, and time-axis clocks
+under `"time_axis"` keyed by episode_id and bounded by the same
+`max_live_episodes` LRU (issue #172). All are restored tolerantly
+so new snapshots remain loadable by older code without a format-version bump. Writes are atomic (tmp file +
 `os.replace`). `Monitor.restore(path)` is a setup-time operation with the
 one deliberate exception to fail-open: a version or strict-composition
 mismatch raises, because a monitor that silently starts blank is exactly


### PR DESCRIPTION
Fixes #205 — follow-up to #172 (time-axis persistence).

project.md §4.6 previously listed only per-detector dump_state and DedupSink cooldowns. Now that Monitor._clocks (per-episode time-axis) are persisted via snapshot/restore (PR #200), docs must say so.

- project.md: snapshot payload now includes time-axis clocks under "time_axis", keyed by episode_id, bounded by same max_live_episodes LRU, restored tolerantly without format_version bump
- DETECTOR_GUIDE.md: note Monitor-level clocks participate alongside StatefulDetector snapshots

Gate: docs-only, ruff/mypy clean, no em dashes, existing snapshot tests still green.

Fixes #205
