### PR TITLE
fix(detectors): restore the effective stagnation window, not the base (Fixes #218)

### DIFF
--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -181,25 +181,36 @@ class StagnationDetector:
 
     def load_state(self, state: dict[str, Any]) -> None:
         self._windows = {}
+        # Read the scaler positions first: they decide how large the restored
+        # window is allowed to be when auto-scaling is on (issue #92).
+        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
         for ep, raw in state.get("windows", {}).items():
             w = _EpisodeWindow()
-            # Clamp to the CURRENT window_size: restore is tolerant by default
-            # (matches by name, ignores config), so a snapshot taken with a
-            # larger window must not leave an overlong deque whose equality-
-            # based eviction never fires again. Mirrors LoopDetector's
-            # deque(sigs, maxlen=self.window_size) rebuild; the sliding
-            # counter is recomputed from the truncated flags so the two stay
-            # consistent. With auto-scaling enabled (issue #92) the deque is
-            # deliberately UNCAPPED: observe() trims at the current effective
-            # target every step, and a base-sized maxlen would silently drop
-            # flags and blind the detector once the target grows past it.
-            flags = [bool(b) for b in raw.get("flags", [])][-self.window_size :]
+            # Clamp to the window this detector will actually evaluate against:
+            # restore is tolerant by default (matches by name, ignores config),
+            # so a snapshot taken with a larger window must not leave an
+            # overlong deque whose eviction never fires again (issue #149). With
+            # auto-scaling that bound is the *effective* target for the restored
+            # scaler position, not the base -- clamping to the base would drop
+            # the very flags the snapshot carries and blind observe(), whose
+            # every check is gated on ``len(flags) >= target``, for
+            # ``target - window_size`` steps. The deque itself stays UNCAPPED
+            # under scaling: observe() trims at the live target every step, and
+            # a fixed maxlen would blind it again once the target grows past it.
+            target = effective_window_size(
+                self.window_size,
+                self._counts.get(str(ep), 0),
+                self._scale_steps,
+                self._max_window,
+            )
+            flags = [bool(b) for b in raw.get("flags", [])][-target:]
             w.flags = deque(
                 flags,
                 maxlen=self.window_size if self._scale_steps <= 0 else None,
             )
+            # The sliding counter is recomputed from the kept flags so the two
+            # stay consistent.
             w.novel_in_window = sum(flags)
             w.stale_windows = int(raw.get("stale_windows", 0))
             w.seen_all_time = set(raw.get("seen_all_time", []))
             self._windows[str(ep)] = w
-        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}

--- a/tests/test_detector_snapshots.py
+++ b/tests/test_detector_snapshots.py
@@ -14,9 +14,11 @@ from __future__ import annotations
 
 import json
 
+from snagline.config import Config
 from snagline.detectors.compaction_tripwire import CompactionTripwireDetector
 from snagline.detectors.side_effect_guard import SideEffectGuardDetector
 from snagline.detectors.stagnation import StagnationDetector
+from snagline.detectors.windowing import effective_window_size
 from snagline.events import StepEvent
 from snagline.monitor import Monitor
 
@@ -169,6 +171,54 @@ def test_stagnation_restore_clamps_flags_to_current_window_size():
     for i in range(10):
         d_small.observe(_ev(100 + i, signature="stale"))
     assert len(d_small._windows["ep"].flags) == 4
