### PR TITLE
fix(core): lock the cross-episode dicts that snapshot and teardown walk (Fixes #228, #229)

### DIFF
--- a/src/snagline/detectors/latency_anomaly.py
+++ b/src/snagline/detectors/latency_anomaly.py
@@ -32,6 +32,7 @@ knobs: k/h stay as configured.
 from __future__ import annotations
 
 import math
+import threading
 from typing import Any
 
 from snagline.baseline import BaselineProfile, ToolBaseline
@@ -178,6 +179,16 @@ class LatencyAnomalyDetector:
         # per-tool stats only; no content is retained or consulted.
         self._baseline = baseline
         self._states: dict[tuple[str, str], _WelfordCUSUM] = {}
+        # ``_states`` is keyed by (episode_id, tool_name), so unlike every
+        # other detector it is not partitioned by episode: the Monitor's
+        # per-episode lock cannot keep reset()/dump_state() from walking the
+        # dict while an ingest for a *different* episode meets a new tool and
+        # inserts into it (issue #229). This lock guards only the operations
+        # that change or walk the key set -- first-sight insert, reset,
+        # dump_state, load_state -- so the per-step ``state.update(...)``,
+        # which mutates an existing _WelfordCUSUM and adds no key, stays
+        # lock-free and O(1) amortized per event.
+        self._states_lock = threading.Lock()
         # Periodic baseline re-fit (issue #92); 0 disables (the default).
         self.refit_every = cfg.cusum_refit_every
 
@@ -208,7 +219,11 @@ class LatencyAnomalyDetector:
                     seeded = candidate
             if seeded is not None:
                 state.seed(seeded.mean_latency, seeded.std_latency)
-            self._states[key] = state
+            # Only the key-set mutation needs the lock (issue #229); building
+            # the state above is pure. A concurrent first-sight of the same key
+            # would otherwise be lost, so keep whichever entry landed first.
+            with self._states_lock:
+                state = self._states.setdefault(key, state)
 
         if not state.frozen:
             state.learn_only(event.latency_ms)
@@ -291,8 +306,9 @@ class LatencyAnomalyDetector:
         return False, 0.0, 0.0
 
     def reset(self, episode_id: str) -> None:
-        for key in [k for k in self._states if k[0] == episode_id]:
-            self._states.pop(key, None)
+        with self._states_lock:
+            for key in [k for k in self._states if k[0] == episode_id]:
+                self._states.pop(key, None)
 
     @staticmethod
     def _state_to_dict(s: _WelfordCUSUM) -> dict[str, Any]:
@@ -340,15 +356,14 @@ class LatencyAnomalyDetector:
     def dump_state(self) -> dict[str, Any]:
         # Keys are (episode_id, tool_name) tuples; JSON dict keys must be
         # strings, so serialize as [key-pair, state] entries.
+        with self._states_lock:
+            items = sorted(self._states.items())
         return {
-            "states": [
-                [[ep, tool], self._state_to_dict(s)]
-                for (ep, tool), s in sorted(self._states.items())
-            ]
+            "states": [[[ep, tool], self._state_to_dict(s)] for (ep, tool), s in items]
         }
 
     def load_state(self, state: dict[str, Any]) -> None:
-        self._states = {}
+        restored: dict[tuple[str, str], _WelfordCUSUM] = {}
         for key_pair, raw in state.get("states", []):
             ep, tool = key_pair[0], key_pair[1]
             s = _WelfordCUSUM(
@@ -358,4 +373,6 @@ class LatencyAnomalyDetector:
             # The live config owns the refit cadence; the snapshot only
             # carries accumulated bookkeeping.
             s.refit_every = self.refit_every
-            self._states[(ep, tool)] = s
+            restored[(ep, tool)] = s
+        with self._states_lock:
+            self._states = restored

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -215,6 +215,16 @@ class Monitor:
         self._warn_fraction = cfg.warn_fraction
         self._idle_warn_seconds = cfg.idle_warn_seconds
         self._clocks: dict[str, _EpisodeClock] = {}
+        # ``_clocks`` spans every episode, so the per-episode lock cannot
+        # protect its key set: an ingest for episode A inserting a clock races
+        # a teardown or a snapshot walking the dict for anything else. This
+        # lock covers the dict-level operations only (get / insert / pop /
+        # iterate); the fields *inside* an _EpisodeClock stay under the
+        # per-episode lock, so the hot path takes this lock once per episode
+        # first-sight and once per teardown, never per step. It is a leaf lock
+        # -- nothing is ever acquired while holding it -- so no ordering
+        # hazard exists against _live_lock or the episode locks.
+        self._clocks_lock = threading.Lock()
         # Per-episode retention cap (issue #184): bounded LRU of live episode
         # ids. Every ingest touches the entry; when the cap is exceeded the
         # least-recently-seen id is evicted silently (no finalize risks) via
@@ -345,7 +355,9 @@ class Monitor:
         with self._state.episode_lock(event.episode_id):
             # Time-axis head (issue #92): computed from StepEvent timestamps at
             # the top of ingest(), under the episode lock so concurrent ingests
-            # serialize exactly like detector state does.
+            # for the same episode serialize exactly like detector state does.
+            # The episode lock says nothing about the cross-episode ``_clocks``
+            # dict, which carries its own lock (issue #228).
             risks.extend(self._advance_clock(event))
             for detector in self._detectors:
                 try:
@@ -390,11 +402,15 @@ class Monitor:
         if self._max_wall_seconds is None and self._idle_warn_seconds is None:
             return out
         try:
-            clock = self._clocks.get(event.episode_id)
+            # Dict-level access only under _clocks_lock; the returned clock's
+            # fields are mutated below under the caller's per-episode lock.
+            with self._clocks_lock:
+                clock = self._clocks.get(event.episode_id)
+                if clock is None:
+                    # First event of the episode establishes the reference
+                    # point; there is no delta yet, so nothing can fire.
+                    self._clocks[event.episode_id] = _EpisodeClock(event.timestamp)
             if clock is None:
-                # First event of the episode establishes the reference point;
-                # there is no delta yet, so nothing can fire.
-                self._clocks[event.episode_id] = _EpisodeClock(event.timestamp)
                 return out
             delta = event.timestamp - clock.last_ts
             clock.last_ts = event.timestamp
@@ -639,7 +655,8 @@ class Monitor:
                 return
         try:
             with self._state.episode_lock(episode_id):
-                self._clocks.pop(episode_id, None)
+                with self._clocks_lock:
+                    self._clocks.pop(episode_id, None)
                 for detector in self._detectors:
                     try:
                         detector.reset(episode_id)
@@ -685,7 +702,8 @@ class Monitor:
         with self._state.episode_lock(episode_id):
             # Time-axis state (issue #92) is per-episode like detector state;
             # drop it here so a reused episode id starts with a clean clock.
-            self._clocks.pop(episode_id, None)
+            with self._clocks_lock:
+                self._clocks.pop(episode_id, None)
             for detector in self._detectors:
                 finalize = getattr(detector, "finalize", None)
                 if callable(finalize):
@@ -750,7 +768,14 @@ class Monitor:
             dump = getattr(sink, "dump_state", None)
             sinks[f"{i}:{type(sink).__name__}"] = dump() if callable(dump) else None
         time_axis: dict[str, Any] = {}
-        for episode_id, clock in self._clocks.items():
+        # Copy the (episode_id, clock) pairs under the lock: iterating _clocks
+        # directly would raise RuntimeError as soon as a concurrent ingest
+        # meets a new episode (issue #228). Building the payload afterwards is
+        # safe -- each clock object is only mutated under its episode lock, and
+        # a snapshot is a point-in-time read either way.
+        with self._clocks_lock:
+            clocks = list(self._clocks.items())
+        for episode_id, clock in clocks:
             time_axis[episode_id] = {
                 "last_ts": clock.last_ts,
                 "elapsed": clock.elapsed,
@@ -886,8 +911,10 @@ class Monitor:
                         self._live_episodes[episode_id] = None
                         if len(self._live_episodes) > self._max_live_episodes:
                             evicted, _ = self._live_episodes.popitem(last=False)
-                            self._clocks.pop(evicted, None)
-                    self._clocks[episode_id] = clock
+                            with self._clocks_lock:
+                                self._clocks.pop(evicted, None)
+                    with self._clocks_lock:
+                        self._clocks[episode_id] = clock
             # If we evicted due to cap, live_snapshot entries not in time_axis
             # are already accounted for; no further action needed.
 

--- a/tests/test_shared_state_concurrency.py
+++ b/tests/test_shared_state_concurrency.py
@@ -87,7 +87,8 @@ class _Worker:
 
 def test_snapshot_dict_survives_concurrent_ingest_of_new_episodes() -> None:
     monitor = Monitor(detectors=[], sinks=[], config=_HORIZON)
-    stop, errors = threading.Event(), []
+    stop = threading.Event()
+    errors: list[BaseException] = []
 
     class Ingest(_Worker):
         def __init__(self, tag: str) -> None:
@@ -109,7 +110,8 @@ def test_snapshot_dict_survives_concurrent_ingest_of_new_episodes() -> None:
 def test_snapshot_dict_survives_concurrent_end_episode() -> None:
     """Teardown pops from _clocks; the snapshot walk must tolerate that too."""
     monitor = Monitor(detectors=[], sinks=[], config=_HORIZON)
-    stop, errors = threading.Event(), []
+    stop = threading.Event()
+    errors: list[BaseException] = []
 
     class Churn(_Worker):
         def __init__(self, tag: str) -> None:
@@ -177,7 +179,8 @@ def test_time_axis_round_trip_still_restores(tmp_path) -> None:
 
 def test_reset_survives_concurrent_observe_of_other_episodes() -> None:
     detector = LatencyAnomalyDetector()
-    stop, errors = threading.Event(), []
+    stop = threading.Event()
+    errors: list[BaseException] = []
 
     class Observe(_Worker):
         def __init__(self, tag: str) -> None:
@@ -202,7 +205,8 @@ def test_reset_survives_concurrent_observe_of_other_episodes() -> None:
 
 def test_dump_state_survives_concurrent_observe() -> None:
     detector = LatencyAnomalyDetector()
-    stop, errors = threading.Event(), []
+    stop = threading.Event()
+    errors: list[BaseException] = []
 
     class Observe(_Worker):
         def __init__(self, tag: str) -> None:

--- a/tests/test_shared_state_concurrency.py
+++ b/tests/test_shared_state_concurrency.py
@@ -1,0 +1,254 @@
+"""Concurrency regressions for cross-episode shared state (#228, #229).
+
+Two dicts in the hot path are keyed across episodes rather than partitioned by
+one, so the Monitor's *per-episode* lock does not protect their key sets:
+
+* ``Monitor._clocks`` -- ``snapshot_dict`` walked it with no lock while
+  ``_advance_clock`` inserted under only the episode lock, so a snapshot taken
+  while the host kept ingesting raised ``RuntimeError`` out of a public API
+  that has no fail-open guard (#228).
+* ``LatencyAnomalyDetector._states`` -- keyed by ``(episode_id, tool_name)``,
+  so ``reset`` has to scan instead of popping. Teardown for one episode raced
+  an ingest meeting a new tool in another; the Monitor swallowed the
+  ``RuntimeError`` fail-open and the episode's state leaked past the #184
+  retention cap (#229).
+
+Both are timing-dependent, so each test drives the race for a bounded wall
+time with several threads. They reproduce reliably on the unfixed code
+(sub-second) and are a no-op once the locks are in place.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+
+from snagline.config import Config
+from snagline.detectors.latency_anomaly import LatencyAnomalyDetector
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+
+# Any horizon knob activates the time axis; with both unset _advance_clock
+# returns early and _clocks stays empty, which is why the rest of the suite
+# never exercises this path.
+_HORIZON = Config(idle_warn_seconds=3600.0)
+
+_RACE_SECONDS = 1.5
+
+
+def _ev(episode: str, i: int, tool: str = "t") -> StepEvent:
+    return StepEvent(
+        step_id=str(i),
+        episode_id=episode,
+        timestamp=float(i),
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", tool, str(i)),
+        tool_name=tool,
+        latency_ms=10.0,
+    )
+
+
+def _race(workers: list, seconds: float = _RACE_SECONDS) -> None:
+    """Start every callable, let them run, then join."""
+    threads = [threading.Thread(target=w, daemon=True) for w in workers]
+    for thread in threads:
+        thread.start()
+    threading.Event().wait(timeout=seconds)
+    for worker in workers:
+        worker.stop.set()  # type: ignore[attr-defined]
+    for thread in threads:
+        thread.join(timeout=10.0)
+
+
+class _Worker:
+    """A stoppable loop that records the first exception it sees."""
+
+    def __init__(self, stop: threading.Event, errors: list[BaseException]) -> None:
+        self.stop = stop
+        self.errors = errors
+
+    def __call__(self) -> None:
+        for n in itertools.count():
+            if self.stop.is_set():
+                return
+            try:
+                self.step(n)
+            except BaseException as exc:
+                self.errors.append(exc)
+                self.stop.set()
+                return
+
+    def step(self, n: int) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+# --- #228: Monitor._clocks -------------------------------------------------
+
+
+def test_snapshot_dict_survives_concurrent_ingest_of_new_episodes() -> None:
+    monitor = Monitor(detectors=[], sinks=[], config=_HORIZON)
+    stop, errors = threading.Event(), []
+
+    class Ingest(_Worker):
+        def __init__(self, tag: str) -> None:
+            super().__init__(stop, errors)
+            self.tag = tag
+
+        def step(self, n: int) -> None:
+            monitor.ingest(_ev(f"{self.tag}-{n}", n))
+
+    class Snapshot(_Worker):
+        def step(self, n: int) -> None:
+            monitor.snapshot_dict()
+
+    _race([Ingest("w0"), Ingest("w1"), Ingest("w2"), Snapshot(stop, errors)])
+
+    assert not errors, f"snapshot raced ingest: {errors[0]!r}"
+
+
+def test_snapshot_dict_survives_concurrent_end_episode() -> None:
+    """Teardown pops from _clocks; the snapshot walk must tolerate that too."""
+    monitor = Monitor(detectors=[], sinks=[], config=_HORIZON)
+    stop, errors = threading.Event(), []
+
+    class Churn(_Worker):
+        def __init__(self, tag: str) -> None:
+            super().__init__(stop, errors)
+            self.tag = tag
+
+        def step(self, n: int) -> None:
+            episode = f"{self.tag}-{n}"
+            monitor.ingest(_ev(episode, n))
+            monitor.ingest(_ev(episode, n + 1))
+            monitor.end_episode(episode)
+
+    class Snapshot(_Worker):
+        def step(self, n: int) -> None:
+            monitor.snapshot_dict()
+
+    _race([Churn("c0"), Churn("c1"), Churn("c2"), Snapshot(stop, errors)])
+
+    assert not errors, f"snapshot raced end_episode: {errors[0]!r}"
+
+
+def test_time_axis_snapshot_content_is_unchanged() -> None:
+    """The lock must not alter what a single-threaded snapshot records."""
+    monitor = Monitor(detectors=[], sinks=[], config=_HORIZON)
+    monitor.ingest(_ev("ep", 0))
+    monitor.ingest(_ev("ep", 1))
+
+    time_axis = monitor.snapshot_dict()["time_axis"]
+
+    assert set(time_axis) == {"ep"}
+    assert time_axis["ep"]["last_ts"] == 1.0
+    assert time_axis["ep"]["idle_fired"] is False
+
+
+def test_first_event_of_an_episode_still_establishes_the_clock_quietly() -> None:
+    """The reworked _advance_clock head must keep its no-delta early return."""
+    received: list[object] = []
+
+    class Sink:
+        def emit(self, risk: object) -> None:
+            received.append(risk)
+
+    monitor = Monitor(detectors=[], sinks=[Sink()], config=_HORIZON)
+    monitor.ingest(_ev("ep", 0))
+
+    assert received == []
+    assert set(monitor.snapshot_dict()["time_axis"]) == {"ep"}
+
+
+def test_time_axis_round_trip_still_restores(tmp_path) -> None:
+    monitor = Monitor(detectors=[], sinks=[], config=_HORIZON)
+    monitor.ingest(_ev("ep", 0))
+    monitor.ingest(_ev("ep", 5))
+    path = str(tmp_path / "snap.json")
+    monitor.snapshot(path)
+
+    restored = Monitor(detectors=[], sinks=[], config=_HORIZON)
+    restored.restore(path)
+
+    assert restored.snapshot_dict()["time_axis"]["ep"]["last_ts"] == 5.0
+
+
+# --- #229: LatencyAnomalyDetector._states ---------------------------------
+
+
+def test_reset_survives_concurrent_observe_of_other_episodes() -> None:
+    detector = LatencyAnomalyDetector()
+    stop, errors = threading.Event(), []
+
+    class Observe(_Worker):
+        def __init__(self, tag: str) -> None:
+            super().__init__(stop, errors)
+            self.tag = tag
+
+        def step(self, n: int) -> None:
+            # A new (episode, tool) pair every step: maximum key-set churn.
+            detector.observe(_ev(f"{self.tag}-{n}", n, tool=f"tool-{n}"))
+
+    class Teardown(_Worker):
+        def step(self, n: int) -> None:
+            detector.observe(_ev("mine", n, tool=f"t{n}"))
+            detector.reset("mine")
+
+    _race([Observe("o0"), Observe("o1"), Observe("o2"), Teardown(stop, errors)])
+
+    assert not errors, f"reset raced observe: {errors[0]!r}"
+    leaked = [k for k in detector.dump_state()["states"] if k[0][0] == "mine"]
+    assert not leaked, f"reset left {len(leaked)} entries behind"
+
+
+def test_dump_state_survives_concurrent_observe() -> None:
+    detector = LatencyAnomalyDetector()
+    stop, errors = threading.Event(), []
+
+    class Observe(_Worker):
+        def __init__(self, tag: str) -> None:
+            super().__init__(stop, errors)
+            self.tag = tag
+
+        def step(self, n: int) -> None:
+            detector.observe(_ev(f"{self.tag}-{n}", n, tool=f"tool-{n}"))
+
+    class Dump(_Worker):
+        def step(self, n: int) -> None:
+            detector.dump_state()
+
+    _race([Observe("o0"), Observe("o1"), Observe("o2"), Dump(stop, errors)])
+
+    assert not errors, f"dump_state raced observe: {errors[0]!r}"
+
+
+def test_reset_still_only_drops_the_named_episode() -> None:
+    detector = LatencyAnomalyDetector()
+    detector.observe(_ev("a", 0, tool="x"))
+    detector.observe(_ev("a", 1, tool="y"))
+    detector.observe(_ev("b", 2, tool="x"))
+
+    detector.reset("a")
+
+    remaining = {tuple(k) for k, _ in detector.dump_state()["states"]}
+    assert remaining == {("b", "x")}
+
+
+def test_state_round_trip_is_unchanged_by_the_load_state_rework() -> None:
+    detector = LatencyAnomalyDetector()
+    for i in range(10):
+        detector.observe(_ev("ep", i, tool="x"))
+    dumped = detector.dump_state()
+
+    target = LatencyAnomalyDetector()
+    target.load_state(dumped)
+
+    assert target.dump_state() == dumped
+
+
+def test_load_state_replaces_rather_than_merges() -> None:
+    detector = LatencyAnomalyDetector()
+    detector.observe(_ev("stale", 0, tool="x"))
+
+    detector.load_state({"states": []})
+
+    assert detector.dump_state() == {"states": []}


### PR DESCRIPTION
Fixes #228
Fixes #229

Two dicts in the hot path are keyed **across** episodes rather than partitioned by one, so the Monitor's *per-episode* lock never protected their key sets. Same root cause, same shape of fix, so they ship together.

## #228 — `Monitor._clocks`

`snapshot_dict()` iterated `_clocks` with nothing held while `_advance_clock` inserted under only the episode lock. A snapshot taken from a sidecar/cron thread while the agent kept ingesting raised:

```
RuntimeError: dictionary keys changed during iteration
```

Unlike a detector or sink fault this one is **not** fail-open — it propagated into the host that called `snapshot()`, and it lost the snapshot it was taking. Contradicts README.md:172 ("Thread-safe").

`_clocks_lock` now covers the dict-level operations only:

| site | operation |
| --- | --- |
| `_advance_clock` | the `get` / first-sight insert |
| `end_episode`, `_evict_episode` | the `pop` |
| `snapshot_dict` | copy the pairs, build the `time_axis` payload afterwards |
| `restore_dict` | the repopulation (and the over-cap eviction pop) |

Fields *inside* an `_EpisodeClock` stay under the per-episode lock exactly as before. It is a **leaf lock** — nothing is ever acquired while holding it — so there is no ordering hazard against `_live_lock` or the episode locks. I also corrected the comment at `monitor.py:356` that claimed the episode lock made concurrent ingests serialize here; it only does so *within* one episode id.

## #229 — `LatencyAnomalyDetector._states`

Keyed by `(episode_id, tool_name)`, so `reset` must scan rather than `pop`:

```python
for key in [k for k in self._states if k[0] == episode_id]:
```

That is a Python-level comprehension, so it yields mid-walk and teardown for one episode raced an ingest meeting a new tool in another. The Monitor caught the `RuntimeError` fail-open, which is what makes it nasty: `reset` aborted partway and left the episode's per-tool CUSUM state behind for the life of the process — **reopening the leak the #184 retention cap exists to close**, while `episodes_active` still dropped and the gauge looked healthy. The fault log is deduplicated once per distinct message (#14), so a busy host saw it once and then never again.

`_states_lock` now covers the first-sight insert, `reset`, `dump_state` and `load_state`. The insert uses `setdefault` so a concurrent first sight of the same key cannot be lost. `load_state` builds the replacement dict outside the lock and swaps it in under it.

## Cost

Both locks are off the hot path. The per-step `state.update(...)` mutates an existing `_WelfordCUSUM` and adds no key, so it stays lock-free; the time axis is inert unless `SNAGLINE_IDLE_WARN_SECONDS` or `SNAGLINE_MAX_EPISODE_WALL_SECONDS` is set. `O(1)` amortized per event is preserved.

`benchmarks/overhead_benchmark.py`, 200,000 steps, same checkout with and without these changes:

| | median | p99 |
| --- | --- | --- |
| with fix | 1.81 us/step | 1.94 us/step |
| without | 1.83 us/step | 1.93 us/step |

## Tests

New `tests/test_shared_state_concurrency.py`, 10 cases. The five race tests drive several threads for a bounded 1.5 s each; three of them fail on `master` within that window and all pass with the fix. The rest pin behavior that must not change: `time_axis` snapshot content, the no-delta early return on an episode's first event, the time-axis snapshot→restore round trip, `reset` dropping only the named episode, and the `load_state` round trip and replace-not-merge semantics (guarding the restructure).

`test_dump_state_survives_concurrent_observe` passes on `master` too — `sorted(d.items())` builds its list in C without yielding, so that walk was safe by accident rather than by design. Keeping it as a guard now that the lock makes it deliberate.

## Not fixed here — one related defect remains

While writing the #228 tests I found the same class of race in **every** detector's `dump_state`, because they use Python-level comprehensions over their per-episode dicts:

```
File ".../monitor.py", line 765, in snapshot_dict
    detectors[_detector_key(i, detector)] = dump() if callable(dump) else None
File ".../detectors/loop.py", line 374, in dump_state
    "windows": {ep: list(w) for ep, w in self._windows.items()},
RuntimeError: dictionary changed size during iteration
```

So `Monitor.default().snapshot_dict()` under concurrent ingest is still exposed after this PR, via a different mechanism in different modules. Filed separately as #231 with the traceback rather than widened into this PR; happy to send that one next.

## Verification

```
707 passed, 2 skipped          (baseline on this branch point: 697 passed, 2 skipped)
Total coverage: 87.96%         (gate: 80%)
ruff check src tests           All checks passed!
ruff format --check src tests  130 files already formatted
mypy src                       Success: no issues found in 55 source files
```
