### PR TITLE
fix(core): sort snapshot detector keys by slot; validate strict_names before mutating (Fixes #217)

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -107,6 +107,23 @@ def _detector_key(index: int, detector: Any) -> str:
     return f"{index}:{getattr(detector, 'name', type(detector).__name__)}"
 
 
+def _detector_slot_order(key: str) -> tuple[int, int, str]:
+    """Sort key recovering the numeric slot order of a snapshot detector key.
+
+    ``sorted()`` on the raw ``"<index>:<name>"`` strings is lexicographic, so
+    slot ``10`` lands between ``1`` and ``2``. Any monitor with 11+ detectors
+    then compared two differently-ordered name lists in the ``strict_names``
+    check, rejecting a matching composition and accepting a mismatched one
+    (issue #217). Keys without an integer prefix cannot be placed by slot, so
+    they sort after the numbered ones, deterministically by the raw key.
+    """
+    head, _, _ = key.partition(":")
+    try:
+        return (0, int(head), key)
+    except ValueError:
+        return (1, 0, key)
+
+
 def _auto_calibration_plan(cfg: Config) -> CalibrationPlan | None:
     """Resolve the auto-calibration plan for ``cfg``, fail-open (issue #101).
 
@@ -781,6 +798,10 @@ class Monitor:
         default is tolerant: matching entries are applied by key, missing
         detectors are skipped with a warning, and states without a home are
         ignored with a warning.
+
+        The strict check runs *before* any state is applied, so a rejected
+        restore leaves the monitor untouched: a caller that catches the
+        ``ValueError`` never has to wonder which half of the snapshot landed.
         """
         version = data.get("format_version")
         if version != SNAPSHOT_FORMAT_VERSION:
@@ -789,6 +810,23 @@ class Monitor:
                 f"{SNAPSHOT_FORMAT_VERSION}"
             )
         dumped_detectors: dict[str, Any] = data.get("detectors") or {}
+        # Validate before mutating (strict mode): the composition check below
+        # reads only the snapshot's keys and the monitor's detector list, so
+        # running it first guarantees a rejected restore applies no state at
+        # all. After the loop it would be too late -- the per-key and
+        # name-suffix fallbacks would already have loaded windows into
+        # detectors that the check then rejects the snapshot for.
+        if strict_names:
+            expected = [
+                k.split(":", 1)[1]
+                for k in sorted(dumped_detectors, key=_detector_slot_order)
+            ]
+            current = [getattr(d, "name", type(d).__name__) for d in self._detectors]
+            if expected != current:
+                raise ValueError(
+                    "snapshot detector composition mismatch: "
+                    f"snapshot={expected} monitor={current}"
+                )
         consumed: set[str] = set()
         for i, detector in enumerate(self._detectors):
             load = getattr(detector, "load_state", None)
@@ -827,14 +865,6 @@ class Monitor:
                 "slot(s); ignored",
                 len(orphaned),
             )
-        if strict_names:
-            expected = [k.split(":", 1)[1] for k in sorted(dumped_detectors)]
-            current = [getattr(d, "name", type(d).__name__) for d in self._detectors]
-            if expected != current:
-                raise ValueError(
-                    "snapshot detector composition mismatch: "
-                    f"snapshot={expected} monitor={current}"
-                )
         dumped_sinks: dict[str, Any] = data.get("sinks") or {}
         for i, sink in enumerate(self._sinks):
             load = getattr(sink, "load_state", None)

--- a/tests/test_monitor_snapshot.py
+++ b/tests/test_monitor_snapshot.py
@@ -8,13 +8,18 @@ from typing import cast
 
 import pytest
 
+from snagline.detectors.compaction_tripwire import CompactionTripwireDetector
 from snagline.detectors.error_cascade import ErrorCascadeDetector
+from snagline.detectors.goal_drift import GoalDriftDetector
 from snagline.detectors.latency_anomaly import LatencyAnomalyDetector
 from snagline.detectors.loop import LoopDetector
+from snagline.detectors.meltdown import MeltdownDetector
+from snagline.detectors.side_effect_guard import SideEffectGuardDetector
 from snagline.detectors.silent_abort import SilentAbortDetector