+
+
+def test_stagnation_restore_keeps_the_scaled_window_and_still_fires_on_time():
+    """Issue #218: with auto-scaling on (#92) the clamp must use the *effective*
+    window for the restored scaler position, not the base. Clamping to the base
+    dropped flags observe() had already accumulated, and since every check there
+    is gated on ``len(flags) >= target`` the detector went blind for
+    ``target - window_size`` steps -- long enough to miss a collapse outright."""
+    cfg = Config(stagnation_enabled=True, window_scale_steps=10, max_window=512)
+    base = 4
+
+    def fresh() -> StagnationDetector:
+        return StagnationDetector(
+            window_size=base, min_novelty=0.25, patience=1, config=cfg
+        )
+
+    # 24 distinct actions grow the window past the base, then the agent stalls.
+    warmup = [_ev(i, signature=f"u{i}") for i in range(24)]
+    stall = _repeats(24, 40)
+
+    live = fresh()
+    assert _risks(live, warmup) == [], "novel work must stay quiet"
+    dumped = json.loads(json.dumps(live.dump_state()))
+    live_flags = len(live._windows["ep"].flags)
+    assert live_flags > base, "window scaled past its base"
+    assert dumped["counts"]["ep"] == len(warmup)
+
+    restored = fresh()
+    restored.load_state(dumped)
+    w = restored._windows["ep"]
+    assert len(w.flags) == live_flags, (
+        "restore must keep the scaled window, not clamp it to the base"
+    )
+    assert w.novel_in_window == sum(w.flags), "counter must match kept flags"
+
+    # Behavioral consequence: the restarted detector reports the collapse on the
+    # same step as the one that never restarted.
+    live_fires = [r.step_id for r in _risks(live, stall)]
+    assert live_fires, "the uninterrupted detector must report the collapse"
+    assert [r.step_id for r in _risks(restored, stall)] == live_fires
+
+    # Still bounded afterwards: the window tracks the live effective target.
+    for i in range(60):
+        restored.observe(_ev(200 + i, signature="stale"))
+    n = len(warmup) + len(stall) + 60
+    assert len(restored._windows["ep"].flags) == effective_window_size(
+        base, n, cfg.window_scale_steps, cfg.max_window
+    )
 
 
 def test_stagnation_recovery_rearms_after_restore():


### PR DESCRIPTION
Fixes #218

Summary of Changes

`StagnationDetector.load_state` clamped the restored novelty flags to the *base*
`stagnation_window_size`:

```python
flags = [bool(b) for b in raw.get("flags", [])][-self.window_size :]
w.flags = deque(flags, maxlen=self.window_size if self._scale_steps <= 0 else None)
```

