### PR TITLE
fix(detectors): copy per-episode state before serializing it (Fixes #231)

### DIFF
--- a/src/snagline/detectors/base.py
+++ b/src/snagline/detectors/base.py
@@ -8,10 +8,14 @@ episode ends so per-episode state does not leak across runs.
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+from collections.abc import Mapping
+from typing import Any, Protocol, TypeVar
 
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
+
+_K = TypeVar("_K")
+_V = TypeVar("_V")
 
 
 class Detector(Protocol):
@@ -66,3 +70,32 @@ class StatefulDetector(Protocol):
     def load_state(self, state: dict[str, Any]) -> None:
         """Restore internal state previously produced by ``dump_state``."""
         ...
+
+
+def snapshot_items(state: Mapping[_K, _V]) -> list[tuple[_K, _V]]:
+    """Atomically copy a per-episode state dict before serializing it (#231).
+
+    ``dump_state`` runs on whichever thread called ``Monitor.snapshot`` and
+    takes no lock, while an ingest on another thread may be meeting a new
+    episode and inserting its first-sight key. Detector state is partitioned by
+    ``episode_id``, so the *values* are safe -- but the key set is shared, and
+    the Monitor's per-episode lock cannot serialize a walk of it against an
+    insert for a different episode.
+
+    A Python-level comprehension over ``state.items()`` yields between
+    bytecodes, so that insert lands mid-walk and ``RuntimeError: dictionary
+    changed size during iteration`` escapes ``Monitor.snapshot`` -- a public API
+    with no fail-open guard, because restore-time errors are deliberately loud.
+    ``list(state.items())`` builds the copy inside a single C call with no
+    Python executing in between, so it cannot be interrupted; callers then
+    build their JSON payload from the returned copy.
+
+    Cross-dict atomicity is deliberately *not* provided: a detector holding
+    several dicts may snapshot episode X in one and miss it in another. Every
+    ``load_state`` already reads each dict independently and defaults what is
+    absent, and a snapshot taken during live ingest is a point-in-time smear
+    either way. Guaranteeing more would mean holding one lock across the whole
+    of ``observe``, which would serialize ingest across episodes and cost the
+    per-episode concurrency the Monitor is built around.
+    """
+    return list(state.items())

--- a/src/snagline/detectors/compaction_tripwire.py
+++ b/src/snagline/detectors/compaction_tripwire.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -163,9 +164,12 @@ class CompactionTripwireDetector:
         A restart between a compaction and its confirmations must not let the
         grace deadline vanish silently: the pending set, its deadline ordinal,
         and the fired latch all survive.
+
+        The walk goes through ``snapshot_items``: a concurrent ingest meeting a
+        new episode must not change the key set mid-loop (issue #231).
         """
         episodes: dict[str, Any] = {}
-        for ep, st in self._episodes.items():
+        for ep, st in snapshot_items(self._episodes):
             entry: dict[str, Any] = {"ordinal": st.ordinal, "pending": None}
             if st.pending is not None:
                 entry["pending"] = {

--- a/src/snagline/detectors/error_cascade.py
+++ b/src/snagline/detectors/error_cascade.py
@@ -19,6 +19,7 @@ from collections import deque
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.detectors.windowing import next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
@@ -137,8 +138,10 @@ class ErrorCascadeDetector:
         self._fired.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
+        # snapshot_items: a concurrent ingest meeting a new episode must not
+        # change the key set mid-comprehension (issue #231).
         return {
-            "windows": {ep: list(w) for ep, w in self._windows.items()},
+            "windows": {ep: list(w) for ep, w in snapshot_items(self._windows)},
             "counts": dict(self._counts),
             "consecutive": dict(self._consecutive),
             "fired": dict(self._fired),

--- a/src/snagline/detectors/goal_drift.py
+++ b/src/snagline/detectors/goal_drift.py
@@ -21,6 +21,7 @@ from typing import Any
 
 from snagline.baseline import BaselineProfile
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -98,8 +99,10 @@ class GoalDriftDetector:
         self._fired.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
+        # snapshot_items: a concurrent ingest meeting a new episode must not
+        # change the key set mid-comprehension (issue #231).
         return {
-            "live": {ep: p.to_dict() for ep, p in self._live.items()},
+            "live": {ep: p.to_dict() for ep, p in snapshot_items(self._live)},
             "fired": dict(self._fired),
         }
 

--- a/src/snagline/detectors/loop.py
+++ b/src/snagline/detectors/loop.py
@@ -45,6 +45,7 @@ from collections.abc import Callable
 from typing import Any, cast
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.detectors.windowing import next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk, TriggerType
@@ -370,14 +371,24 @@ class LoopDetector:
         # re-arm semantics); sort so the JSON snapshot is deterministic.
         # Hardening modes (#89) persist their state too: a restart must not
         # silently reset an in-progress stall streak or cycle track.
+        # Every dict walked below is copied via snapshot_items first: a
+        # concurrent ingest meeting a new episode would otherwise change the
+        # key set mid-comprehension (issue #231). The dict(...) copies are
+        # already atomic C-level builds and need no wrapper.
         return {
-            "windows": {ep: list(w) for ep, w in self._windows.items()},
+            "windows": {ep: list(w) for ep, w in snapshot_items(self._windows)},
             "counts": dict(self._counts),
-            "fired": {ep: sorted(sigs) for ep, sigs in self._fired.items()},
-            "near_windows": {ep: list(w) for ep, w in self._near_windows.items()},
+            "fired": {ep: sorted(sigs) for ep, sigs in snapshot_items(self._fired)},
+            "near_windows": {
+                ep: list(w) for ep, w in snapshot_items(self._near_windows)
+            },
             "near_counts": dict(self._near_counts),
-            "near_fired": {ep: sorted(sigs) for ep, sigs in self._near_fired.items()},
-            "cycle_windows": {ep: list(w) for ep, w in self._cycle_windows.items()},
+            "near_fired": {
+                ep: sorted(sigs) for ep, sigs in snapshot_items(self._near_fired)
+            },
+            "cycle_windows": {
+                ep: list(w) for ep, w in snapshot_items(self._cycle_windows)
+            },
             "cycle_counts": dict(self._cycle_counts),
             "cycle_fired": dict(self._cycle_fired),
             "stall_sig": dict(self._stall_sig),

--- a/src/snagline/detectors/meltdown.py
+++ b/src/snagline/detectors/meltdown.py
@@ -38,6 +38,7 @@ from collections import Counter, deque
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.detectors.windowing import effective_window_size
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
@@ -164,9 +165,11 @@ class MeltdownDetector:
         self._clear_streak.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
+        # snapshot_items: a concurrent ingest meeting a new episode must not
+        # change the key set mid-comprehension (issue #231).
         return {
             "window_size": self.window_size,
-            "windows": {ep: list(w.window) for ep, w in self._eps.items()},
+            "windows": {ep: list(w.window) for ep, w in snapshot_items(self._eps)},
             "counts": dict(self._counts),
             "fired": dict(self._fired),
             "clear_streak": dict(self._clear_streak),

--- a/src/snagline/detectors/side_effect_guard.py
+++ b/src/snagline/detectors/side_effect_guard.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 from typing import Any, cast
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk, TriggerType
 
@@ -109,6 +110,11 @@ class SideEffectGuardDetector:
         Plain nested dicts of ints by construction; only the inner
         ``(tool_name, action_signature)`` tuple keys need encoding, which
         become two-element JSON lists. Sorted so snapshots are deterministic.
+
+        The outer walk goes through ``snapshot_items``: a concurrent ingest
+        meeting a new episode must not change the key set mid-comprehension
+        (issue #231). The inner ``sorted(...)`` is already an atomic C-level
+        copy, and that dict is only ever touched under one episode's lock.
         """
         return {
             "counts": {
@@ -118,7 +124,7 @@ class SideEffectGuardDetector:
                         per_episode.items(), key=lambda kv: repr(kv[0])
                     )
                 ]
-                for ep, per_episode in self._counts.items()
+                for ep, per_episode in snapshot_items(self._counts)
             }
         }
 