+from snagline.detectors.stagnation import StagnationDetector
 from snagline.detectors.token_runaway import TokenRunawayDetector
 from snagline.events import StepEvent
-from snagline.monitor import Monitor
+from snagline.monitor import SNAPSHOT_FORMAT_VERSION, Monitor
 from snagline.sinks.dedup import DedupSink
 
 
@@ -216,3 +221,128 @@ def test_latency_state_round_trip_behavioral():
     scores_2 = [r.score for e in tail if (r := d2.observe(e)) is not None]
     assert scores_1 == scores_2
     assert scores_1, "sustained shift after restored baseline must still alarm"
+
+
+# --- strict_names slot ordering (issue #217) --------------------------------
+#
+# Snapshot keys are "<slot>:<name>", so sorting them as plain strings puts slot
+# 10 between 1 and 2. Below 11 detectors every index is one digit and the bug
+# is invisible, which is why the coverage above (1-5 detectors) misses it.
+
+_DETECTOR_CLASSES = {
+    "loop": LoopDetector,
+    "error_cascade": ErrorCascadeDetector,
+    "latency_anomaly": LatencyAnomalyDetector,
+    "stagnation": StagnationDetector,
+    "token_runaway": TokenRunawayDetector,
+    "meltdown": MeltdownDetector,
+    "silent_abort": SilentAbortDetector,
+    "side_effect_guard": SideEffectGuardDetector,
+    "governance_decay": CompactionTripwireDetector,
+    "goal_drift": GoalDriftDetector,
+}
+
+# Eleven slots is not a synthetic number: it is what Monitor.default() builds
+# once the opt-in detectors are enabled, with no extras installed.
+_ELEVEN_NAMES = [*_DETECTOR_CLASSES, "loop"]
+
+
+def _eleven() -> list:
+    return [_DETECTOR_CLASSES[name]() for name in _ELEVEN_NAMES]
+
+
+def test_strict_names_accepts_identical_11_detector_composition(tmp_path):
+    path = str(tmp_path / "state.json")
+    a = Monitor(_eleven(), [ListSink()])
+    a.ingest(
+        StepEvent(
+            step_id="0",
+            episode_id="ep",
+            timestamp=0.0,
+            action_type="tool_call",
+            action_signature="s0",
+            tool_name="api",
+            latency_ms=10.0,
+        )
+    )
+    a.snapshot(path)
+
+    b = Monitor(_eleven(), [ListSink()])
+    assert [d.name for d in a._detectors] == [d.name for d in b._detectors]
+    b.restore(path, strict_names=True)  # raised "composition mismatch" pre-#217
+
+
+def test_strict_names_rejects_mismatch_in_lexicographic_key_order(tmp_path):
+    """The false-accept direction: a genuinely wrong composition that happens
+    to equal the *string* order of the snapshot's keys must still raise."""
+    path = str(tmp_path / "state.json")
+    snapshotted = _eleven()
+    Monitor(snapshotted, [ListSink()]).snapshot(path)
+
+    with open(path, encoding="utf-8") as fh:
+        keys = json.load(fh)["detectors"]
+    lexicographic = [k.split(":", 1)[1] for k in sorted(keys)]
+    assert lexicographic != [d.name for d in snapshotted], (
+        "11 slots must reorder under string sorting, or the test proves nothing"
+    )
+
+    wrong = Monitor([_DETECTOR_CLASSES[n]() for n in lexicographic], [ListSink()])
+    with pytest.raises(ValueError, match="composition mismatch"):
+        wrong.restore(path, strict_names=True)
+
+
+def test_strict_names_survives_key_without_integer_slot_prefix():
+    """restore_dict takes caller-supplied dicts; an unparseable slot prefix
+    must not crash the strict check (setup-time raise stays a ValueError)."""
+    monitor = Monitor([LoopDetector()], [ListSink()])
+    with pytest.raises(ValueError, match="composition mismatch"):
+        monitor.restore_dict(
+            {
+                "format_version": SNAPSHOT_FORMAT_VERSION,
+                "detectors": {"0:loop": None, "x:error_cascade": None},
+            },
+            strict_names=True,
+        )
+
+
+def test_strict_names_rejection_applies_no_state(tmp_path):
+    """A rejected strict restore must leave the monitor untouched.
+
+    The composition check runs *before* the load loop. After the loop it
+    would be too late: the name-suffix fallback would already have loaded
+    the snapshot's per-episode windows into detectors by name, so a caller
+    that catches the ValueError keeps a monitor contaminated with state
+    from the snapshot it just rejected.
+    """
+    path = str(tmp_path / "state.json")
+    a = Monitor([LoopDetector(), ErrorCascadeDetector()], [ListSink()])
+    a.ingest(
+        StepEvent(
+            step_id="0",
+            episode_id="ep",
+            timestamp=0.0,
+            action_type="tool_call",
+            action_signature="q-a",
+            tool_name="search",
+        )
+    )
+    a.ingest(
+        StepEvent(
+            step_id="1",
+            episode_id="ep",
+            timestamp=1.0,
+            action_type="tool_call",
+            action_signature="q-a",
+            tool_name="search",
+        )
+    )
+    a.snapshot(path)
+
+    b = Monitor([ErrorCascadeDetector(), LoopDetector()], [ListSink()])
+    with pytest.raises(ValueError, match="composition mismatch"):
+        b.restore(path, strict_names=True)
+    b_loop = cast(LoopDetector, next(d for d in b._detectors if d.name == "loop"))
+    assert b_loop._windows == {}, (
+        "rejected snapshot must not leave per-episode state behind "
+        "(name-suffix fallback loaded it pre-fix)"
+    )