The `maxlen` on the second line is already conditional, and its comment says why —
with auto-scaling on (#92) "a base-sized maxlen would silently drop flags and blind
the detector once the target grows past it". The base-sized *slice* one line above
dropped exactly those flags anyway, so the deliberately uncapped deque was only ever
handed `window_size` of them.

`observe()` gates every evaluation on `len(w.flags) >= target`, so a restored episode
whose window had scaled could not reach its fire condition until the window refilled:
`target - window_size` steps of silence after each restore.

- `src/snagline/detectors/stagnation.py`: read `state["counts"]` before rebuilding the
  windows, then clamp each restored flag list to `effective_window_size()` for that
  episode's restored scaler position instead of to the base.
- `src/snagline/detectors/stagnation.py`: comment rewritten to say what the clamp is
  for (#149 bounds the deque) and why the bound is the effective target, not the base.
- `tests/test_detector_snapshots.py`: add
  `test_stagnation_restore_keeps_the_scaled_window_and_still_fires_on_time`.

The deque stays uncapped under scaling, exactly as before: `observe()` trims at the
live target every step, and the restored length can never exceed it, since
`effective_window_size` is monotonically non-decreasing in `episode_len`.

Justification

Snapshot/restore across a process restart is the #91 contract, and window scaling is
the knob for long-horizon episodes (#92) — the same runs most likely to snapshot in
the first place. Under that configuration a restart silently degraded detection: with
`window_scale_steps=1000`, a 2660-step episode whose window had scaled to 150 flags
came back from its own snapshot holding 50, and the collapse an uninterrupted monitor
reported at step 2643 was never reported at all, because the 60 steps left in the
episode were fewer than the 100 needed to refill the window.

Moving the restart point shows the gap is deterministic, not a timing artifact
(episode extended to 2900 steps so the fire still lands):

| restart at | no restart | with restart | delay |
|--:|:--|:--|--:|
| 2560 | 2643 | 2660 | 100 |
| 2600 | 2643 | 2700 | 100 |
| 2620 | 2643 | 2720 | 100 |
| 2640 | 2643 | 2740 | 100 |

`target - window_size == 150 - 50 == 100` in every case.

Scaling off (`window_scale_steps == 0`, the default) is unaffected: the effective
window is always the base, so the slice is a no-op and the #149 clamp behaves exactly
as it did. Pre-#92 snapshots that carry no `counts` also still clamp to the base.

Kind of Contribution

Bug Fix

Benchmark (for Performance Improvements)

Not a performance change — `load_state` is off the `ingest()` hot path and the
per-step work in `observe()` is untouched. The accuracy corpus is byte-identical
before and after: `benchmarks/detection_accuracy.py --format json` diffs clean
between `master` and this branch (macro-F1 0.951, 0 healthy controls fired).

Unit Tests:

Added `test_stagnation_restore_keeps_the_scaled_window_and_still_fires_on_time` in
`tests/test_detector_snapshots.py`. It asserts both halves of the contract: the
restored window keeps its scaled length with `novel_in_window` consistent with the
kept flags, and the restarted detector reports the collapse on the *same* step as a
detector that never restarted. It then runs 60 more steps to prove the window is
still bounded by the live `effective_window_size()` afterwards, so the #149 guarantee
is not traded away. The test fails on `master` and passes on this branch.

The existing `test_stagnation_restore_clamps_flags_to_current_window_size` covers this
code path but builds the detector with explicit kwargs and no `Config`, so
`_scale_steps == 0` and the scaled case was never exercised; `tests/test_window_scaling.py`
exercises scaling but never snapshots. Both still pass unchanged.

Execution Tests:

Reproduced end to end with the standalone script in #218 — a 2660-step episode
snapshotted at step 2600, restored into a fresh `StagnationDetector`, and replayed:

```
# before
no restart:   [2643]
with restart:
  restart: novelty flags 150 -> 50
  fired:      []

# after
no restart:   [2643]
with restart:
  restart: novelty flags 150 -> 150
  fired:      [2643]
```

Local validation, Windows 11 / CPython 3.13.1, venv built exactly as `ci.yml` does
(`pip install -e . --no-deps`, `langchain-core`, `pytest`, `pytest-cov==7.1.0`,
`ruff==0.16.3`, `mypy`):

| command | result |
|:--|:--|
| `python -m pytest tests/test_detector_snapshots.py::test_stagnation_restore_keeps_the_scaled_window_and_still_fires_on_time -q` (on `master`) | 1 failed — the regression is real |
| `python -m pytest tests/test_detector_snapshots.py -q` | 12 passed |
| `python -m pytest tests/ -q --cov-fail-under=0` | 697 passed, 2 skipped, 1 failed |
| `ruff check src tests` | All checks passed |
| `ruff format --check src tests` | 129 files already formatted |
| `mypy src tests` | 1 error, pre-existing and Windows-only |
| `python benchmarks/detection_accuracy.py --fixtures benchmarks/fixtures --format table` | exit 0, 0 healthy controls fired |

Limitations / notes on the two red lines above, both pre-existing and unrelated:

- The suite failure is `tests/test_hook_bridge.py::test_watch_follow_teardown_reaps_the_child_on_a_healthy_run`, i.e. #215. It reproduces identically on unmodified `master` here (1 failed, 696 passed) and passes in isolation on both, which is the ~75%-of-runs flake documented in that issue. #216 is the fix.
- The mypy error is `tests/test_hook_bridge.py:527: Module has no attribute "SIGKILL"` — `signal.SIGKILL` does not exist on Windows. CI runs mypy on Linux only, where it does.

Neither touches `src/snagline/detectors/`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of detector state when automatic window scaling is enabled.
  * Preserved effective window sizes, novelty tracking, and stagnation detection behavior after state reloads.
  * Ensured restored monitoring windows remain properly bounded as new data is processed.

* **Tests**
  * Added regression coverage for saving and restoring scaled detector state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->