### PR TITLE
fix(detector): re-arm GoalDriftDetector after recovery

### DIFF
--- a/src/snagline/detectors/goal_drift.py
+++ b/src/snagline/detectors/goal_drift.py
@@ -51,6 +51,14 @@ class GoalDriftDetector:
             return None
         score = self._drift_score(event.episode_id, baseline)
         if score < self._cfg.goal_drift_score_threshold:
+            # Below threshold: the episode has recovered from whatever fired
+            # before, so re-arm. Without this the latch held forever (issue
+            # #247) -- a long-lived episode that recovered from one drift and
+            # later hit a second, independent one never alerted again. This
+            # mirrors the re-arm semantics every other shipped detector has
+            # (loop clears when the signature leaves the window; the ESN
+            # CUSUM resets to re-alarm on persistent faults).
+            self._fired[event.episode_id] = False
             return None
         if self._fired.get(event.episode_id, False):
             return None

--- a/tests/test_goal_drift.py
+++ b/tests/test_goal_drift.py
@@ -82,3 +82,41 @@ def test_goal_drift_reset_clears_state():
     # After reset, accumulating fresh healthy traffic must not immediately alarm.
     risks = [det.observe(_ev("search", 100.0 + i)) for i in range(4)]
     assert all(r is None for r in risks)
+
+
+def test_goal_drift_rearms_after_recovery():
+    """Issue #247: _fired latched once per episode and never re-armed, so a
+    long-lived episode that recovered from one drift and later hit a second,
+    independent (worse) one stayed silent forever. The latch now clears when
+    the drift score drops back below the threshold, mirroring the re-arm
+    semantics of every other shipped detector."""
+    cfg = Config()
+    cfg.goal_drift_min_samples = 3
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+
+    # Phase 1: a drift (errors) fires exactly once.
+    phase1 = [det.observe(_ev("search", 100.0, error=True)) for _ in range(6)]
+    assert sum(1 for r in phase1 if r is not None) == 1
+
+    # Phase 2: healthy traffic brings the live profile back in line. Enough
+    # steps to dilute the phase-1 errors below the error tolerance and push
+    # the live mean back toward the baseline.
+    for _ in range(40):
+        det.observe(_ev("search", 100.0))
+    assert det._fired.get("ep") is not True, "recovery must re-arm the latch"
+
+    # Phase 3: a second, independent drift must alert again.
+    phase3 = [det.observe(_ev("search", 20000.0, error=True)) for _ in range(6)]
+    fired3 = [r for r in phase3 if r is not None]
+    assert fired3, "a second independent drift in the same episode must fire"
+    assert fired3[0].trigger == "goal_drift"
+
+
+def test_goal_drift_still_dedupes_while_drift_persists():
+    """Re-arm must not turn into alert spam: while the drift score stays above
+    the threshold without an intervening recovery, exactly one risk fires."""
+    cfg = Config()
+    cfg.goal_drift_min_samples = 3
+    det = GoalDriftDetector(baseline=_healthy_baseline(), config=cfg)
+    risks = [det.observe(_ev("search", 5000.0, error=True)) for _ in range(10)]
+    assert sum(1 for r in risks if r is not None) == 1


### PR DESCRIPTION
## Summary

`GoalDriftDetector.observe()` latched `_fired[episode_id]` on the first threshold crossing and never cleared it — not even after the drift score dropped back below `goal_drift_score_threshold`. Only `reset()` (episode end) cleared the latch, and per #184 hosts that never call `end_episode` are a supported deployment, so a long-lived episode that recovered from one drift and later hit a second, independent one stayed silent forever.

The latch now clears when the score falls back under the threshold, mirroring the re-arm semantics of every other shipped detector (loop re-arms when the signature leaves the window; the ESN CUSUM resets to re-alarm on persistent faults). While the drift persists without an intervening recovery, the once-per-phase dedupe behavior is unchanged.

## Why it matters

A monitoring library that only ever fires once per episode for a given trigger is fail-open in the wrong direction: a recovered-then-re-drifted run is exactly the "flaky then truly stuck" pattern the detector exists to catch.

## Tests

- `test_goal_drift_rearms_after_recovery` — phase-1 drift fires once, 40 healthy steps re-arm, phase-3 drift fires again (fails on pre-fix code).
- `test_goal_drift_still_dedupes_while_drift_persists` — 10 continuously drifted events still produce exactly one risk.

Full gates pass locally: `pytest -q` (697 passed, 87.48% coverage), `mypy src tests`, `ruff check`, `ruff format --check`.

Fixes #247
