### PR TITLE
fix(ml): score the ESN live path with the same pairing fit() solved for

### DIFF
--- a/src/snagline/ml/esn_ensemble.py
+++ b/src/snagline/ml/esn_ensemble.py
@@ -263,15 +263,22 @@ class EsnCusumDetector:
 
     def _esn_anomaly(self, st: _EpisodeState, x: np.ndarray) -> float:
         """Next-step prediction anomaly of the ESN, in [0, 1]."""
+        # Score x from the *pre-advance* context (state after x_{t-1}) -- the
+        # exact pairing both fit() and the warm-up learner solved beta for.
+        # The step being judged must not leak into the context judging it:
+        # scoring from the post-advance state made the prediction partially
+        # self-fulfilling, shrinking residuals for exactly the anomalies the
+        # detector should amplify (issue #243).
+        context_prev = st.context_prev
         st.state = self._advance(st.state, x)
         context = np.concatenate((np.ones(1), st.state))
         if st.beta is None:
             # Warm-up: learn this episode's own (assumed healthy) dynamics
             # from previous-step context to current features. Silent phase.
-            if st.context_prev is not None:
-                st.gram += np.outer(st.context_prev, st.context_prev)
-                st.rhs += np.outer(st.context_prev, x)
-                st.warm_ctx.append(st.context_prev)
+            if context_prev is not None:
+                st.gram += np.outer(context_prev, context_prev)
+                st.rhs += np.outer(context_prev, x)
+                st.warm_ctx.append(context_prev)
                 st.warm_tgt.append(x)
                 st.warm_n += 1
                 if st.warm_n >= self._warmup_steps:
@@ -279,7 +286,14 @@ class EsnCusumDetector:
                     self._seed_residual_stats(st)
             st.context_prev = context
             return 0.0
-        predicted = context @ st.beta
+        # Fitted path: remember the pre-advance context for the *next* step's
+        # score, so live scoring keeps the fit-consistent pairing.
+        st.context_prev = context
+        if context_prev is None:
+            # First scored step of the episode has no pre-advance context to
+            # predict from (fit() skips the same step); stay silent once.
+            return 0.0
+        predicted = context_prev @ st.beta
         residual = float(np.linalg.norm(predicted - x)) / math.sqrt(_FEATURE_DIM)
         excess = max(0.0, residual - st.res_mu) / (
             _RESIDUAL_SIGMA_INFLATION

--- a/tests/test_ml_esn_ensemble.py
+++ b/tests/test_ml_esn_ensemble.py
@@ -394,3 +394,54 @@ def test_features_ignore_metadata_content():
     scores_a = [r.score if (r := det_a.observe(e)) else None for e in stream_a]
     scores_b = [r.score if (r := det_b.observe(e)) else None for e in stream_b]
     assert scores_a == scores_b
+
+
+# --- live scoring uses the fit-consistent pairing (issue #243) ----------------
+
+
+def test_fitted_live_residuals_match_fit_pairing_on_healthy_traffic():
+    """Issue #243: fit() solves beta for (state after x_{t-1}) -> x_t, but
+    live scoring advanced the reservoir with x_t *first* and predicted x_t
+    from the post-advance state. The step leaked into the context judging it,
+    so even a perfectly healthy continuation carried a systematic residual
+    bias over the trained mean, and the running residual-stat update absorbed
+    it (res_mu drifting ~2 sigma on clean data). Drives the real observe()
+    path: on healthy traffic the running res_mu must stay centered on the
+    fitted mean.
+    """
+    det = EsnCusumDetector(seed=7, warmup_steps=5, cusum_h=1.0)
+    healthy = [
+        _ev(i, signature=f"a{i % 2}", latency=100.0 if i % 2 else 200.0)
+        for i in range(40)
+    ]
+    det.fit(healthy)
+    fitted_mu = det._fitted_res_mu
+    fitted_sigma = det._fitted_res_sigma
+    assert fitted_sigma > 0.0
+
+    # Long, perfectly in-pattern continuation: nothing here is anomalous, so
+    # every step updates the running residual stats with a "healthy" residual.
+    for i in range(40, 240):
+        det.observe(_ev(i, signature=f"a{i % 2}", latency=100.0 if i % 2 else 200.0))
+    st = det._episodes["ep"]
+    drift = st.res_mu - fitted_mu
+    assert abs(drift) < 0.5 * fitted_sigma, (
+        f"healthy continuation drifted res_mu by {drift / fitted_sigma:.2f} "
+        f"sigma from the fitted mean: the live pairing does not match fit()"
+    )
+
+
+def test_fitted_first_live_step_is_silent_then_scores():
+    """The first scored step has no pre-advance context (fit() skips the same
+    step); it stays silent once, and the second step scores normally."""
+    det = _fast()
+    healthy = [_ev(i, signature=f"a{i % 4}", latency=100.0) for i in range(12)]
+    det.fit(healthy)
+    st = det._new_state()
+
+    det._episodes["ep"] = st
+    first = det._esn_anomaly(st, det._features(healthy[0]))
+    assert first == 0.0, "no pre-advance context exists for the first step"
+    assert st.context_prev is not None
+    second = det._esn_anomaly(st, det._features(healthy[1]))
+    assert second is not None  # scores from the previous context


### PR DESCRIPTION
## Summary

The ESN module promises next-step prediction: *"the reservoir predicts the next feature vector from the previous reservoir state."* Both training paths honor that pairing — `fit()` and the warm-up learner solve beta for `(state after x_{t-1}) → x_t`. But the live scoring path advanced the reservoir with the current step **first**, then asked the readout to predict that same step:

```python
st.state = self._advance(st.state, x)          # state now includes x_t
context = np.concatenate((np.ones(1), st.state))
predicted = context @ st.beta                  # predicts x_t from post-x_t state
```

The step being judged leaked into the context judging it, so beta — solved for a systematically different input distribution — produced biased residuals.

Live scoring now predicts `x_t` from `st.context_prev` (the pre-advance context), and `st.context_prev` is kept updated on the fitted path as well (previously it was only maintained inside the warm-up branch). The first scored step of an episode has no pre-advance context — `fit()` skips the same step — and stays silent once, matching the training contract.

## Verification

Measured on `master` with a seeded constructor, fitted on a period-2 latency stream and fed a perfectly **healthy** continuation through the real `observe()` path for 200 steps:

- **master**: running `res_mu` drifts **+1.98 σ** above the fitted mean — purely from the pairing mismatch; the residual-stat update absorbs the bias
- **this PR**: drift is **−0.03 σ**

The note in the issue about a ~3× residual amplification didn't reproduce on my machine (I measured ~1.10× on healthy continuation); the systematic bias itself is real and deterministic, so the tests pin the σ-scaled drift instead of the ratio.

## Tests

- `test_fitted_live_residuals_match_fit_pairing_on_healthy_traffic` — 200 in-pattern `observe()` steps; `res_mu` must stay within 0.5 σ of the fitted mean (fails pre-fix at ~+2 σ). Drives the real code path, not a hand-replicated one.
- `test_fitted_first_live_step_is_silent_then_scores` — the first scored step has no pre-advance context and is silent; the second scores normally (fails pre-fix: master scores the first step from a context containing it).

Full local gates: `pytest -q` (717 passed with the ml extra, 87.50% coverage), `benchmarks/detection_accuracy.py` exits 0 (no healthy-control false positives), `mypy src tests` (clean at the CI matrix's Python versions; the local numpy-stub error is an env artifact — CI's mypy leg runs without numpy), `ruff check`, `ruff format --check`.

Fixes #243
