### PR TITLE
fix(cli): honor --min-severity for --sink webhook and validate the value

### DIFF
--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -139,7 +139,7 @@ def _build_sinks(args: argparse.Namespace, cfg: Config) -> list[AlertSink]:
             raise SystemExit(2)
         from snagline.sinks.webhook import WebhookSink
 
-        sinks.append(WebhookSink(args.webhook_url))
+        sinks.append(WebhookSink(args.webhook_url, min_severity=args.min_severity))
     elif args.sink == "slack":
         if not args.slack_url:
             print("--slack-url is required with --sink slack", file=sys.stderr)
@@ -244,6 +244,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_watch.add_argument(
         "--min-severity",
         default=None,
+        choices=("info", "warning", "critical"),
         help="Only escalate risks at or above this severity "
         "(info|warning|critical). Optional.",
     )
@@ -359,6 +360,7 @@ def _build_parser() -> argparse.ArgumentParser:
     p_serve.add_argument(
         "--min-severity",
         default=None,
+        choices=("info", "warning", "critical"),
         help="Only escalate risks at or above this severity "
         "(info|warning|critical). Optional.",
     )

--- a/src/snagline/sinks/webhook.py
+++ b/src/snagline/sinks/webhook.py
@@ -17,19 +17,44 @@ import logging
 import urllib.request
 from typing import Any
 
-from snagline.risk import FailureRisk
+from snagline.risk import (
+    SEVERITY_CRITICAL,
+    SEVERITY_INFO,
+    SEVERITY_WARNING,
+    FailureRisk,
+)
 
 logger = logging.getLogger("snagline")
+
+_SEVERITY_ORDER = {
+    SEVERITY_INFO: 0,
+    SEVERITY_WARNING: 1,
+    SEVERITY_CRITICAL: 2,
+}
+
+
+def _order(severity: str) -> int:
+    return _SEVERITY_ORDER.get(severity, 1)
 
 
 class WebhookSink:
     """POSTs each ``FailureRisk`` as JSON to ``url`` and ignores any failure."""
 
-    def __init__(self, url: str, timeout: float = 2.0) -> None:
+    def __init__(
+        self,
+        url: str,
+        timeout: float = 2.0,
+        min_severity: str | None = None,
+    ) -> None:
         self._url = url
         self._timeout = timeout
+        self._min = min_severity
 
     def emit(self, risk: FailureRisk) -> None:
+        # A webhook is typically an escalation endpoint; unfiltered it fires
+        # on every info-level risk (issue #248). Same filtering as SlackSink.
+        if self._min is not None and _order(risk.severity) < _order(self._min):
+            return
         payload: dict[str, Any] = {
             "episode_id": risk.episode_id,
             "step_id": risk.step_id,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -313,3 +313,40 @@ def test_maybe_dedup_wraps_sinks_only_when_cooldown_set() -> None:
     assert len(wrapped) == 1
     assert isinstance(wrapped[0], DedupSink)
     assert wrapped[0]._cooldown == 120.0
+
+
+# --- --min-severity honored for webhook + validated (issue #248) ---------------
+
+
+def test_build_sinks_webhook_receives_min_severity():
+    from snagline.cli import _build_sinks
+    from snagline.sinks.webhook import WebhookSink
+
+    sink = _build_sinks(
+        _args(sink="webhook", webhook_url="http://x", min_severity="critical"),
+        Config(),
+    ).pop()
+    assert isinstance(sink, WebhookSink)
+    assert sink._min == "critical", "webhook branch must consume --min-severity"
+
+
+def test_min_severity_typo_exits_2(capsys):
+    """A typo'd severity must fail loudly like other closed-set config values
+    (#119 log_format, #93 policy), not quietly degrade the filter to warning."""
+    import pytest
+
+    with pytest.raises(SystemExit) as exc:
+        main(
+            [
+                "watch",
+                "--sink",
+                "slack",
+                "--slack-url",
+                "u",
+                "--min-severity",
+                "CRITICALL",
+            ]
+        )
+    assert exc.value.code == 2
+    err = capsys.readouterr().err
+    assert "invalid choice" in err, f"argparse should reject the typo, got: {err}"

--- a/tests/test_webhook_sink.py
+++ b/tests/test_webhook_sink.py
@@ -74,3 +74,72 @@ def test_emit_never_raises_on_bad_status() -> None:
         side_effect=urllib.error.HTTPError("url", 500, "boom", hdrs=None, fp=None),  # type: ignore[arg-type]
     ):
         WebhookSink("http://hooks.example/alerts").emit(_risk())
