### PR TITLE
fix(core): let FailureRisk keep an explicitly requested severity of warning (Fixes #246)

### DIFF
--- a/src/snagline/risk.py
+++ b/src/snagline/risk.py
@@ -61,11 +61,18 @@ class FailureRisk:
     trigger: TriggerType
     detail: str  # short human-readable explanation, no raw content
     timestamp: float
-    severity: str = SEVERITY_WARNING  # auto-derived from score if left default
+    # "" means "unset": derived from score in __post_init__. A literal
+    # severity, including "warning", survives construction exactly as the
+    # caller requested (issue #246). The default cannot use the string
+    # "warning" itself -- it would be indistinguishable from an explicit
+    # "warning" and silently re-derived, re-routing alerts in
+    # min_severity-filtered sinks. "" is not a legal severity value, so it
+    # can only mean "unset".
+    severity: str = ""
 
     def __post_init__(self) -> None:
-        # If the caller did not set an explicit severity, derive one from the
-        # score so every risk carries a useful routing hint. A caller that
-        # passes `severity=` explicitly keeps that value.
-        if self.severity == SEVERITY_WARNING:
+        # Derive a routing hint from the score only when the caller left
+        # severity unset. A caller that passes `severity=` explicitly keeps
+        # that value -- all three legal values, warning included.
+        if not self.severity:
             object.__setattr__(self, "severity", severity_from_score(self.score))

--- a/tests/test_sinks_dedup.py
+++ b/tests/test_sinks_dedup.py
@@ -44,6 +44,18 @@ def test_risk_explicit_severity_kept():
     assert _risk(0.9, severity=SEVERITY_INFO).severity == SEVERITY_INFO
 
 
+def test_risk_explicit_warning_survives():
+    # Issue #246: the default used to BE "warning", so an explicitly
+    # requested warning was indistinguishable from "unset" and silently
+    # re-derived from the score -- becoming "critical" above 0.8 (paging
+    # on-call against the caller's intent) and "info" below 0.5 (dropped
+    # by min_severity="warning" filters). The None default keeps all
+    # three legal values literal.
+    assert _risk(0.9, severity=SEVERITY_WARNING).severity == SEVERITY_WARNING
+    assert _risk(0.6, severity=SEVERITY_WARNING).severity == SEVERITY_WARNING
+    assert _risk(0.2, severity=SEVERITY_WARNING).severity == SEVERITY_WARNING
+
+
 class _RecordingSink:
     def __init__(self):
         self.emitted: list[FailureRisk] = []


### PR DESCRIPTION
## Summary

`FailureRisk.severity` defaulted to `SEVERITY_WARNING`, and `__post_init__`
treated **any** `severity == "warning"` as "unset", overwriting it with the
score-derived value. An explicitly requested `"warning"` was therefore
indistinguishable from the default:

- `FailureRisk("ep","s",0.95,"loop","d",0.0, severity="warning").severity`
  became `"critical"` — a deliberate downgrade of a high-score risk still
  **pages on-call** through `min_severity` filters, against the caller's intent
- the same at score 0.30 became `"info"` — **dropped** by a
  `min_severity="warning"` filter

Severity is load-bearing downstream: `SlackSink`/`PagerDutySink` route on
`min_severity`, `DedupSink`'s default key includes it, and the Prometheus
renderer labels by it. The `__post_init__` comment claimed explicit severities
were kept; for one of the three legal values it never was (issue #246).

### Fix

The default is now `""` — not a legal severity value, so it can only mean
"unset" — and derivation happens only for an empty value. All three legal
values survive construction literally. The field's type stays `str`, so no
consumer signature changes.

## Tests

`test_risk_explicit_warning_survives` pins all three score bands with an
explicit `severity="warning"`. The existing
`test_risk_default_severity_derived_from_score` / `test_risk_explicit_severity_kept`
suite continues to pass unchanged (no shipped detector passes `severity=`
explicitly, so no detector behavior shifts).

Full suite, `mypy src tests`, `ruff check`/`ruff format` pass locally
(696 passed, 3 skipped).

Fixes #246
