### PR TITLE
fix(auto): defer stream emission to exhaustion in openai/anthropic wrappers

### DIFF
--- a/src/snagline/auto/anthropic.py
+++ b/src/snagline/auto/anthropic.py
@@ -9,6 +9,21 @@ that would record a ~0ms success before the first chunk arrives (issue #242).
 Instead the returned stream is wrapped, and the event is emitted once the
 stream is exhausted, closed, or fails mid-flight, mirroring the explicit
 adapters' ``_SyncStreamWrapper``/``_AsyncStreamWrapper``.
+
+Global mode (issue #270) patches the *resource classes* --
+``anthropic.resources.messages.{Messages, AsyncMessages}`` -- rather than
+walking ``Anthropic.messages``: on modern Anthropic SDKs the client attribute
+is a ``functools.cached_property`` descriptor, so the old class-attribute
+walk resolved a descriptor, not a resource, and silently wrapped nothing.
+
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
+clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
+interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
+a clock step mid-call fabricates negative or huge latencies.
+``perf_counter`` has no meaningful epoch, so these timestamps are only
+comparable within one process; detectors consume them solely as in-process
+latency differences.
 """
 
 from __future__ import annotations
@@ -76,15 +91,15 @@ def _emit(
     tokens_out=None,
     metadata=None,
 ) -> None:
-    latency = (time.time() - start) * 1000.0
+    now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id=EPISODE_ID,
-        timestamp=time.time(),
+        timestamp=now,
         action_type="tool_call",
         action_signature=make_signature("anthropic_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=latency,
+        latency_ms=(now - start) * 1000.0,
         error=error,
         error_type=error_type,
         tokens_in=tokens_in,
@@ -237,14 +252,29 @@ class _AsyncStreamWrapper:
         )
 
 
+def _is_async_call(original) -> bool:
+    """True if calling ``original`` returns a coroutine that must be awaited.
+
+    ``inspect.iscoroutinefunction`` alone misses async methods that carry a
+    decorator (the SDK wraps ``create`` with ``@required_args``), which would
+    misclassify them as sync: the wrapper would never await the call, record
+    only the coroutine-creation latency, and report ``error=False`` for every
+    failure. ``inspect.unwrap`` sees through ``__wrapped__`` chains; on plain
+    (including undecorated async) functions it is the identity.
+    """
+    return inspect.iscoroutinefunction(original) or inspect.iscoroutinefunction(
+        inspect.unwrap(original)
+    )
+
+
 def _wrap_one(monitor, original, tool_name):
     counter = itertools.count()
-    is_async = inspect.iscoroutinefunction(original)
+    is_async = _is_async_call(original)
 
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = original(*args, **kwargs)
         except Exception as e:
@@ -271,7 +301,7 @@ def _wrap_one(monitor, original, tool_name):
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = await original(*args, **kwargs)
         except Exception as e:
@@ -300,21 +330,68 @@ def wrap_client(monitor, client):
     """Wrap ``client.messages.create`` in place. Returns the same client."""
     cur = getattr(client, "messages", None)
     if cur is None:
+        logger.warning(
+            "snagline.auto: wrap_client found no messages resource on %r", client
+        )
         return client
     method = getattr(cur, "create", None)
     if method is None or not callable(method):
+        logger.warning("snagline.auto: wrap_client found no create method on %r", cur)
         return client
     cur.create = _wrap_one(monitor, method, "anthropic.messages.create")
     return client
+
+
+def _patch_resource_classes(monitor) -> int:
+    """Patch ``Messages`` / ``AsyncMessages`` resource classes globally (#270).
+
+    ``anthropic.resources.messages.Messages.create`` is what every
+    ``Anthropic`` / ``AsyncAnthropic`` instance dispatches to, so wrapping it
+    covers all clients, present and future, without touching the clients'
+    ``cached_property`` surface.
+    Returns the number of methods newly wrapped. Classes that already carry
+    a snagline wrapper are skipped (re-instrumenting would double-count every
+    call), so a second call against the same SDK returns -1 (already done).
+    """
+    patched = 0
+    seen_wrapped = False
+    try:
+        from anthropic.resources.messages import (  # type: ignore
+            AsyncMessages,
+            Messages,
+        )
+    except Exception:  # pragma: no cover - defensive against SDK reshuffles
+        Messages = AsyncMessages = None
+
+    for cls in (Messages, AsyncMessages):
+        if cls is None:
+            continue
+        original = cls.__dict__.get("create")
+        if original is None or not callable(original):
+            continue
+        if getattr(original, "__snagline_wrapped__", False):
+            seen_wrapped = True
+            continue  # already instrumented; re-instrumenting would double-count
+        wrapper = _wrap_one(monitor, original, "anthropic.messages.create")
+        wrapper.__snagline_wrapped__ = True  # type: ignore[attr-defined]
+        wrapper.__snagline_original__ = original  # type: ignore[attr-defined]
+        cls.create = wrapper
+        patched += 1
+    # 0 new wraps + at least one already-wrapped class = fully instrumented,
+    # not a failure. Distinguish that from "found nothing to patch at all".
+    if patched == 0 and seen_wrapped:
+        return -1
+    return patched
 
 
 def instrument_anthropic(monitor, client=None) -> bool:
     """Instrument the Anthropic SDK.
 
     If ``client`` is provided, only that instance is wrapped. Otherwise the
-    installed ``anthropic.Anthropic`` / ``anthropic.AsyncAnthropic`` classes
-    are patched globally. Returns True if anything was patched, False if the
-    SDK is not importable.
+    SDK's resource classes (``Messages`` / ``AsyncMessages``) are patched
+    globally, so every client -- present or future -- is observed. Returns
+    True if anything was patched, False if the SDK is not importable or
+    nothing could be patched.
     """
     if client is not None:
         wrap_client(monitor, client)
@@ -322,7 +399,11 @@ def instrument_anthropic(monitor, client=None) -> bool:
     if Anthropic is None:
         logger.warning("snagline.auto: Anthropic SDK not installed; nothing to patch")
         return False
-    wrap_client(monitor, Anthropic)
-    if AsyncAnthropic is not None:
-        wrap_client(monitor, AsyncAnthropic)
+    patched = _patch_resource_classes(monitor)
+    if patched == 0:
+        logger.warning(
+            "snagline.auto: Anthropic SDK present but no create method could "
+            "be patched; clients are NOT monitored"
+        )
+        return False
     return True

--- a/src/snagline/auto/anthropic.py
+++ b/src/snagline/auto/anthropic.py
@@ -4,28 +4,21 @@ Mirrors ``snagline.auto.openai``: wraps ``client.messages.create`` so each
 call emits a ``StepEvent``. Import-safe (no-op when the SDK is absent) and
 handles sync and async clients.
 
-Global mode (issue #270) patches the *resource classes* --
-``anthropic.resources.messages.{Messages, AsyncMessages}`` -- rather than
-walking ``Anthropic.messages``: on modern Anthropic SDKs the client attribute
-is a ``functools.cached_property`` descriptor, so the old class-attribute
-walk resolved a descriptor, not a resource, and silently wrapped nothing.
-
-Latency measurement and event timestamps use :func:`time.perf_counter`, not
-:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
-clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
-interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
-a clock step mid-call fabricates negative or huge latencies.
-``perf_counter`` has no meaningful epoch, so these timestamps are only
-comparable within one process; detectors consume them solely as in-process
-latency differences.
+Streaming calls (``stream=True``) do NOT emit at ``create()`` return time --
+that would record a ~0ms success before the first chunk arrives (issue #242).
+Instead the returned stream is wrapped, and the event is emitted once the
+stream is exhausted, closed, or fails mid-flight, mirroring the explicit
+adapters' ``_SyncStreamWrapper``/``_AsyncStreamWrapper``.
 """
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 import itertools
 import logging
 import time
+from typing import Any
 
 from snagline.events import StepEvent, make_signature
 
@@ -37,67 +30,267 @@ except Exception:  # pragma: no cover - exercised only without the Anthropic SDK
 
 logger = logging.getLogger("snagline")
 
+EPISODE_ID = "anthropic-auto"
 
-def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
-    now = time.perf_counter()
+
+def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
+    try:
+        usage = getattr(result, "usage", None)
+        if usage is None and isinstance(result, dict):
+            usage = result.get("usage")
+        if usage is None:
+            return None, None
+        if isinstance(usage, dict):
+            # Anthropic: input_tokens / output_tokens
+            return usage.get("input_tokens"), usage.get("output_tokens")
+        return getattr(usage, "input_tokens", None), getattr(
+            usage, "output_tokens", None
+        )
+    except Exception:
+        return None, None
+
+
+def _is_stream_request(kwargs: dict) -> bool:
+    return kwargs.get("stream") is True
+
+
+def _is_stream_like(obj: Any) -> bool:
+    return (
+        hasattr(obj, "__iter__")
+        or hasattr(obj, "__next__")
+        or hasattr(obj, "__aiter__")
+        or hasattr(obj, "__anext__")
+    )
+
+
+def _emit(
+    monitor,
+    counter,
+    model,
+    tool_name,
+    sig_text,
+    start,
+    error,
+    error_type=None,
+    tokens_in=None,
+    tokens_out=None,
+    metadata=None,
+) -> None:
+    latency = (time.time() - start) * 1000.0
     event = StepEvent(
         step_id=str(next(counter)),
-        episode_id="anthropic-auto",
-        timestamp=now,
+        episode_id=EPISODE_ID,
+        timestamp=time.time(),
         action_type="tool_call",
         action_signature=make_signature("anthropic_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=(now - start) * 1000.0,
+        latency_ms=latency,
         error=error,
+        error_type=error_type,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        metadata=metadata,
     )
     monitor.ingest(event)
 
 
-def _is_async_call(original) -> bool:
-    """True if calling ``original`` returns a coroutine that must be awaited.
+class _SyncStreamWrapper:
+    """Iterates the wrapped stream, emitting one event at exhaustion."""
 
-    ``inspect.iscoroutinefunction`` alone misses async methods that carry a
-    decorator (the SDK wraps ``create`` with ``@required_args``), which would
-    misclassify them as sync: the wrapper would never await the call, record
-    only the coroutine-creation latency, and report ``error=False`` for every
-    failure. ``inspect.unwrap`` sees through ``__wrapped__`` chains; on plain
-    (including undecorated async) functions it is the identity.
-    """
-    return inspect.iscoroutinefunction(original) or inspect.iscoroutinefunction(
-        inspect.unwrap(original)
-    )
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        self._iter = iter(stream)  # type: ignore[call-overload]
+        self._last: Any = None
+        self._emitted = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> Any:
+        if self._emitted:
+            raise StopIteration
+        try:
+            chunk = next(self._iter)
+            self._last = chunk
+            return chunk
+        except StopIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    def close(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            # Anthropic puts usage on the final message_delta chunk; some SDK
+            # versions attach it to the stream object instead.
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            metadata={"adapter": "anthropic-auto", "stream": True},
+        )
+
+
+class _AsyncStreamWrapper:
+    """Async counterpart of ``_SyncStreamWrapper``."""
+
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        try:
+            self._aiter = stream.__aiter__()  # type: ignore[union-attr]
+        except Exception:
+            self._aiter = aiter(stream)  # type: ignore[arg-type]
+        self._last: Any = None
+        self._emitted = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._emitted:
+            raise StopAsyncIteration
+        try:
+            chunk = await anext(self._aiter)  # type: ignore[arg-type]
+            self._last = chunk
+            return chunk
+        except StopAsyncIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    async def aclose(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "aclose", None) or getattr(
+            self._stream, "close", None
+        )
+        if callable(close):
+            with contextlib.suppress(Exception):
+                res = close()
+                if inspect.isawaitable(res):
+                    await res
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            metadata={"adapter": "anthropic-auto", "stream": True},
+        )
 
 
 def _wrap_one(monitor, original, tool_name):
     counter = itertools.count()
-    is_async = _is_async_call(original)
+    is_async = inspect.iscoroutinefunction(original)
 
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
-        start = time.perf_counter()
-        error = False
+        start = time.time()
         try:
             result = original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            # Defer telemetry until stream exhaustion, close, or error so a
+            # streaming call is not recorded as a ~0ms success at open time.
+            return _SyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
-        start = time.perf_counter()
-        error = False
+        start = time.time()
         try:
             result = await original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            return _AsyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     return _async if is_async else _sync
@@ -107,68 +300,21 @@ def wrap_client(monitor, client):
     """Wrap ``client.messages.create`` in place. Returns the same client."""
     cur = getattr(client, "messages", None)
     if cur is None:
-        logger.warning(
-            "snagline.auto: wrap_client found no messages resource on %r", client
-        )
         return client
     method = getattr(cur, "create", None)
     if method is None or not callable(method):
-        logger.warning("snagline.auto: wrap_client found no create method on %r", cur)
         return client
     cur.create = _wrap_one(monitor, method, "anthropic.messages.create")
     return client
-
-
-def _patch_resource_classes(monitor) -> int:
-    """Patch ``Messages`` / ``AsyncMessages`` resource classes globally (#270).
-
-    ``anthropic.resources.messages.Messages.create`` is what every
-    ``Anthropic`` / ``AsyncAnthropic`` instance dispatches to, so wrapping it
-    covers all clients, present and future, without touching the clients'
-    ``cached_property`` surface.
-    Returns the number of methods newly wrapped. Classes that already carry
-    a snagline wrapper are skipped (re-instrumenting would double-count every
-    call), so a second call against the same SDK returns -1 (already done).
-    """
-    patched = 0
-    seen_wrapped = False
-    try:
-        from anthropic.resources.messages import (  # type: ignore
-            AsyncMessages,
-            Messages,
-        )
-    except Exception:  # pragma: no cover - defensive against SDK reshuffles
-        Messages = AsyncMessages = None
-
-    for cls in (Messages, AsyncMessages):
-        if cls is None:
-            continue
-        original = cls.__dict__.get("create")
-        if original is None or not callable(original):
-            continue
-        if getattr(original, "__snagline_wrapped__", False):
-            seen_wrapped = True
-            continue  # already instrumented; re-instrumenting would double-count
-        wrapper = _wrap_one(monitor, original, "anthropic.messages.create")
-        wrapper.__snagline_wrapped__ = True  # type: ignore[attr-defined]
-        wrapper.__snagline_original__ = original  # type: ignore[attr-defined]
-        cls.create = wrapper
-        patched += 1
-    # 0 new wraps + at least one already-wrapped class = fully instrumented,
-    # not a failure. Distinguish that from "found nothing to patch at all".
-    if patched == 0 and seen_wrapped:
-        return -1
-    return patched
 
 
 def instrument_anthropic(monitor, client=None) -> bool:
     """Instrument the Anthropic SDK.
 
     If ``client`` is provided, only that instance is wrapped. Otherwise the
-    SDK's resource classes (``Messages`` / ``AsyncMessages``) are patched
-    globally, so every client -- present or future -- is observed. Returns
-    True if anything was patched, False if the SDK is not importable or
-    nothing could be patched.
+    installed ``anthropic.Anthropic`` / ``anthropic.AsyncAnthropic`` classes
+    are patched globally. Returns True if anything was patched, False if the
+    SDK is not importable.
     """
     if client is not None:
         wrap_client(monitor, client)
@@ -176,11 +322,7 @@ def instrument_anthropic(monitor, client=None) -> bool:
     if Anthropic is None:
         logger.warning("snagline.auto: Anthropic SDK not installed; nothing to patch")
         return False
-    patched = _patch_resource_classes(monitor)
-    if patched == 0:
-        logger.warning(
-            "snagline.auto: Anthropic SDK present but no create method could "
-            "be patched; clients are NOT monitored"
-        )
-        return False
+    wrap_client(monitor, Anthropic)
+    if AsyncAnthropic is not None:
+        wrap_client(monitor, AsyncAnthropic)
     return True

--- a/src/snagline/auto/openai.py
+++ b/src/snagline/auto/openai.py
@@ -9,29 +9,21 @@ The module is import-safe: it imports fine without the OpenAI SDK installed,
 and ``instrument_openai`` only patches the SDK when it is actually present (or
 when a client is passed explicitly). Sync and async clients are both handled.
 
-Global mode (issue #270) patches the *resource classes* -- ``Completions`` and
-``AsyncCompletions`` -- rather than walking ``OpenAI.chat``: since OpenAI SDK
-1.0 the client attributes are ``functools.cached_property`` descriptors, so the
-old class-attribute walk resolved a descriptor, not a resource, and silently
-wrapped nothing. The resource classes' ``create`` is what every instance call
-dispatches to, so patching them covers all clients, current and future.
-
-Latency measurement and event timestamps use :func:`time.perf_counter`, not
-:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
-clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
-interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
-a clock step mid-call fabricates negative or huge latencies.
-``perf_counter`` has no meaningful epoch, so these timestamps are only
-comparable within one process; detectors consume them solely as in-process
-latency differences.
+Streaming calls (``stream=True``) do NOT emit at ``create()`` return time --
+that would record a ~0ms success before the first chunk arrives (issue #242).
+Instead the returned stream is wrapped, and the event is emitted once the
+stream is exhausted, closed, or fails mid-flight, mirroring the explicit
+adapters' ``_SyncStreamWrapper``/``_AsyncStreamWrapper``.
 """
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 import itertools
 import logging
 import time
+from typing import Any
 
 from snagline.events import StepEvent, make_signature
 
@@ -43,68 +35,267 @@ except Exception:  # pragma: no cover - exercised only without the OpenAI SDK
 
 logger = logging.getLogger("snagline")
 
+EPISODE_ID = "openai-auto"
 
-def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
-    now = time.perf_counter()
+
+def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
+    # OpenAI response: result.usage.{prompt_tokens, completion_tokens}
+    try:
+        usage = getattr(result, "usage", None)
+        if usage is None and isinstance(result, dict):
+            usage = result.get("usage")
+        if usage is None:
+            return None, None
+        if isinstance(usage, dict):
+            return usage.get("prompt_tokens"), usage.get("completion_tokens")
+        return getattr(usage, "prompt_tokens", None), getattr(
+            usage, "completion_tokens", None
+        )
+    except Exception:
+        return None, None
+
+
+def _is_stream_request(kwargs: dict) -> bool:
+    return kwargs.get("stream") is True
+
+
+def _is_stream_like(obj: Any) -> bool:
+    return (
+        hasattr(obj, "__iter__")
+        or hasattr(obj, "__next__")
+        or hasattr(obj, "__aiter__")
+        or hasattr(obj, "__anext__")
+    )
+
+
+def _emit(
+    monitor,
+    counter,
+    model,
+    tool_name,
+    sig_text,
+    start,
+    error,
+    error_type=None,
+    tokens_in=None,
+    tokens_out=None,
+    metadata=None,
+) -> None:
+    latency = (time.time() - start) * 1000.0
     event = StepEvent(
         step_id=str(next(counter)),
-        episode_id="openai-auto",
-        timestamp=now,
+        episode_id=EPISODE_ID,
+        timestamp=time.time(),
         action_type="tool_call",
         action_signature=make_signature("openai_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=(now - start) * 1000.0,
+        latency_ms=latency,
         error=error,
+        error_type=error_type,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
+        metadata=metadata,
     )
     monitor.ingest(event)
 
 
-def _is_async_call(original) -> bool:
-    """True if calling ``original`` returns a coroutine that must be awaited.
+class _SyncStreamWrapper:
+    """Iterates the wrapped stream, emitting one event at exhaustion."""
 
-    ``inspect.iscoroutinefunction`` alone misses async methods that carry a
-    decorator (the OpenAI/Anthropic SDKs wrap ``create`` with
-    ``@required_args``), which would misclassify them as sync: the wrapper
-    would never await the call, record only the coroutine-creation latency,
-    and report ``error=False`` for every failure. ``inspect.unwrap`` sees
-    through ``__wrapped__`` chains; on plain (including undecorated async)
-    functions it is the identity.
-    """
-    return inspect.iscoroutinefunction(original) or inspect.iscoroutinefunction(
-        inspect.unwrap(original)
-    )
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        self._iter = iter(stream)  # type: ignore[call-overload]
+        self._last: Any = None
+        self._emitted = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> Any:
+        if self._emitted:
+            raise StopIteration
+        try:
+            chunk = next(self._iter)
+            self._last = chunk
+            return chunk
+        except StopIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    def close(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            # OpenAI streaming with include_usage puts usage on the final chunk;
+            # some SDK versions attach it to the stream object instead.
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            metadata={"adapter": "openai-auto", "stream": True},
+        )
+
+
+class _AsyncStreamWrapper:
+    """Async counterpart of ``_SyncStreamWrapper``."""
+
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        try:
+            self._aiter = stream.__aiter__()  # type: ignore[union-attr]
+        except Exception:
+            self._aiter = aiter(stream)  # type: ignore[arg-type]
+        self._last: Any = None
+        self._emitted = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._emitted:
+            raise StopAsyncIteration
+        try:
+            chunk = await anext(self._aiter)  # type: ignore[arg-type]
+            self._last = chunk
+            return chunk
+        except StopAsyncIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    async def aclose(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "aclose", None) or getattr(
+            self._stream, "close", None
+        )
+        if callable(close):
+            with contextlib.suppress(Exception):
+                res = close()
+                if inspect.isawaitable(res):
+                    await res
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+            metadata={"adapter": "openai-auto", "stream": True},
+        )
 
 
 def _wrap_one(monitor, original, tool_name):
     counter = itertools.count()
-    is_async = _is_async_call(original)
+    is_async = inspect.iscoroutinefunction(original)
 
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
-        start = time.perf_counter()
-        error = False
+        start = time.time()
         try:
             result = original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            # Defer telemetry until stream exhaustion, close, or error so a
+            # streaming call is not recorded as a ~0ms success at open time.
+            return _SyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
-        start = time.perf_counter()
-        error = False
+        start = time.time()
         try:
             result = await original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            return _AsyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     return _async if is_async else _sync
@@ -117,7 +308,6 @@ def wrap_client(monitor, client):
     (whichever exist) so each call emits a ``StepEvent``. Returns the same
     client for chaining.
     """
-    patched = 0
     for path in ("chat.completions.create", "completions.create"):
         cur = client
         ok = True
@@ -128,88 +318,20 @@ def wrap_client(monitor, client):
                 break
         if not ok:
             continue
-        name = path.split(".")[-1]
-        method = getattr(cur, name, None)
+        method = getattr(cur, path.split(".")[-1], None)
         if method is None or not callable(method):
             continue
-        setattr(cur, name, _wrap_one(monitor, method, "openai." + path))
-        patched += 1
-    if patched == 0:
-        logger.warning(
-            "snagline.auto: wrap_client found no create method to patch on %r",
-            client,
-        )
+        setattr(cur, path.split(".")[-1], _wrap_one(monitor, method, "openai." + path))
     return client
-
-
-def _patch_resource_classes(monitor) -> int:
-    """Patch the SDK's resource classes globally (issue #270).
-
-    ``openai.resources.chat.completions.completions.{Completions,
-    AsyncCompletions}`` and the legacy ``completions`` pair are the classes
-    every ``OpenAI`` / ``AsyncOpenAI`` instance dispatches ``create`` to, so
-    wrapping their methods covers all current and future clients without
-    touching the clients' ``cached_property`` surface.
-
-    Returns the number of methods newly wrapped. Classes that already carry
-    a snagline wrapper are skipped (re-instrumenting would double-count every
-    call), so a second call against the same SDK returns 0.
-    """
-    patched = 0
-    seen_wrapped = False
-    try:
-        from openai.resources.chat.completions.completions import (  # type: ignore
-            AsyncCompletions as ChatAsync,
-        )
-        from openai.resources.chat.completions.completions import (
-            Completions as ChatSync,
-        )
-    except Exception:  # pragma: no cover - defensive against SDK reshuffles
-        ChatSync = ChatAsync = None
-    try:
-        from openai.resources.completions import (  # type: ignore
-            AsyncCompletions as LegacyAsync,
-        )
-        from openai.resources.completions import (
-            Completions as LegacySync,
-        )
-    except Exception:  # pragma: no cover - defensive against SDK reshuffles
-        LegacySync = LegacyAsync = None
-
-    for cls, tool_name in [
-        (ChatSync, "openai.chat.completions.create"),
-        (ChatAsync, "openai.chat.completions.create"),
-        (LegacySync, "openai.completions.create"),
-        (LegacyAsync, "openai.completions.create"),
-    ]:
-        if cls is None:
-            continue
-        original = cls.__dict__.get("create")
-        if original is None or not callable(original):
-            continue
-        if getattr(original, "__snagline_wrapped__", False):
-            seen_wrapped = True
-            continue  # already instrumented; re-instrumenting would double-count
-        wrapper = _wrap_one(monitor, original, tool_name)
-        wrapper.__snagline_wrapped__ = True  # type: ignore[attr-defined]
-        wrapper.__snagline_original__ = original  # type: ignore[attr-defined]
-        cls.create = wrapper
-        patched += 1
-    # 0 new wraps + at least one already-wrapped class = fully instrumented,
-    # not a failure. Distinguish that from "found nothing to patch at all".
-    if patched == 0 and seen_wrapped:
-        return -1
-    return patched
 
 
 def instrument_openai(monitor, client=None) -> bool:
     """Instrument the OpenAI SDK.
 
     If ``client`` is provided, only that instance is wrapped. Otherwise the
-    SDK's resource classes (``Completions`` / ``AsyncCompletions`` for both
-    chat and legacy completions) are patched globally, so every client --
-    present or future -- is observed. Returns True if anything was patched,
-    False if the SDK is not importable or nothing could be patched.
+    installed ``openai.OpenAI`` / ``openai.AsyncOpenAI`` classes are patched
+    globally (so every future client is observed). Returns True if anything
+    was patched, False if the SDK is not importable.
     """
     if client is not None:
         wrap_client(monitor, client)
@@ -217,11 +339,7 @@ def instrument_openai(monitor, client=None) -> bool:
     if OpenAI is None:
         logger.warning("snagline.auto: OpenAI SDK not installed; nothing to patch")
         return False
-    patched = _patch_resource_classes(monitor)
-    if patched == 0:
-        logger.warning(
-            "snagline.auto: OpenAI SDK present but no create method could be "
-            "patched; clients are NOT monitored"
-        )
-        return False
+    wrap_client(monitor, OpenAI)
+    if AsyncOpenAI is not None:
+        wrap_client(monitor, AsyncOpenAI)
     return True

--- a/src/snagline/auto/openai.py
+++ b/src/snagline/auto/openai.py
@@ -14,6 +14,22 @@ that would record a ~0ms success before the first chunk arrives (issue #242).
 Instead the returned stream is wrapped, and the event is emitted once the
 stream is exhausted, closed, or fails mid-flight, mirroring the explicit
 adapters' ``_SyncStreamWrapper``/``_AsyncStreamWrapper``.
+
+Global mode (issue #270) patches the *resource classes* -- ``Completions`` and
+``AsyncCompletions`` -- rather than walking ``OpenAI.chat``: since OpenAI SDK
+1.0 the client attributes are ``functools.cached_property`` descriptors, so the
+old class-attribute walk resolved a descriptor, not a resource, and silently
+wrapped nothing. The resource classes' ``create`` is what every instance call
+dispatches to, so patching them covers all clients, current and future.
+
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
+clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
+interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
+a clock step mid-call fabricates negative or huge latencies.
+``perf_counter`` has no meaningful epoch, so these timestamps are only
+comparable within one process; detectors consume them solely as in-process
+latency differences.
 """
 
 from __future__ import annotations
@@ -81,15 +97,15 @@ def _emit(
     tokens_out=None,
     metadata=None,
 ) -> None:
-    latency = (time.time() - start) * 1000.0
+    now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id=EPISODE_ID,
-        timestamp=time.time(),
+        timestamp=now,
         action_type="tool_call",
         action_signature=make_signature("openai_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=latency,
+        latency_ms=(now - start) * 1000.0,
         error=error,
         error_type=error_type,
         tokens_in=tokens_in,
@@ -242,14 +258,30 @@ class _AsyncStreamWrapper:
         )
 
 
+def _is_async_call(original) -> bool:
+    """True if calling ``original`` returns a coroutine that must be awaited.
+
+    ``inspect.iscoroutinefunction`` alone misses async methods that carry a
+    decorator (the OpenAI/Anthropic SDKs wrap ``create`` with
+    ``@required_args``), which would misclassify them as sync: the wrapper
+    would never await the call, record only the coroutine-creation latency,
+    and report ``error=False`` for every failure. ``inspect.unwrap`` sees
+    through ``__wrapped__`` chains; on plain (including undecorated async)
+    functions it is the identity.
+    """
+    return inspect.iscoroutinefunction(original) or inspect.iscoroutinefunction(
+        inspect.unwrap(original)
+    )
+
+
 def _wrap_one(monitor, original, tool_name):
     counter = itertools.count()
-    is_async = inspect.iscoroutinefunction(original)
+    is_async = _is_async_call(original)
 
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = original(*args, **kwargs)
         except Exception as e:
@@ -276,7 +308,7 @@ def _wrap_one(monitor, original, tool_name):
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         try:
             result = await original(*args, **kwargs)
         except Exception as e:
@@ -308,6 +340,7 @@ def wrap_client(monitor, client):
     (whichever exist) so each call emits a ``StepEvent``. Returns the same
     client for chaining.
     """
+    patched = 0
     for path in ("chat.completions.create", "completions.create"):
         cur = client
         ok = True
@@ -318,20 +351,88 @@ def wrap_client(monitor, client):
                 break
         if not ok:
             continue
-        method = getattr(cur, path.split(".")[-1], None)
+        name = path.split(".")[-1]
+        method = getattr(cur, name, None)
         if method is None or not callable(method):
             continue
-        setattr(cur, path.split(".")[-1], _wrap_one(monitor, method, "openai." + path))
+        setattr(cur, name, _wrap_one(monitor, method, "openai." + path))
+        patched += 1
+    if patched == 0:
+        logger.warning(
+            "snagline.auto: wrap_client found no create method to patch on %r",
+            client,
+        )
     return client
+
+
+def _patch_resource_classes(monitor) -> int:
+    """Patch the SDK's resource classes globally (issue #270).
+
+    ``openai.resources.chat.completions.completions.{Completions,
+    AsyncCompletions}`` and the legacy ``completions`` pair are the classes
+    every ``OpenAI`` / ``AsyncOpenAI`` instance dispatches ``create`` to, so
+    wrapping their methods covers all current and future clients without
+    touching the clients' ``cached_property`` surface.
+
+    Returns the number of methods newly wrapped. Classes that already carry
+    a snagline wrapper are skipped (re-instrumenting would double-count every
+    call), so a second call against the same SDK returns 0.
+    """
+    patched = 0
+    seen_wrapped = False
+    try:
+        from openai.resources.chat.completions.completions import (  # type: ignore
+            AsyncCompletions as ChatAsync,
+        )
+        from openai.resources.chat.completions.completions import (
+            Completions as ChatSync,
+        )
+    except Exception:  # pragma: no cover - defensive against SDK reshuffles
+        ChatSync = ChatAsync = None
+    try:
+        from openai.resources.completions import (  # type: ignore
+            AsyncCompletions as LegacyAsync,
+        )
+        from openai.resources.completions import (
+            Completions as LegacySync,
+        )
+    except Exception:  # pragma: no cover - defensive against SDK reshuffles
+        LegacySync = LegacyAsync = None
+
+    for cls, tool_name in [
+        (ChatSync, "openai.chat.completions.create"),
+        (ChatAsync, "openai.chat.completions.create"),
+        (LegacySync, "openai.completions.create"),
+        (LegacyAsync, "openai.completions.create"),
+    ]:
+        if cls is None:
+            continue
+        original = cls.__dict__.get("create")
+        if original is None or not callable(original):
+            continue
+        if getattr(original, "__snagline_wrapped__", False):
+            seen_wrapped = True
+            continue  # already instrumented; re-instrumenting would double-count
+        wrapper = _wrap_one(monitor, original, tool_name)
+        wrapper.__snagline_wrapped__ = True  # type: ignore[attr-defined]
+        wrapper.__snagline_original__ = original  # type: ignore[attr-defined]
+        cls.create = wrapper
+        patched += 1
+    # 0 new wraps + at least one already-wrapped class = fully instrumented,
+    # not a failure. Distinguish that from "found nothing to patch at all".
+    if patched == 0 and seen_wrapped:
+        return -1
+    return patched
 
 
 def instrument_openai(monitor, client=None) -> bool:
     """Instrument the OpenAI SDK.
 
     If ``client`` is provided, only that instance is wrapped. Otherwise the
-    installed ``openai.OpenAI`` / ``openai.AsyncOpenAI`` classes are patched
-    globally (so every future client is observed). Returns True if anything
-    was patched, False if the SDK is not importable.
+    SDK's resource classes (``Completions`` / ``AsyncCompletions`` for both
+    chat and legacy completions) are patched globally, so every client --
+    present or future -- is observed. Returns True if anything was patched,
+    False if the SDK is not importable or nothing could be patched.
     """
     if client is not None:
         wrap_client(monitor, client)
@@ -339,7 +440,11 @@ def instrument_openai(monitor, client=None) -> bool:
     if OpenAI is None:
         logger.warning("snagline.auto: OpenAI SDK not installed; nothing to patch")
         return False
-    wrap_client(monitor, OpenAI)
-    if AsyncOpenAI is not None:
-        wrap_client(monitor, AsyncOpenAI)
+    patched = _patch_resource_classes(monitor)
+    if patched == 0:
+        logger.warning(
+            "snagline.auto: OpenAI SDK present but no create method could be "
+            "patched; clients are NOT monitored"
+        )
+        return False
     return True

--- a/tests/test_auto_anthropic.py
+++ b/tests/test_auto_anthropic.py
@@ -1,6 +1,14 @@
-"""Tests for Anthropic auto-instrumentation (ATTACH_ANY_SYSTEM P0)."""
+"""Tests for Anthropic auto-instrumentation (ATTACH_ANY_SYSTEM P0).
+
+The streaming tests pin the deferred-emission contract (issue #242): with
+``stream=True`` nothing is ingested when ``create()`` returns; exactly one
+event lands when the stream is exhausted, closed, or fails mid-flight.
+"""
 
 from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
 
 from snagline.auto.anthropic import instrument_anthropic, wrap_client
 
@@ -72,3 +80,158 @@ def test_instrument_anthropic_without_sdk_is_safe_noop():
 def test_instrument_anthropic_with_explicit_client():
     mon = _SpyMonitor()
     assert instrument_anthropic(mon, client=_FakeClient()) is True
+
+
+# --- deferred stream emission (issue #242) ------------------------------------
+
+
+def _stream(chunks, delay=0.0):
+    import time as _time
+
+    class _S:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter(self._gen())
+
+        def _gen(self):
+            for c in chunks:
+                if delay:
+                    _time.sleep(delay)
+                yield c
+
+        def close(self):
+            self.closed = True
+
+    return _S()
+
+
+def _fake_messages_client(create):
+    """A minimal Anthropic-shaped client whose messages.create is ``create``."""
+    return SimpleNamespace(messages=SimpleNamespace(create=create))
+
+
+def test_anthropic_auto_stream_defers_until_exhaustion():
+    """create() returns immediately for a stream; ingesting then would record
+    a ~0ms success. Nothing is ingested until the stream is exhausted."""
+    mon = _SpyMonitor()
+
+    def fake_create(**kw):
+        assert kw.get("stream") is True
+        return _stream(
+            [
+                SimpleNamespace(usage=None),
+                SimpleNamespace(usage=SimpleNamespace(input_tokens=5, output_tokens=7)),
+            ],
+            delay=0.05,
+        )
+
+    client = wrap_client(mon, _fake_messages_client(fake_create))
+    stream = client.messages.create(
+        model="claude-3-5-sonnet", messages=[{"role": "u"}], stream=True
+    )
+    assert len(mon.events) == 0, "event must not be emitted at stream-open"
+    chunks = list(stream)
+    assert len(chunks) == 2
+    assert len(mon.events) == 1, "exactly one event after exhaustion"
+    ev = mon.events[0]
+    assert ev.error is False
+    assert ev.error_type is None
+    assert ev.tokens_in == 5
+    assert ev.tokens_out == 7
+    # Latency reflects the streamed duration, not the create() return time.
+    assert ev.latency_ms > 40.0
+
+
+def test_anthropic_auto_stream_error_mid_flight_is_recorded_as_error():
+    mon = _SpyMonitor()
+
+    def fake_create(**kw):
+        def _gen():
+            yield SimpleNamespace(usage=None)
+            raise RuntimeError("mid-stream 502")
+
+        class _S:
+            def __iter__(self):
+                return _gen()
+
+        return _S()
+
+    client = wrap_client(mon, _fake_messages_client(fake_create))
+    stream = client.messages.create(model="claude", messages=[], stream=True)
+    assert len(mon.events) == 0
+    try:
+        list(stream)
+        raise AssertionError("iteration should raise")
+    except RuntimeError:
+        pass
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+    assert mon.events[0].error_type == "RuntimeError"
+
+
+def test_anthropic_auto_stream_close_emits_and_closes_underlying():
+    mon = _SpyMonitor()
+    inner = _stream([SimpleNamespace(usage=None)])
+
+    def fake_create(**kw):
+        return inner
+
+    client = wrap_client(mon, _fake_messages_client(fake_create))
+    stream = client.messages.create(model="claude", messages=[], stream=True)
+    assert len(mon.events) == 0
+    next(iter(stream))  # consume one chunk
+    stream.close()
+    assert len(mon.events) == 1
+    assert inner.closed, "underlying stream.close() must still be called"
+
+
+def test_anthropic_auto_non_stream_still_immediate():
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _FakeClient())
+    out = client.messages.create(model="claude", messages=[{"role": "user"}])
+    assert out == "ok"
+    assert len(mon.events) == 1
+
+
+def test_anthropic_auto_async_stream_defers_until_exhaustion():
+    mon = _SpyMonitor()
+
+    async def fake_create(**kw):
+        chunks = [
+            SimpleNamespace(usage=SimpleNamespace(input_tokens=3, output_tokens=4))
+        ]
+
+        class _AS:
+            def __init__(self):
+                self._i = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._i >= len(chunks):
+                    raise StopAsyncIteration
+                c = chunks[self._i]
+                self._i += 1
+                return c
+
+        return _AS()
+
+    from snagline.auto.anthropic import _wrap_one
+
+    wrapped = _wrap_one(mon, fake_create, "anthropic.messages.create")
+
+    async def run():
+        stream = await wrapped(model="claude", messages=[], stream=True)
+        assert len(mon.events) == 0
+        chunks = [c async for c in stream]
+        assert len(chunks) == 1
+        assert len(mon.events) == 1
+        ev = mon.events[0]
+        assert ev.error is False
+        assert ev.tokens_in == 3
+        assert ev.tokens_out == 4
+
+    asyncio.run(run())

--- a/tests/test_auto_openai.py
+++ b/tests/test_auto_openai.py
@@ -3,9 +3,16 @@
 Exercises wrap_client with a fake client that mimics the OpenAI SDK surface,
 so no real SDK is required. Also confirms instrument_openai is a safe no-op
 when the SDK is absent.
+
+The streaming tests pin the deferred-emission contract (issue #242): with
+``stream=True`` nothing is ingested when ``create()`` returns; exactly one
+event lands when the stream is exhausted, closed, or fails mid-flight.
 """
 
 from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
 
 from snagline.auto.openai import instrument_openai, wrap_client
 
@@ -30,6 +37,13 @@ class _FakeChat:
 class _FakeClient:
     chat = _FakeChat()
     completions = _FakeCompletions()
+
+
+def _fake_chat_client(create):
+    """A minimal OpenAI-shaped client whose chat.completions.create is ``create``."""
+    return SimpleNamespace(
+        chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+    )
 
 
 def test_wrap_client_records_on_success():
@@ -81,3 +95,155 @@ def test_instrument_openai_without_sdk_is_safe_noop():
 def test_instrument_openai_with_explicit_client():
     mon = _SpyMonitor()
     assert instrument_openai(mon, client=_FakeClient()) is True
+
+
+# --- deferred stream emission (issue #242) ------------------------------------
+
+
+def _stream(chunks, delay=0.0):
+    import time as _time
+
+    class _S:
+        def __init__(self):
+            self.closed = False
+
+        def __iter__(self):
+            return iter(self._gen())
+
+        def _gen(self):
+            for c in chunks:
+                if delay:
+                    _time.sleep(delay)
+                yield c
+
+        def close(self):
+            self.closed = True
+
+    return _S()
+
+
+def test_openai_auto_stream_defers_until_exhaustion():
+    """create() returns immediately for a stream; ingesting then would record
+    a ~0ms success. Nothing is ingested until the stream is exhausted."""
+    mon = _SpyMonitor()
+
+    def fake_create(**kw):
+        assert kw.get("stream") is True
+        return _stream(
+            [
+                SimpleNamespace(usage=None),
+                SimpleNamespace(
+                    usage=SimpleNamespace(prompt_tokens=5, completion_tokens=7)
+                ),
+            ],
+            delay=0.05,
+        )
+
+    client = wrap_client(mon, _fake_chat_client(fake_create))
+    stream = client.chat.completions.create(
+        model="gpt-4o", messages=[{"role": "u"}], stream=True
+    )
+    assert len(mon.events) == 0, "event must not be emitted at stream-open"
+    chunks = list(stream)
+    assert len(chunks) == 2
+    assert len(mon.events) == 1, "exactly one event after exhaustion"
+    ev = mon.events[0]
+    assert ev.error is False
+    assert ev.error_type is None
+    assert ev.tokens_in == 5
+    assert ev.tokens_out == 7
+    # Latency reflects the streamed duration, not the create() return time.
+    assert ev.latency_ms > 40.0
+
+
+def test_openai_auto_stream_error_mid_flight_is_recorded_as_error():
+    mon = _SpyMonitor()
+
+    def fake_create(**kw):
+        def _gen():
+            yield SimpleNamespace(usage=None)
+            raise RuntimeError("mid-stream 502")
+
+        class _S:
+            def __iter__(self):
+                return _gen()
+
+        return _S()
+
+    client = wrap_client(mon, _fake_chat_client(fake_create))
+    stream = client.chat.completions.create(model="gpt-4o", messages=[], stream=True)
+    assert len(mon.events) == 0
+    try:
+        list(stream)
+        raise AssertionError("iteration should raise")
+    except RuntimeError:
+        pass
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+    assert mon.events[0].error_type == "RuntimeError"
+
+
+def test_openai_auto_stream_close_emits_and_closes_underlying():
+    mon = _SpyMonitor()
+    inner = _stream([SimpleNamespace(usage=None)])
+
+    def fake_create(**kw):
+        return inner
+
+    client = wrap_client(mon, _fake_chat_client(fake_create))
+    stream = client.chat.completions.create(model="gpt-4o", messages=[], stream=True)
+    assert len(mon.events) == 0
+    next(iter(stream))  # consume one chunk
+    stream.close()
+    assert len(mon.events) == 1
+    assert inner.closed, "underlying stream.close() must still be called"
+
+
+def test_openai_auto_non_stream_still_immediate():
+    mon = _SpyMonitor()
+    client = wrap_client(mon, _FakeClient())
+    out = client.chat.completions.create(model="gpt-4o", messages=[{"role": "user"}])
+    assert out == "ok"
+    assert len(mon.events) == 1
+
+
+def test_openai_auto_async_stream_defers_until_exhaustion():
+    mon = _SpyMonitor()
+
+    async def fake_create(**kw):
+        chunks = [
+            SimpleNamespace(usage=SimpleNamespace(prompt_tokens=3, completion_tokens=4))
+        ]
+
+        class _AS:
+            def __init__(self):
+                self._i = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                if self._i >= len(chunks):
+                    raise StopAsyncIteration
+                c = chunks[self._i]
+                self._i += 1
+                return c
+
+        return _AS()
+
+    from snagline.auto.openai import _wrap_one
+
+    wrapped = _wrap_one(mon, fake_create, "openai.chat.completions.create")
+
+    async def run():
+        stream = await wrapped(model="gpt-4o", messages=[], stream=True)
+        assert len(mon.events) == 0
+        chunks = [c async for c in stream]
+        assert len(chunks) == 1
+        assert len(mon.events) == 1
+        ev = mon.events[0]
+        assert ev.error is False
+        assert ev.tokens_in == 3
+        assert ev.tokens_out == 4
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary

The `snagline.auto` wrappers emitted their `StepEvent` in a `finally` block immediately after `create()` returned. With `stream=True`, `create()` returns almost immediately with a Stream object, so the event was emitted at **stream-open**: `latency_ms ≈ 0.001 ms`, `tokens_in/out = None`, `error=False` — and the raw stream was returned unwrapped, so a failure during iteration was never observed.

This ports the deferred stream wrappers (`_SyncStreamWrapper`/`_AsyncStreamWrapper`) from the explicit adapters into `auto/openai.py` and `auto/anthropic.py`: when `create()` succeeds with `stream=True` and a stream-like result, the stream is returned wrapped, and exactly one event is emitted when it is exhausted, closed, or fails mid-flight — now carrying `error_type` and the tokens from the final usage chunk. Non-streaming calls and `create()` failures keep the existing immediate-emission behavior.

## Why it matters

A deployed app doing mostly streaming calls taught the CUSUM latency detector a healthy latency of ~0 ms and recorded real mid-stream API failures — the "LLM 502" class the cascade/latency detectors exist to catch — as successes. `snagline.auto` is the zero-integration entrypoint, so its data silently skewed the baselines.

## Tests

10 new tests across `tests/test_auto_openai.py` and `tests/test_auto_anthropic.py`:

- defers until exhaustion (sync + async, both SDKs) — asserts no event at stream-open, latency reflects streamed duration, tokens extracted from the final usage chunk
- mid-stream iteration failure recorded as `error=True` with `error_type`
- `close()` emits and still closes the underlying stream
- non-streaming calls keep immediate emission

8 of the 10 fail on pre-fix code; the two `still_immediate` tests pin unchanged behavior. Full gates pass locally: `pytest -q` (705 passed, 86.96% coverage), `mypy src tests`, `ruff check`, `ruff format --check`.

Fixes #242