+
+
+# --- min_severity filtering (issue #248) --------------------------------------
+class _Resp:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    def read(self):
+        return b"{}"
+
+
+def _posting_urlopen(posted: list) -> object:
+    def fake_urlopen(req, timeout=None):
+        posted.append(json.loads(req.data.decode()))
+        return _Resp()
+
+    return fake_urlopen
+
+
+def _risk_with_severity(severity: str) -> FailureRisk:
+    return FailureRisk(
+        episode_id="ep-1",
+        step_id="3",
+        score=0.5,
+        trigger="loop",
+        detail="action repeated 3x in last 4 steps",
+        timestamp=1718300000.0,
+        severity=severity,
+    )
+
+
+def test_min_severity_info_passes_everything() -> None:
+    posted: list = []
+    with mock.patch.object(
+        urllib.request, "urlopen", side_effect=_posting_urlopen(posted)
+    ):
+        sink = WebhookSink("http://x", min_severity="info")
+        sink.emit(_risk_with_severity("info"))
+        sink.emit(_risk_with_severity("warning"))
+        sink.emit(_risk_with_severity("critical"))
+    assert len(posted) == 3
+
+
+def test_min_severity_critical_suppresses_lower() -> None:
+    posted: list = []
+    with mock.patch.object(
+        urllib.request, "urlopen", side_effect=_posting_urlopen(posted)
+    ):
+        sink = WebhookSink("http://x", min_severity="critical")
+        sink.emit(_risk_with_severity("info"))
+        sink.emit(_risk_with_severity("warning"))
+        sink.emit(_risk_with_severity("critical"))
+    assert len(posted) == 1, (
+        "critical-only endpoint must not receive info/warning risks"
+    )
+    assert posted[0]["trigger"] == "loop"
+
+
+def test_min_severity_unset_is_unfiltered() -> None:
+    posted: list = []
+    with mock.patch.object(
+        urllib.request, "urlopen", side_effect=_posting_urlopen(posted)
+    ):
+        sink = WebhookSink("http://x")
+        sink.emit(_risk_with_severity("info"))
+    assert len(posted) == 1


### PR DESCRIPTION
## Summary

Two defects in the `--min-severity` plumbing:

**(a) The webhook branch never consumed it** — `_build_sinks` passed `min_severity` to the slack and pagerduty branches only, so `snagline watch --sink webhook --webhook-url URL --min-severity critical` built a bare `WebhookSink(url)` and info-level risks were POSTed to the webhook anyway. `WebhookSink` now takes the same `min_severity` filter `SlackSink` has, and the webhook branch passes it through.

**(b) The value was never validated** — the flag had no `choices=`, so a typo like `--min-severity CRITICALL` was accepted, and `SlackSink._order`/`PagerDutySink._order` map unknown severity strings to `1` (= warning) — degrading a critical-only filter to warning with no error anywhere. Both `--min-severity` definitions (watch, serve) now carry `choices=("info", "warning", "critical")` so a typo exits 2, matching the loud-validation convention of `log_format` (#119) and `policy` (#93).

## Why it matters

A webhook is typically an escalation endpoint (chat ops, incident tooling); believing it is critical-only when it receives everything is an alerting-fidelity bug, and the typo case fails in the direction of *more* noise rather than less.

## Tests

- `test_build_sinks_webhook_receives_min_severity` — webhook branch consumes the flag (fails pre-fix)
- `test_min_severity_typo_exits_2` — `--min-severity CRITICALL` exits 2 with `invalid choice` on stderr (fails pre-fix)
- 3 `WebhookSink` severity-filter tests (info passes everything / critical suppresses lower / unset is unfiltered)

Full gates pass locally: `pytest -q` (700 passed, 87.55% coverage), `mypy src tests`, `ruff check`, `ruff format --check`.

Fixes #248
