### PR TITLE
fix(core): keep MemoryStateBackend.release() from orphaning parked waiters (Fixes #238)

### DIFF
--- a/src/snagline/state.py
+++ b/src/snagline/state.py
@@ -46,22 +46,49 @@ class ReleasableStateBackend(StateBackend, Protocol):
         ...
 
 
+class _LockEntry:
+    """One episode's lock plus the bookkeeping that keeps it safe to drop.
+
+    ``waiters`` counts threads that have fetched this entry -- holding its
+    lock or parked waiting for it. ``released`` marks an episode whose lock
+    the backend has been asked to drop. The entry leaves the table only
+    once every waiter has drained, so a thread parked on the lock when
+    ``release()`` ran can never end up inside the critical section beside
+    a fetcher that arrived afterwards: both serialize on this same entry
+    until the last one exits and the entry is finally removed (issue #238).
+    """
+
+    __slots__ = ("lock", "waiters", "released")
+
+    def __init__(self) -> None:
+        self.lock = threading.RLock()
+        self.waiters: int = 0
+        self.released: bool = False
+
+
 class MemoryStateBackend:
     """Process-local backend: one re-entrant lock per episode id."""
 
     def __init__(self) -> None:
         self._meta = threading.Lock()
-        self._locks: dict[str, threading.RLock] = {}
+        self._locks: dict[str, _LockEntry] = {}
 
     @contextmanager
     def episode_lock(self, episode_id: str) -> Iterator[None]:
         with self._meta:
-            lock = self._locks.get(episode_id)
-            if lock is None:
-                lock = threading.RLock()
-                self._locks[episode_id] = lock
-        with lock:
-            yield
+            entry = self._locks.get(episode_id)
+            if entry is None:
+                entry = _LockEntry()
+                self._locks[episode_id] = entry
+            entry.waiters += 1
+        try:
+            with entry.lock:
+                yield
+        finally:
+            with self._meta:
+                entry.waiters -= 1
+                if entry.released and entry.waiters == 0:
+                    self._locks.pop(episode_id, None)
 
     def release(self, episode_id: str) -> None:
         """Drop the lock allocated for a finished episode.
@@ -70,14 +97,23 @@ class MemoryStateBackend:
         shrinks, so a long-lived Monitor watching many short runs retains a
         lock for every episode it has ever seen.
 
-        ``Monitor.end_episode`` calls this while holding the episode lock, so
-        no other thread can be inside the critical section when the entry is
-        dropped. A thread that ingests for the same id *after* the release
-        simply allocates a fresh lock -- correct, because an episode that has
-        ended has no detector state left to serialize.
+        ``Monitor.end_episode`` calls this while holding the episode lock.
+        Other threads may still be *parked* on that lock -- they fetched it
+        before the release and are waiting for the holder to finish -- so
+        the entry is only removed once every such waiter has drained
+        (issue #238). Until then a parked waiter and any fetcher that
+        arrives later share this same entry, keeping the episode's critical
+        section mutually exclusive; a thread that fetches after the entry
+        is finally removed allocates a fresh one, which is correct because
+        an ended episode has no detector state left to serialize.
         """
         with self._meta:
-            self._locks.pop(episode_id, None)
+            entry = self._locks.get(episode_id)
+            if entry is None:
+                return
+            entry.released = True
+            if entry.waiters == 0:
+                self._locks.pop(episode_id, None)
 
 
 class RedisStateBackend:  # pragma: no cover - optional, requires redis

--- a/tests/test_state_backend.py
+++ b/tests/test_state_backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import threading
+import time
 from contextlib import contextmanager
 
 import pytest
@@ -149,3 +150,119 @@ def test_end_episode_propagates_release_error_when_not_fail_open():
     )
     with pytest.raises(RuntimeError):
         monitor.end_episode("ep")
