### PR TITLE
fix(adapter): give Claude Code Pre/Post tool events distinct signatures (Fixes #237)

### DIFF
--- a/src/snagline/adapters/claude_code.py
+++ b/src/snagline/adapters/claude_code.py
@@ -143,14 +143,21 @@ def payload_to_event(
 
     # Stable, structural parts only: the same logical attempt (same tool,
     # same input) must hash identically for loop detection to see a retry.
+    # The start/end subkind is included for tool calls: Claude Code fires
+    # PreToolUse and PostToolUse for ONE logical call with the same tool and
+    # input, and a signature blind to the subkind made that single attempt
+    # count twice in the loop window (issue #237), halving the effective
+    # repeat_threshold for every Claude Code host.
     if is_tool:
         stable = json.dumps(payload.get("tool_input") or {}, sort_keys=True)
         tool_for_sig = str(tool_name or "tool")
+        stable_parts: tuple[str, ...] = (subkind,)
     else:
         stable = str(payload.get("prompt") or payload.get("error") or subkind)
         # prompt_id is volatile (unique per turn): excluding it from the
         # signature lets a repeated identical prompt be loop-detectable.
         tool_for_sig = "claude-code"
+        stable_parts = ()
 
     error = payload.get("hook_event_name") in _ERROR_EVENTS
     error_type = None
@@ -176,7 +183,9 @@ def payload_to_event(
         episode_id=episode_id,
         timestamp=timestamp if timestamp is not None else time.time(),
         action_type=action_type,
-        action_signature=make_signature(action_type, tool_for_sig, stable),
+        action_signature=make_signature(
+            action_type, tool_for_sig, stable, *stable_parts
+        ),
         tool_name=str(tool_name) if tool_name is not None else None,
         latency_ms=latency_ms,
         error=error,

--- a/tests/adapters/test_claude_code_adapter.py
+++ b/tests/adapters/test_claude_code_adapter.py
@@ -222,3 +222,60 @@ def test_ingest_payload_never_raises() -> None:
         m,
         {"hook_event_name": "PreToolUse", "session_id": None, "tool_input": {}},  # type: ignore[dict-item]
     )
+
+
+def test_two_healthy_logical_calls_do_not_trip_loop() -> None:
+    # Issue #237: PreToolUse and PostToolUse of ONE logical call used to share
+    # an action signature (same tool, same input; only the volatile
+    # tool_use_id differs, which the signature excludes). The loop window
+    # counts events, so 2 healthy identical calls contributed 4 identical
+    # signatures and tripped the default repeat_threshold of 3. The subkind
+    # now separates the Pre and Post signatures. Asserted through the real
+    # Monitor so the shipped repeat_threshold (not the stub window above)
+    # is what decides.
+    risks: list[FailureRisk] = []
+
+    class _Sink:
+        def emit(self, risk: FailureRisk) -> None:
+            risks.append(risk)
+
+    monitor = Monitor.default(config=Config(), sinks=[_Sink()])
+    tracker = HookTracker()
+    for i in range(2):  # exactly TWO logical calls
+        p = _tool_payload("PreToolUse", tool_use_id=f"toolu_{i}")
+        ingest_payload(monitor, p, tracker)
+        ingest_payload(monitor, {**p, "hook_event_name": "PostToolUse"}, tracker)
+    assert not [r for r in risks if r.trigger == "loop"], (
+        "2 identical logical tool calls must not fire loop"
+    )
+
+
+def test_third_logical_call_still_trips_loop() -> None:
+    # The guard must not over-suppress: 3 identical logical attempts (6
+    # events) is a genuine repeat pattern and must keep firing.
+    risks: list[FailureRisk] = []
+
+    class _Sink:
+        def emit(self, risk: FailureRisk) -> None:
+            risks.append(risk)
+
+    monitor = Monitor.default(config=Config(), sinks=[_Sink()])
+    tracker = HookTracker()
+    for i in range(3):  # THREE logical calls
+        p = _tool_payload("PreToolUse", tool_use_id=f"toolu_{i}")
+        ingest_payload(monitor, p, tracker)
+        ingest_payload(monitor, {**p, "hook_event_name": "PostToolUse"}, tracker)
+    assert [r for r in risks if r.trigger == "loop"], (
+        "3 identical logical tool calls must fire loop"
+    )
+
+
+def test_pre_and_post_have_distinct_signatures() -> None:
+    pre = payload_to_event(_tool_payload("PreToolUse"))
+    post = payload_to_event(_tool_payload("PostToolUse"))
+    assert pre is not None and post is not None
+    assert pre.action_signature != post.action_signature
+    # And retries stay pairable with themselves:
+    pre2 = payload_to_event(_tool_payload("PreToolUse", tool_use_id="other"))
+    assert pre2 is not None
+    assert pre2.action_signature == pre.action_signature


### PR DESCRIPTION
## Summary

One logical Claude Code tool call emits two hook payloads — `PreToolUse` and
`PostToolUse` — with the same `tool_name` and `tool_input`. The signature was
built from exactly those (plus `action_type`), so both events hashed
identically: only the volatile `tool_use_id` differs, and the signature
deliberately excludes it.

`LoopDetector` counts **events** in its window, so one logical attempt
contributed 2 identical signatures. With the default `loop_repeat_threshold=3`,
a healthy agent that runs the same tool with the same arguments **twice**
fired `loop` ("action repeated 3x in last 3 steps") — the effective threshold
was halved for every Claude Code host (issue #237).

The fix: the tool-call signature includes the `start`/`end` subkind as an
extra stable part.

- Pre and Post of one logical call now have distinct signatures.
- Retries of either kind still hash identically to their own kind, so loop
  detection of genuine repetition is unaffected.
- The message path (`UserPromptSubmit` etc.) is unchanged.

## Tests

- `test_two_healthy_logical_calls_do_not_trip_loop` — 2 Pre/Post pairs (the
  false-positive repro from #237) through the real `Monitor.default()`.
- `test_third_logical_call_still_trips_loop` — guards against
  over-suppression: 3 identical logical attempts still fire.
- `test_pre_and_post_have_distinct_signatures` — signature-level check,
  including retry pairability.

The existing `test_hook_latency_reaches_the_cusum_detector` (10 Pre/Post
pairs) and `test_repeated_same_tool_input_is_loop_detectable` (4 Pre events)
continue to pass, confirming no collateral behavior change.

Full suite, `mypy src tests`, and `ruff check`/`ruff format` all pass locally
(698 passed, 3 skipped).

Fixes #237