--- a/src/snagline/detectors/silent_abort.py
+++ b/src/snagline/detectors/silent_abort.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -73,6 +74,8 @@ class SilentAbortDetector:
         self._last.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
+        # snapshot_items: a concurrent ingest meeting a new episode must not
+        # change the key set mid-comprehension (issue #231).
         return {
             "output_action_types": sorted(self.output_action_types),
             "last": {
@@ -82,7 +85,7 @@ class SilentAbortDetector:
                     "action_type": ev.action_type,
                     "error": ev.error,
                 }
-                for ep, ev in self._last.items()
+                for ep, ev in snapshot_items(self._last)
             },
         }
 

--- a/src/snagline/detectors/stagnation.py
+++ b/src/snagline/detectors/stagnation.py
@@ -46,6 +46,7 @@ from collections import deque
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.detectors.windowing import effective_window_size
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
@@ -164,6 +165,10 @@ class StagnationDetector:
         (raw sets are not JSON-serializable). The auto-scaler position
         (``counts``, issue #92) rides along so a restored episode keeps its
         scaling cadence.
+
+        The outer walk goes through ``snapshot_items``: a concurrent ingest
+        meeting a new episode must not change the key set mid-comprehension
+        (issue #231).
         """
         return {
             "windows": {
@@ -173,7 +178,7 @@ class StagnationDetector:
                     "stale_windows": w.stale_windows,
                     "seen_all_time": sorted(w.seen_all_time),
                 }
-                for ep, w in self._windows.items()
+                for ep, w in snapshot_items(self._windows)
             },
             # Tolerant readers on load: pre-#92 payloads carry no counts.
             "counts": dict(self._counts),

--- a/src/snagline/detectors/token_runaway.py
+++ b/src/snagline/detectors/token_runaway.py
@@ -23,6 +23,7 @@ from __future__ import annotations
 from typing import Any
 
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.detectors.latency_anomaly import _WelfordCUSUM
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
@@ -127,6 +128,8 @@ class TokenRunawayDetector:
         self._breached.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
+        # snapshot_items: a concurrent ingest meeting a new episode must not
+        # change the key set mid-comprehension (issue #231).
         return {
             "states": {
                 ep: {
@@ -138,7 +141,7 @@ class TokenRunawayDetector:
                     "sigma0": s.sigma0,
                     "frozen": s.frozen,
                 }
-                for ep, s in self._states.items()
+                for ep, s in snapshot_items(self._states)
             },
             "totals": dict(self._totals),
             "warned": dict(self._warned),

--- a/src/snagline/drift/goal_drift.py
+++ b/src/snagline/drift/goal_drift.py
@@ -43,6 +43,7 @@ from typing import Any
 
 from snagline.baseline import BaselineProfile
 from snagline.config import Config
+from snagline.detectors.base import snapshot_items
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -160,10 +161,12 @@ class SemanticGoalDriftDetector:
         self._episodes.pop(episode_id, None)
 
     def dump_state(self) -> dict[str, Any]:
+        # snapshot_items: a concurrent ingest meeting a new episode must not
+        # change the key set mid-comprehension (issue #231).
         return {
             "episodes": {
                 ep: {"sum": st.sum, "n": st.n, "debt": st.debt}
-                for ep, st in self._episodes.items()
+                for ep, st in snapshot_items(self._episodes)
                 if st.sum is not None
             }
         }

--- a/tests/test_dump_state_concurrency.py
+++ b/tests/test_dump_state_concurrency.py
@@ -1,0 +1,238 @@
+"""``dump_state`` must not walk a live per-episode dict (#229 follow-up, #231).
+
+Every stateful detector keys its state by ``episode_id``, and the Monitor holds
+only a *per-episode* lock while ingesting. ``Monitor.snapshot()`` calls each
+detector's ``dump_state`` with no lock at all, so a Python-level comprehension
+over ``self._some_dict.items()`` yields between bytecodes and an ingest meeting
+a new episode inserts a key mid-walk::
+
+    File "src/snagline/detectors/error_cascade.py", line 141, in dump_state
+      "windows": {ep: list(w) for ep, w in self._windows.items()},
+    RuntimeError: dictionary keys changed during iteration
+
+That escapes ``Monitor.snapshot`` -- a public API with no fail-open guard,
+because snapshot/restore faults are deliberately loud. The fix routes each walk
+through ``detectors.base.snapshot_items``, which copies the pairs in a single C
+call that cannot be interrupted.
+
+The race tests drive the collision for a bounded wall time with several
+threads; they reproduce in well under a second on the unfixed code and are a
+no-op once the copies are in place. The rest pin the payloads so the change
+stays behavior-preserving.
+"""
+
+from __future__ import annotations
+
+import itertools
+import threading
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+
+from snagline.baseline import BaselineProfile
+from snagline.detectors.base import snapshot_items
+from snagline.detectors.compaction_tripwire import CompactionTripwireDetector
+from snagline.detectors.error_cascade import ErrorCascadeDetector
+from snagline.detectors.goal_drift import GoalDriftDetector
+from snagline.detectors.loop import LoopDetector
+from snagline.detectors.meltdown import MeltdownDetector
+from snagline.detectors.side_effect_guard import SideEffectGuardDetector
+from snagline.detectors.silent_abort import SilentAbortDetector
+from snagline.detectors.stagnation import StagnationDetector
+from snagline.detectors.token_runaway import TokenRunawayDetector
+from snagline.events import StepEvent, make_signature
+from snagline.monitor import Monitor
+
+_RACE_SECONDS = 1.5
+
+# Every detector whose dump_state walks a per-episode dict. Built so that the
+# shared _ev() below populates that dict on the first observe.
+_FACTORIES: dict[str, Callable[[], Any]] = {
+    "loop": LoopDetector,
+    "error_cascade": ErrorCascadeDetector,
+    "stagnation": StagnationDetector,
+    "meltdown": MeltdownDetector,
+    "token_runaway": TokenRunawayDetector,
+    "compaction_tripwire": CompactionTripwireDetector,
+    "silent_abort": SilentAbortDetector,
+    "side_effect_guard": SideEffectGuardDetector,
+    # Inert without a healthy reference, so _live never fills.
+    "goal_drift": lambda: GoalDriftDetector(baseline=BaselineProfile()),
+}
+
+
+def _ev(episode: str, i: int) -> StepEvent:
+    """One event rich enough that every detector above records the episode."""
+    return StepEvent(
+        step_id=str(i),
+        episode_id=episode,
+        timestamp=float(i),
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", "write_file", str(i)),
+        tool_name="write_file",
+        latency_ms=10.0,
+        tokens_in=5,
+        tokens_out=5,
+        side_effect=True,
+        error=i % 3 == 0,
+    )
+
+
+class _Worker:
+    """A stoppable loop that records the first exception it sees."""
+
+    def __init__(self, stop: threading.Event, errors: list[BaseException]) -> None:
+        self.stop = stop
+        self.errors = errors
+
+    def __call__(self) -> None:
+        for n in itertools.count():
+            if self.stop.is_set():
+                return
+            try:
+                self.step(n)
+            except BaseException as exc:
+                self.errors.append(exc)
+                self.stop.set()
+                return
+
+    def step(self, n: int) -> None:  # pragma: no cover - overridden
+        raise NotImplementedError
+
+
+def _race(workers: list[Any], seconds: float = _RACE_SECONDS) -> None:
+    """Start every worker, let them collide, then stop and join."""
+    threads = [threading.Thread(target=w, daemon=True) for w in workers]
+    for thread in threads:
+        thread.start()
+    threading.Event().wait(timeout=seconds)
+    for worker in workers:
+        worker.stop.set()
+    for thread in threads:
+        thread.join(timeout=10.0)
+
+
+# --- the reported failure: Monitor.default() under live ingest --------------
+
+
+def test_monitor_default_snapshot_dict_survives_concurrent_ingest() -> None:
+    """The exact #231 repro: the full detector stack, snapshotted while busy."""
+    monitor = Monitor.default()
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    class Ingest(_Worker):
+        def __init__(self, tag: str) -> None:
+            super().__init__(stop, errors)
+            self.tag = tag
+
+        def step(self, n: int) -> None:
+            monitor.ingest(_ev(f"{self.tag}-{n}", n))
+
+    class Snapshot(_Worker):
+        def step(self, n: int) -> None:
+            monitor.snapshot_dict()
+
+    _race([Ingest("w0"), Ingest("w1"), Ingest("w2"), Snapshot(stop, errors)])
+
+    assert not errors, f"snapshot_dict raced ingest: {errors[0]!r}"
+
+
+def test_monitor_default_snapshot_file_survives_concurrent_ingest(tmp_path) -> None:
+    """Same race through the public on-disk path, which also JSON-encodes."""
+    monitor = Monitor.default()
+    stop = threading.Event()
+    errors: list[BaseException] = []
+    path = str(tmp_path / "snap.json")
+
+    class Ingest(_Worker):
+        def step(self, n: int) -> None:
+            monitor.ingest(_ev(f"ep-{n}", n))
+
+    class Snapshot(_Worker):
+        def step(self, n: int) -> None:
+            monitor.snapshot(path)
+
+    _race([Ingest(stop, errors), Ingest(stop, errors), Snapshot(stop, errors)])
+
+    assert not errors, f"snapshot raced ingest: {errors[0]!r}"
+
+
+# --- per-detector coverage -------------------------------------------------
+
+
+@pytest.mark.parametrize("factory", list(_FACTORIES.values()), ids=list(_FACTORIES))
+def test_detector_dump_state_survives_concurrent_observe(factory) -> None:
+    detector = factory()
+    stop = threading.Event()
+    errors: list[BaseException] = []
+
+    class Observe(_Worker):
+        def __init__(self, tag: str) -> None:
+            super().__init__(stop, errors)
+            self.tag = tag
+
+        def step(self, n: int) -> None:
+            # A brand-new episode every step: maximum key-set churn.
+            detector.observe(_ev(f"{self.tag}-{n}", n))
+
+    class Dump(_Worker):
+        def step(self, n: int) -> None:
+            detector.dump_state()
+
+    _race([Observe("o0"), Observe("o1"), Observe("o2"), Dump(stop, errors)])
+
+    assert not errors, f"dump_state raced observe: {errors[0]!r}"
+
+
+@pytest.mark.parametrize("factory", list(_FACTORIES.values()), ids=list(_FACTORIES))
+def test_detector_dump_state_still_records_every_live_episode(factory) -> None:
+    """The copy must not drop entries: two episodes in, two episodes out."""
+    detector = factory()
+    for i in range(6):
+        detector.observe(_ev("a", i))
+        detector.observe(_ev("b", i))
+
+    dumped = detector.dump_state()
+
+    walked = [v for v in dumped.values() if isinstance(v, dict) and v]
+    assert walked, f"no per-episode dict populated in {dumped!r}"
+    for section in walked:
+        assert set(section) == {"a", "b"}
+
+
+@pytest.mark.parametrize("factory", list(_FACTORIES.values()), ids=list(_FACTORIES))
+def test_detector_state_round_trip_is_unchanged(factory) -> None:
+    detector = factory()
+    for i in range(6):
+        detector.observe(_ev("a", i))
+        detector.observe(_ev("b", i))
+    dumped = detector.dump_state()
+
+    target = factory()
+    target.load_state(dumped)
+
+    assert target.dump_state() == dumped
+
+
+# --- snapshot_items itself -------------------------------------------------
+
+
+def test_snapshot_items_preserves_every_pair() -> None:
+    source = {"a": 1, "b": 2, "c": 3}
+
+    assert snapshot_items(source) == list(source.items())
+
+
+def test_snapshot_items_returns_an_independent_copy() -> None:
+    """A later insert must not be visible to a walk already under way."""
+    source = {"a": 1}
+    copied = snapshot_items(source)
+    source["b"] = 2
+
+    assert copied == [("a", 1)]
+
+
+def test_snapshot_items_tolerates_an_empty_dict() -> None:
+    assert snapshot_items({}) == []


### PR DESCRIPTION
Fixes #231.

## The bug

`Monitor.snapshot()` calls every detector's `dump_state` with **no lock**, on
whichever thread asked for the snapshot. Detector state is partitioned by
`episode_id`, so the *values* are safe under the Monitor's per-episode lock —
but the **key set** is shared, and a per-episode lock cannot serialize a walk of
it against an insert for a *different* episode.

Every `dump_state` walked its dicts with a Python-level comprehension. Those
yield between bytecodes, so a concurrent ingest meeting a new episode inserts
mid-walk:

```
File "src/snagline/monitor.py", line 747, in snapshot_dict
  detectors[_detector_key(i, detector)] = dump() if callable(dump) else None
File "src/snagline/detectors/error_cascade.py", line 141, in dump_state
  "windows": {ep: list(w) for ep, w in self._windows.items()},
RuntimeError: dictionary keys changed during iteration
```

That escapes `Monitor.snapshot` / `Monitor.snapshot_dict` — public APIs with no
fail-open guard, because snapshot/restore faults are deliberately loud. So the
documented "snapshot a long-running monitor so it survives a restart" workflow
(#91) fails intermittently on exactly the deployments it exists for: ones busy
enough to have several episodes in flight.

`Monitor.default()` reproduces it in **under a second** with three ingest
threads and one snapshot thread.

## The fix

Add `detectors.base.snapshot_items`, which copies the pairs via
`list(state.items())` — a single C-level build with no Python executing in
between, so it cannot be interrupted — and route all **14 affected walks in 10
modules** through it, building the JSON payload from the copy. The `dict(...)`
copies already had this property and are left alone.

Sites: `loop` (×5), `error_cascade`, `stagnation`, `meltdown`, `token_runaway`,
`side_effect_guard`, `compaction_tripwire`, `goal_drift`, `silent_abort`,
`drift/goal_drift`.

### Why not locks

In #231 I offered two options — per-detector locks or a Monitor-wide
shared/exclusive gate — and asked you to pick. Having then mapped every call
site, I think **neither is warranted**, so this PR does something narrower.
Happy to switch if you disagree:

- `observe` is **untouched** — no hot-path cost, and the O(1)-per-step
  guarantee needs no re-argument.
- Every `reset` was already a single-key `pop` (atomic), not a scan, so
  teardown never needed a lock. That is what distinguished
  `LatencyAnomalyDetector`, whose `(episode_id, tool_name)` key forces a scan
  and so does take a lock in #232.
- No new lock means no ordering hazard against `_live_lock`, the episode locks,
  or `_clocks_lock`, and nothing to get wrong later.

Cross-dict atomicity is deliberately **not** added: a detector holding several
dicts may capture episode X in one and miss it in another. Every `load_state`
already reads each dict independently and defaults what is absent, and a
snapshot taken during live ingest is a point-in-time smear regardless.
Guaranteeing more would mean holding one lock across the whole of `observe`,
which would serialize ingest across episodes and cost the per-episode
concurrency the Monitor is built around. The `snapshot_items` docstring records
that reasoning.

## Tests

`tests/test_dump_state_concurrency.py`, 32 tests:

- **Race (11)** — the reported repro on `Monitor.default().snapshot_dict()`,
  the same race through the on-disk `snapshot(path)` path, and one per detector
  driving maximum key-set churn (a brand-new episode every step). Each drives
  the collision for 1.5s across four threads.
- **Behavior-preserving (18)** — per detector: `dump_state` still records every
  live episode, and `dump_state` → `load_state` → `dump_state` still
  round-trips byte-identically.
- **Helper (3)** — `snapshot_items` preserves every pair, returns a copy an
  later insert cannot reach into, and tolerates an empty dict.

All 11 race tests fail on `master` and pass here; the other 21 pass both ways,
which is the point of having them.

Verified with the full CI gate set locally: **729 passed, 2 skipped**, coverage
87.62%, `ruff check src tests`, `ruff format --check src tests` and
`mypy src tests` all clean.

Independent of #230 and #232 — no overlapping files.