+
+
+# --- release() vs parked waiters (issue #238) -------------------------------
+
+
+def test_parked_waiter_keeps_exclusive_section_after_release():
+    """The exact race from issue #238, made deterministic.
+
+    Thread A (end_episode) holds the episode lock inside finalize(); thread
+    B (ingest) fetches the same entry under _meta and parks on the lock; A
+    runs release() and returns. Pre-fix, release() popped the entry
+    immediately, so when B woke it entered on the orphaned lock while a
+    later thread C found no entry and allocated a fresh one: B and C ran
+    observe() for the same episode concurrently. Post-fix, the entry is
+    marked released and stays until every waiter drains, so B and C
+    serialize on the same lock; C only enters after B leaves.
+    """
+    in_finalize = threading.Event()
+    finalize_go = threading.Event()
+    in_observe = threading.Event()
+    observe_go = threading.Event()
+
+    class _GatedDetector:
+        name = "gated"
+
+        def observe(self, event):
+            in_observe.set()
+            assert observe_go.wait(timeout=10)
+            return None
+
+        def finalize(self, episode_id):
+            in_finalize.set()
+            assert finalize_go.wait(timeout=10)
+            return None
+
+        def reset(self, episode_id):
+            pass
+
+    backend = MemoryStateBackend()
+    monitor = Monitor.default(sinks=[], state_backend=backend)
+    monitor._detectors = [_GatedDetector()]
+    monitor.ingest(_event(episode_id="ep", i=0))  # create the entry
+
+    # A holds the lock inside finalize().
+    a = threading.Thread(target=lambda: monitor.end_episode("ep"))
+    a.start()
+    assert in_finalize.wait(timeout=5), "A must reach finalize"
+
+    # B fetches the entry and parks on the lock (A holds it).
+    b = threading.Thread(target=lambda: monitor.ingest(_event("ep", 1)))
+    b.start()
+    time.sleep(0.1)  # let B park
+
+    # A finishes: release() runs inside end_episode, then A exits the lock.
+    finalize_go.set()
+    a.join(timeout=10)
+
+    # B wakes and enters observe() on the (now released-marked) entry.
+    assert in_observe.wait(timeout=5), "B must reach observe after A leaves"
+
+    # C arrives after the release. Pre-fix it got a FRESH lock and entered
+    # observe() concurrently with B; post-fix it shares B's entry and parks.
+    c = threading.Thread(target=lambda: monitor.ingest(_event("ep", 2)))
+    c.start()
+    time.sleep(0.2)
+    # The decisive check: B and C must be counted on ONE shared entry; a
+    # fresh entry for C would mean two live locks guard the same episode.
+    with backend._meta:
+        entries = dict(backend._locks)
+    assert "ep" in entries, "B's entry must still exist while B holds it"
+    assert entries["ep"].waiters >= 2, (
+        "B and C must be counted on one shared entry; a fresh entry for C "
+        "would mean two live locks guard the same episode (issue #238)"
+    )
+
+    # Let B leave; C then enters on the same entry.
+    observe_go.set()
+    b.join(timeout=10)
+    assert in_observe.wait(timeout=5)
+    observe_go.set()
+    c.join(timeout=10)
+    a.join(timeout=10)
+
+    # Once every waiter drains, the released entry is removed. C's own
+    # observe runs under the entry it fetched; after it drains the table is
+    # empty again (the leak guard from #67 keeps holding).
+    deadline = time.monotonic() + 5
+    while backend._locks and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert "ep" not in backend._locks, "entry must drain after the last waiter"
+
+
+def test_release_during_parked_waiter_blocks_new_entry_until_drain():
+    """Directly at the primitive: release() while a waiter is parked must not
+    hand a *fresh* lock to a later fetcher -- the parked waiter and the later
+    fetcher must serialize on the same entry."""
+    backend = MemoryStateBackend()
+
+    def _run_ctx(ctx):
+        with ctx:
+            pass
+
+    # Hold the lock in this thread, and park a second waiter on it.
+    with backend.episode_lock("ep"):
+        with_park = backend.episode_lock("ep")
+        parked = threading.Thread(target=lambda: _run_ctx(with_park))
+        parked.start()
+        time.sleep(0.1)  # parked.waiters counted, blocked on the lock
+        backend.release("ep")  # entry must be marked, not dropped
+        assert "ep" in backend._locks, "released entry with a parked waiter stays"
+    # Holder exits; the parked waiter runs and drains the entry on exit.
+    parked.join(timeout=10)
+    deadline = time.monotonic() + 5
+    while "ep" in backend._locks and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert "ep" not in backend._locks


### PR DESCRIPTION
## Summary

`MemoryStateBackend.episode_lock` fetched the lock under `_meta`, then released
`_meta` **before** parking on the lock. `release()` popped the dict entry while
a waiter could already hold a reference to the old `RLock` and be parked on it.
Sequence:

1. Thread A runs `end_episode("ep")` and holds L1 inside `finalize`.
2. Thread B calls `ingest` for the same episode, fetches L1 under `_meta`,
   blocks on `with lock:`.
3. A calls `release("ep")` — popped L1 — then returns, releasing L1.
4. B wakes on the orphaned L1 and **enters the critical section**.
5. Thread C ingests for `"ep"`, finds no entry, allocates a fresh L2 and enters
   **concurrently with B**.

Result: concurrent `detector.observe()` / `_advance_clock()` mutations of one
episode's state with no mutual exclusion — the exact serialization
`episode_lock` exists to guarantee — with no exception anywhere. Both in-code
safety claims (the `release()` docstring and the comment in
`Monitor.end_episode`) were false for the parked-waiter window. Reproduced
through the real `Monitor` path: max concurrent observers inside one episode
reached 2 (issue #238).

### Fix

The lock table now holds `_LockEntry` objects — `lock`, a `waiters` count, and
a `released` flag:

- `episode_lock` increments `waiters` under `_meta` *before* parking, and
  decrements in a `finally`; the last waiter to drain removes a released entry.
- `release()` marks the entry instead of popping it (an entry with zero
  waiters is still popped immediately, preserving the no-leak guarantee from
  #67).

A parked waiter and any later fetcher therefore serialize on the *same* entry
until everyone has drained; only then does the episode's entry disappear.

## Tests

- `test_parked_waiter_keeps_exclusive_section_after_release` — the exact race
  from #238 made deterministic with a gated `finalize`/`observe`: asserts B and
  C are counted on one shared entry (`waiters >= 2`), and the entry drains
  after the last waiter.
- `test_release_during_parked_waiter_blocks_new_entry_until_drain` — the same
  property directly at the primitive.

Both tests fail against the pre-fix `state.py` and pass with the fix. The
existing suite (including #67's leak guard, `test_end_episode_releases_the_episode_lock`)
continues to pass. Full suite, `mypy src tests`, `ruff check`/`ruff format`
pass locally (697 passed, 3 skipped).

Fixes #238
