### PR TITLE
fix(monitor): only move the episode clock's last_ts forward

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -96,7 +96,7 @@ class _EpisodeClock:
 
     def __init__(self, first_ts: float) -> None:
         self.last_ts = first_ts
-        self.elapsed = 0.0  # sum of positive inter-event deltas
+        self.elapsed = 0.0  # wall-clock span covered; last_ts only moves fwd
         self.idle_fired = False  # "idle_gap" fires once per episode
         self.warned = False  # budget warning fires once per episode
         self.breached = False  # budget breach fires once per episode
@@ -397,7 +397,16 @@ class Monitor:
                 self._clocks[event.episode_id] = _EpisodeClock(event.timestamp)
                 return out
             delta = event.timestamp - clock.last_ts
-            clock.last_ts = event.timestamp
+            if delta > 0.0:
+                # Out-of-order or skewed sources (merged adapter streams, clock
+                # skew between hook processes) must not reduce consumed budget
+                # -- and must not rewind ``last_ts`` either: rewinding makes
+                # the *next* event measure its delta from the moved-back
+                # reference, counting an already-counted span a second time
+                # (issue #249). ``last_ts`` only moves forward, so a late
+                # event neither spends nor un-spends budget.
+                clock.elapsed += delta
+                clock.last_ts = event.timestamp
             if (
                 self._idle_warn_seconds is not None
                 and not clock.idle_fired
@@ -415,10 +424,6 @@ class Monitor:
                         event.timestamp,
                     )
                 )
-            if delta > 0.0:
-                # Negative deltas (out-of-order or skewed sources) must not
-                # reduce consumed budget; clamp them out of the accumulation.
-                clock.elapsed += delta
             budget = self._max_wall_seconds
             if budget is not None:
                 if not clock.breached and clock.elapsed >= budget:

--- a/tests/test_horizon_time_axis.py
+++ b/tests/test_horizon_time_axis.py
@@ -152,6 +152,49 @@ def test_negative_delta_does_not_refund_budget() -> None:
     assert len(breaches) == 1
 
 
+def test_out_of_order_events_do_not_double_count_the_same_span() -> None:
+    """Issue #249: a negative delta was excluded from ``elapsed`` but still
+    rewound ``last_ts``, so the next event measured its delta from the moved-
+    back reference and counted an already-counted span a second time. Events
+    at ts 0, 60, 0, 60 -- a 60-second true span, the second half a skewed
+    replay of the same range -- used to yield ``elapsed == 120`` and breach a
+    100 s budget. ``last_ts`` must only move forward.
+    """
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=100.0)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 60.0),
+        _event("s3", 0.0),  # skewed backwards: rewinds nothing now
+        _event("s4", 60.0),  # delta measured from 60, not from 0
+    )
+    clock = m._clocks["ep1"]
+    assert clock.elapsed == 60.0, "the same wall-clock span was counted twice"
+    assert clock.last_ts == 60.0, "last_ts must not move backwards"
+    assert sink.risks == [], "60s of real time must not breach a 100s budget"
+
+
+def test_out_of_order_replay_still_counts_genuinely_new_time() -> None:
+    """The fix must not under-count either: after a backwards event, a delta
+    past the previous high-water mark is real new time and still spends
+    budget."""
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=100.0)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 60.0),
+        _event("s3", 0.0),
+        _event("s4", 150.0),  # 90s past the high-water mark of 60
+    )
+    breaches = [
+        r for r in sink.risks if r.trigger == "wall_clock_budget" and r.score == 1.0
+    ]
+    assert len(breaches) == 1, "genuinely new time must still breach"
+    assert m._clocks["ep1"].elapsed == 150.0
+
+
 # --- determinism / fail-open / region contract ------------------------------
 
 


### PR DESCRIPTION
## Summary

`_advance_clock` computed `delta = event.timestamp - clock.last_ts` and **always** rewound `last_ts` to the event timestamp — including when the delta was negative. The negative delta was correctly excluded from `elapsed`, but `last_ts` was still moved backwards, so the *next* event measured its delta from the rewound reference and accumulated a positive span that was **already counted once**.

`last_ts` now only moves forward: a late event neither spends nor un-spends budget, and never re-opens an already-counted span. Genuinely new time past the previous high-water mark still spends budget as before.

## Why it matters

`wall_clock_budget` is a hard enforcement trigger (score 1.0, halt-policy routing by trigger name). A premature breach fires the strongest severity SNAGLINE has on an episode that has consumed less budget than reported. Reproduced on `master` with `max_episode_wall_seconds=100`: events at ts `0, 60, 0, 60` (a 60-second true span) yielded `elapsed == 120.0` and both the 0.7 warning and the 1.0 breach. Not covered by #172 (persistence across restarts) or #224 (warning/breach ordering).

## Tests

- `test_out_of_order_events_do_not_double_count_the_same_span` — ts `0, 60, 0, 60` yields `elapsed == 60`, `last_ts == 60`, no risks on a 100 s budget (fails pre-fix).
- `test_out_of_order_replay_still_counts_genuinely_new_time` — after a backwards event, a delta past the high-water mark still breaches (fails pre-fix because of the double-count distortion).

Full gates pass locally: `pytest -q` (697 passed, 87.48% coverage), `mypy src tests`, `ruff check`, `ruff format --check`.

Fixes #249
