### PR TITLE
fix(detectors): isolate base-detector faults in MLOrchestrator (Fixes #227)

### DIFF
--- a/src/snagline/detectors/ml_ensemble.py
+++ b/src/snagline/detectors/ml_ensemble.py
@@ -14,16 +14,26 @@ upgrade path; it is never imported here, so the zero-dep default holds.
 When ``Config.ml_ensemble_enabled`` is set, ``Monitor.default()`` wraps the
 base detectors in a single ``MLOrchestrator`` instead of exposing them
 individually, so there is no double counting.
+
+Fail-open isolation is this class's own responsibility. ``Monitor.ingest``
+guards every detector slot individually, but wrapping the base detectors
+collapses them into one slot, so the Monitor's guard has nothing left to
+isolate: without the per-base guards below, one raising detector would block
+all the others and the Monitor would swallow the evidence. Every delegation
+loop here therefore logs the fault once and moves on to the next detector.
 """
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Sequence
 from typing import Any
 
 from snagline.config import Config
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
+
+logger = logging.getLogger("snagline")
 
 
 class MLOrchestrator:
@@ -38,11 +48,33 @@ class MLOrchestrator:
         self._base = list(detectors)
         self._cfg = config or Config()
         self._model = model
+        # A faulty base detector must not spam the logs on every step; mirror
+        # Monitor._log_fault_once and report each distinct fault exactly once.
+        self._fault_logged: set[str] = set()
+
+    @staticmethod
+    def _base_name(det: Any) -> str:
+        return str(getattr(det, "name", type(det).__name__))
+
+    def _log_fault_once(self, det: Any, phase: str) -> None:
+        key = f"{self._base_name(det)}:{phase}"
+        if key in self._fault_logged:
+            return
+        self._fault_logged.add(key)
+        logger.warning(
+            "snagline: ml_ensemble base detector %s %s raised; ignoring (fail-open)",
+            self._base_name(det),
+            phase,
+        )
 
     def observe(self, event: StepEvent) -> FailureRisk | None:
         scores: list[float] = []
         for det in self._base:
-            risk = det.observe(event)
+            try:
+                risk = det.observe(event)
+            except Exception:
+                self._log_fault_once(det, "observe")
+                continue
             if risk is not None and 0.0 < risk.score <= 1.0:
                 scores.append(risk.score)
         if not scores:
@@ -73,7 +105,16 @@ class MLOrchestrator:
 
     def reset(self, episode_id: str) -> None:
         for det in self._base:
-            det.reset(episode_id)
+            reset = getattr(det, "reset", None)
+            if not callable(reset):
+                continue
+            try:
+                reset(episode_id)
+            except Exception:
+                # A leaked reset strands that episode's state forever and
+                # defeats the retention cap (issue #184); it must never also
+                # strand every sibling's state.
+                self._log_fault_once(det, "reset")
 
     def finalize(self, episode_id: str) -> FailureRisk | None:
         # Passthrough for EpisodeFinalizer bases (issue #86): Monitor.end_episode
@@ -83,7 +124,11 @@ class MLOrchestrator:
         for det in self._base:
             finalize = getattr(det, "finalize", None)
             if callable(finalize):
-                risk = finalize(episode_id)
+                try:
+                    risk = finalize(episode_id)
+                except Exception:
+                    self._log_fault_once(det, "finalize")
+                    continue
                 if risk is not None:
                     return risk
         return None
@@ -93,9 +138,17 @@ class MLOrchestrator:
         merged: dict[str, Any] = {}
         for det in self._base:
             dump = getattr(det, "dump_state", None)
-            state = dump() if callable(dump) else None
+            if not callable(dump):
+                continue
+            try:
+                state = dump()
+            except Exception:
+                # Losing one base detector's state is recoverable (it restarts
+                # cold); losing the whole snapshot is not.
+                self._log_fault_once(det, "dump_state")
+                continue
             if state is not None:
-                merged[getattr(det, "name", type(det).__name__)] = state
+                merged[self._base_name(det)] = state
         return merged or None
 
     def load_state(self, state: dict[str, Any]) -> None:
@@ -103,6 +156,11 @@ class MLOrchestrator:
             load = getattr(det, "load_state", None)
             if not callable(load):
                 continue
-            sub = state.get(getattr(det, "name", type(det).__name__))
+            sub = state.get(self._base_name(det))
             if sub is not None:
-                load(sub)
+                try:
+                    load(sub)
+                except Exception:
+                    # Skipping one entry leaves that detector cold rather than
+                    # leaving every later sibling silently unrestored.
+                    self._log_fault_once(det, "load_state")

--- a/tests/test_ml_ensemble_fail_open.py
+++ b/tests/test_ml_ensemble_fail_open.py
@@ -1,0 +1,220 @@
+"""Regression tests for issue #227: MLOrchestrator must isolate base detectors.
+
+``Monitor.ingest`` guards every detector slot individually, but enabling
+``ml_ensemble`` collapses the base detectors into a single slot, so the
+Monitor's guard has nothing left to isolate. The orchestrator itself must
+therefore honor the README's "one bad detector doesn't block others"
+guarantee on every path it delegates: observe, reset, finalize, dump_state
+and load_state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from snagline.config import Config
+from snagline.detectors.ml_ensemble import MLOrchestrator
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+from snagline.risk import FailureRisk
+
+
+class _Boom:
+    """A base detector that raises on every delegated call."""
+
+    name = "boom"
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        raise RuntimeError("observe exploded")
+
+    def reset(self, episode_id: str) -> None:
+        raise RuntimeError("reset exploded")
+
+    def finalize(self, episode_id: str) -> FailureRisk | None:
+        raise RuntimeError("finalize exploded")
+
+    def dump_state(self) -> dict[str, Any]:
+        raise RuntimeError("dump_state exploded")
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        raise RuntimeError("load_state exploded")
+
+
+class _Healthy:
+    """A base detector that records every delegated call it receives."""
+
+    name = "healthy"
+
+    def __init__(self, score: float = 0.9) -> None:
+        self._score = score
+        self.seen = 0
+        self.resets = 0
+        self.finalized = 0
+        self.loaded: dict[str, Any] | None = None
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        self.seen += 1
+        return FailureRisk(
+            event.episode_id,
+            event.step_id,
+            self._score,
+            "healthy",  # type: ignore[arg-type]
+            "healthy",
+            event.timestamp,
+        )
+
+    def reset(self, episode_id: str) -> None:
+        self.resets += 1
+
+    def finalize(self, episode_id: str) -> FailureRisk | None:
+        self.finalized += 1
+        return FailureRisk(
+            episode_id,
+            "final",
+            self._score,
+            "healthy",  # type: ignore[arg-type]
+            "finalized",
+            0.0,
+        )
+
+    def dump_state(self) -> dict[str, Any]:
+        return {"seen": self.seen}
+
+    def load_state(self, state: dict[str, Any]) -> None:
+        self.loaded = state
+
+
+class _NoReset:
+    """A minimal base detector exposing only ``observe``."""
+
+    name = "no_reset"
+
+    def observe(self, event: StepEvent) -> FailureRisk | None:
+        return None
+
+
+def _cfg() -> Config:
+    return Config(ml_ensemble_enabled=True, ml_ensemble_score_threshold=0.5)
+
+
+def _ev(step: str = "0", episode: str = "ep") -> StepEvent:
+    return StepEvent(
+        step_id=step,
+        episode_id=episode,
+        timestamp=1.0,
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", "t", step),
+        tool_name="t",
+        latency_ms=10.0,
+    )
+
+
+def test_observe_isolates_a_raising_base_detector() -> None:
+    healthy = _Healthy()
+    orch = MLOrchestrator([_Boom(), healthy], config=_cfg())
+
+    risk = orch.observe(_ev())
+
+    assert healthy.seen == 1, "healthy base detector never saw the step"
+    assert risk is not None
+    assert risk.trigger == "ml_ensemble"
+
+
+def test_observe_isolation_holds_for_every_base_position() -> None:
+    """A raiser last must not swallow the risk a raiser first would."""
+    for base in ([_Boom(), _Healthy()], [_Healthy(), _Boom()]):
+        orch = MLOrchestrator(base, config=_cfg())
+        assert orch.observe(_ev()) is not None
+
+
+class _RecordingSink:
+    """Captures every risk the Monitor dispatches."""
+
+    def __init__(self) -> None:
+        self.received: list[FailureRisk] = []
+
+    def emit(self, risk: FailureRisk) -> None:
+        self.received.append(risk)
+
+
+def test_monitor_still_emits_when_one_base_detector_raises() -> None:
+    sink = _RecordingSink()
+    monitor = Monitor([MLOrchestrator([_Boom(), _Healthy()], config=_cfg())], [sink])
+
+    monitor.ingest(_ev())
+
+    assert len(sink.received) == 1, "the ensemble went silent instead of degrading"
+    assert sink.received[0].trigger == "ml_ensemble"
+
+
+def test_a_faulty_base_detector_is_logged_once_not_per_step(caplog) -> None:
+    orch = MLOrchestrator([_Boom(), _Healthy()], config=_cfg())
+    with caplog.at_level("WARNING", logger="snagline"):
+        for i in range(25):
+            orch.observe(_ev(str(i)))
+    faults = [r for r in caplog.records if "boom observe raised" in r.getMessage()]
+    assert len(faults) == 1
+
+
+def test_reset_isolates_so_sibling_episode_state_is_still_freed() -> None:
+    healthy = _Healthy()
+    orch = MLOrchestrator([_Boom(), healthy], config=_cfg())
+
+    orch.reset("ep")
+
+    assert healthy.resets == 1, "sibling state leaked past a failed reset"
+
+
+def test_reset_skips_a_base_detector_without_reset() -> None:
+    healthy = _Healthy()
+    orch = MLOrchestrator([_NoReset(), healthy], config=_cfg())
+
+    orch.reset("ep")  # must not raise AttributeError
+
+    assert healthy.resets == 1
+
+
+def test_finalize_isolates_so_later_completion_checks_still_run() -> None:
+    healthy = _Healthy()
+    orch = MLOrchestrator([_Boom(), healthy], config=_cfg())
+
+    risk = orch.finalize("ep")
+
+    assert healthy.finalized == 1
+    assert risk is not None and risk.detail == "finalized"
+
+
+def test_dump_state_isolates_so_the_snapshot_still_carries_siblings() -> None:
+    healthy = _Healthy()
+    healthy.seen = 7
+    orch = MLOrchestrator([_Boom(), healthy], config=_cfg())
+
+    dumped = orch.dump_state()
+
+    assert dumped == {"healthy": {"seen": 7}}
+
+
+def test_load_state_isolates_so_siblings_are_still_restored() -> None:
+    healthy = _Healthy()
+    orch = MLOrchestrator([_Boom(), healthy], config=_cfg())
+
+    orch.load_state({"boom": {"x": 1}, "healthy": {"seen": 42}})
+
+    assert healthy.loaded == {"seen": 42}
+
+
+def test_monitor_snapshot_round_trip_survives_a_faulty_base_detector(
+    tmp_path,
+) -> None:
+    healthy = _Healthy()
+    healthy.seen = 3
+    monitor = Monitor([MLOrchestrator([_Boom(), healthy], config=_cfg())], [])
+    path = str(tmp_path / "snap.json")
+
+    monitor.snapshot(path)
+
+    target = _Healthy()
+    restored = Monitor([MLOrchestrator([_Boom(), target], config=_cfg())], [])
+    restored.restore(path)
+
+    assert target.loaded == {"seen": 3}


### PR DESCRIPTION
Fixes #227

## Problem

`MLOrchestrator` is the only detector that owns other detectors, and all five of its delegation loops called straight into each base detector with no guard. The first base detector to raise aborted the loop and every remaining one was skipped.

`Monitor.ingest` guards every detector slot individually, so this is invisible with the default composition. But `Config.ml_ensemble_enabled=True` makes `Monitor.default()` collapse every base detector into a single `MLOrchestrator` slot (`monitor.py:1024`), and the Monitor's per-detector guard then has nothing left to isolate: one bad base detector blocks all the others, and the Monitor's fail-open swallows the evidence. That breaks the guarantee stated at README.md:359 — "One bad detector doesn't block others."

The most visible consequence is a total, silent detection blackout: one consistently raising base detector reduces the ensemble to `None` on every step, and because the Monitor deduplicates its fault log (issue #14) the operator sees one line and then permanent silence.

## Fix

Wrap each per-base call the way `Monitor.ingest` already does — log the fault once, continue to the next detector — with a per-`(detector, phase)` fault-once set mirroring the issue #14 discipline so a persistent fault cannot spam the log on every step.

| path | before | after |
| --- | --- | --- |
| `observe` | raiser blanks the ensemble for the step | remaining detectors still score; noisy-OR runs on what survived |
| `reset` | siblings keep episode state forever, defeating the #184 cap | sibling state is still freed |
| `finalize` | a raiser ordered before `SilentAbortDetector` means `silent_abort` never fires | later completion checks still run |
| `dump_state` | one base detector aborts the whole `Monitor.snapshot()` | that detector's slot is dropped, the rest is written |
| `load_state` | siblings after the raiser silently stay unrestored | each entry is applied independently |

`reset` also now probes with `getattr` like the other loops, so a base detector that omits `reset` is skipped instead of raising `AttributeError`.

No behavior change on the healthy path: with no base detector raising, every loop does exactly what it did before.

## Tests

New `tests/test_ml_ensemble_fail_open.py`, 10 cases: isolation on all five paths, isolation regardless of the raiser's position in the base list, the end-to-end `Monitor.ingest` case (the ensemble degrades instead of going silent), fault-once log discipline over 25 steps, the `getattr` probe for a base detector without `reset`, and a `Monitor.snapshot()` → `restore()` round trip through a faulty base detector.

All 10 fail on `master` and pass with the fix.

## Verification

```
707 passed, 2 skipped          (baseline on this branch point: 697 passed, 2 skipped)
Total coverage: 87.95%         (gate: 80%)
ruff check src tests           All checks passed!
ruff format --check src tests  130 files already formatted
mypy src                       Success: no issues found in 55 source files
```
