### PR TITLE
fix(detector): score a CUSUM alarm coinciding with baseline adoption from the alarm-time snapshot

### DIFF
--- a/src/snagline/detectors/latency_anomaly.py
+++ b/src/snagline/detectors/latency_anomaly.py
@@ -217,6 +217,13 @@ class LatencyAnomalyDetector:
             return None
 
         alarm = state.update(event.latency_ms)
+        # Snapshot the alarm-time accumulator and baseline *before* the
+        # re-fit advances: a coincident adoption resets cusum to zero and
+        # replaces mu0, so scoring the alarm after _advance_refit reads the
+        # already-reset state -- a flat 0.6 score and a self-contradictory
+        # "300ms deviates from baseline (mean 300ms)" detail (issue #244).
+        alarm_cusum = state.cusum
+        alarm_mu0 = state.mu0
         drift_risk: FailureRisk | None = None
         if self.refit_every > 0:
             shifted, old_mu, shift = self._advance_refit(state, event.latency_ms)
@@ -241,14 +248,15 @@ class LatencyAnomalyDetector:
                         event.timestamp,
                     )
         if alarm:
-            score = min(1.0, 0.6 + 0.1 * max(0.0, state.cusum / self.h - 1.0))
+            assert alarm_mu0 is not None
+            score = min(1.0, 0.6 + 0.1 * max(0.0, alarm_cusum / self.h - 1.0))
             return FailureRisk(
                 event.episode_id,
                 event.step_id,
                 score,
                 "latency_anomaly",
                 f"latency {event.latency_ms:.0f}ms deviates from baseline "
-                f"(mean {state.mu0:.0f}ms)",
+                f"(mean {alarm_mu0:.0f}ms)",
                 event.timestamp,
             )
         return drift_risk

--- a/tests/test_window_scaling.py
+++ b/tests/test_window_scaling.py
@@ -178,6 +178,38 @@ def test_cusum_refit_surfaces_baseline_drift() -> None:
     assert all(r is None for r in risks[-5:])
 
 
+def test_cusum_alarm_coincident_with_adoption_keeps_severity_and_detail() -> None:
+    """Issue #244: the alarm was scored *after* the periodic re-fit advanced.
+    When adoption landed on the same step as an alarm, adopt_candidate() had
+    already reset cusum to 0 and replaced mu0, so the risk came out with a
+    flat 0.6 score and the self-contradictory detail "300ms deviates from
+    baseline (mean 300ms)". The alarm must be scored against the snapshot
+    taken at alarm time, before the re-fit touches the state.
+    """
+    cfg = Config(cusum_min_samples=5, cusum_refit_every=3)
+    det = LatencyAnomalyDetector(config=cfg)
+    ts = 0.0
+    for i in range(5):  # healthy warm-up at 100ms, then frozen
+        det.observe(_event(f"w{i}", ts, "s", latency_ms=100.0))
+        ts += 1.0
+    risks = []
+    for i in range(10):  # sustained regression at 300ms
+        risks.append(det.observe(_event(f"x{i}", ts, "s", latency_ms=300.0)))
+        ts += 1.0
+    alarm_risks = [
+        r for r in risks if r is not None and "deviates from baseline" in r.detail
+    ]
+    assert alarm_risks, "the sustained shift must alarm"
+    for r in alarm_risks:
+        # Score: pre-adoption cusum was far above h, so the alarm must carry
+        # the severity bonus, not the 0.6 floor an adopted-reset produces.
+        assert r.score > 0.6, f"coincident alarm scored flat {r.score}"
+        # Detail: the mean cited must be the baseline the alarm was measured
+        # against (100ms), never the just-adopted 300ms.
+        assert "mean 100ms" in r.detail, f"self-contradictory detail: {r.detail}"
+        assert "mean 300ms" not in r.detail
+
+
 def test_cusum_refit_disabled_by_default_matches_pre92_behavior() -> None:
     cfg = Config()
     det = LatencyAnomalyDetector(config=cfg)


### PR DESCRIPTION
## Summary

In `LatencyAnomalyDetector.observe()`, the alarm was computed **before** the periodic re-fit advanced, but **scored after it**. When adoption landed on the same step as an alarm, `adopt_candidate()` had already reset `cusum` to 0 and replaced `mu0`, so the alarm emitted:

- a flat **0.6** score — the severity bonus `0.6 + 0.1 * max(0, cusum/h - 1)` computed from the already-reset accumulator, and
- the self-contradictory detail **"latency 300ms deviates from baseline (mean 300ms)"** — citing the just-adopted baseline as the one deviated from.

Reproduced deterministically with `cusum_min_samples=5, cusum_refit_every=3` (warm-up 100 ms, then sustained 300 ms): the coincident step's alarm scored 0.6 instead of 1.0 (cusum was ~276 pre-adoption).

This co-occurrence is not rare: a sustained regression both keeps the CUSUM alarming and is exactly what the learner samples, so adoption routinely lands mid-alarm.

`cusum` and `mu0` are now snapshotted right after `state.update()`, before `_advance_refit()`, and the alarm's score and detail use that snapshot. The deferred drift risk and post-adoption quieting are unchanged.

## Why it matters

Severity is load-bearing: `SlackSink`/`PagerDutySink` route on `min_severity` and score feeds the risk score ceiling. An operator paged with "deviates from baseline (mean 300ms)" for a 300 ms latency has no actionable message, and the lost severity bonus downgrades a genuine sustained regression to the floor score on exactly the steps where it peaks.

## Tests

`test_cusum_alarm_coincident_with_adoption_keeps_severity_and_detail` — reproduces the issue's deterministic setup; asserts every emitted CUSUM alarm carries `score > 0.6` and cites `mean 100ms`, never the just-adopted `mean 300ms` (fails pre-fix on both assertions). Full gates pass locally: `pytest -q` (696 passed, 87.49% coverage), `mypy src tests`, `ruff check`, `ruff format --check`.

Fixes #244