### PR DESCRIPTION
## Summary

Fixes two defects in `Monitor.restore_dict(strict_names=True)`:

### 1. Lexicographic slot ordering (issue #217)

Snapshot detector keys are `"<slot>:<name>"`. The strict composition check
sorted these keys as plain strings, so slot `10` sorted between `1` and `2`.
With 11+ detectors the check compared two differently-ordered name lists:

- a **matching** composition was rejected (`ValueError` on a valid restore), and
- a **mismatched** composition whose names happened to equal the string-sorted
  key order was accepted.

Eleven slots is not a synthetic number: it is what `Monitor.default()` builds
once the opt-in detectors are enabled, with no extras installed.
`_detector_slot_order()` now recovers the numeric slot order; keys without an
integer prefix sort deterministically after the numbered ones.

### 2. Mutation before validation (found while fixing #217)

The strict check ran **after** the per-key/name-suffix fallback load loop, so a
restore the check went on to reject had already loaded the snapshot's
per-episode windows into the monitor's detectors via the name-suffix fallback.
A caller that catches the documented setup-time `ValueError` was left with a
monitor contaminated by the rejected snapshot — the exact "quiet misbehavior"
the feature's own rationale says it exists to prevent. The check now runs
before any state is applied, so a rejected restore leaves the monitor
untouched. Sink restore already ran after the check; the detector path was the
misordered one.

## Repro (pre-fix)

```python
# Slot ordering: 11 detectors, identical composition -> ValueError
a, b = Monitor(_eleven(), []), Monitor(_eleven(), [])
a.snapshot(path)
b.restore(path, strict_names=True)   # raises "composition mismatch"

# Ordering: mismatched composition -> state applied anyway
a = Monitor([LoopDetector(), ErrorCascadeDetector()], [])
a.ingest(...)  # per-episode windows
a.snapshot(path)
b = Monitor([ErrorCascadeDetector(), LoopDetector()], [])
with pytest.raises(ValueError):
    b.restore(path, strict_names=True)
b._detectors[1]._windows  # non-empty: the rejected snapshot landed
```

## Tests

- `test_strict_names_accepts_identical_11_detector_composition` — false-reject direction
- `test_strict_names_rejects_mismatch_in_lexicographic_key_order` — false-accept direction
- `test_strict_names_survives_key_without_integer_slot_prefix` — unparseable slot stays a `ValueError`
- `test_strict_names_rejection_applies_no_state` — rejected restore applies no state

Full suite, `mypy src tests`, and `ruff check`/`ruff format` all pass locally
(699 passed, 3 skipped).

Fixes #217
