### PR TITLE
fix(monitor): suppress the wall-clock pre-breach warning after a breach

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -96,7 +96,7 @@ class _EpisodeClock:
 
     def __init__(self, first_ts: float) -> None:
         self.last_ts = first_ts
-        self.elapsed = 0.0  # sum of positive inter-event deltas
+        self.elapsed = 0.0  # wall-clock span covered; last_ts only moves fwd
         self.idle_fired = False  # "idle_gap" fires once per episode
         self.warned = False  # budget warning fires once per episode
         self.breached = False  # budget breach fires once per episode
@@ -397,7 +397,16 @@ class Monitor:
                 self._clocks[event.episode_id] = _EpisodeClock(event.timestamp)
                 return out
             delta = event.timestamp - clock.last_ts
-            clock.last_ts = event.timestamp
+            if delta > 0.0:
+                # Out-of-order or skewed sources (merged adapter streams, clock
+                # skew between hook processes) must not reduce consumed budget
+                # -- and must not rewind ``last_ts`` either: rewinding makes
+                # the *next* event measure its delta from the moved-back
+                # reference, counting an already-counted span a second time
+                # (issue #249). ``last_ts`` only moves forward, so a late
+                # event neither spends nor un-spends budget.
+                clock.elapsed += delta
+                clock.last_ts = event.timestamp
             if (
                 self._idle_warn_seconds is not None
                 and not clock.idle_fired
@@ -415,10 +424,6 @@ class Monitor:
                         event.timestamp,
                     )
                 )
-            if delta > 0.0:
-                # Negative deltas (out-of-order or skewed sources) must not
-                # reduce consumed budget; clamp them out of the accumulation.
-                clock.elapsed += delta
             budget = self._max_wall_seconds
             if budget is not None:
                 if not clock.breached and clock.elapsed >= budget:

--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -380,7 +380,9 @@ class Monitor:
           "warning" severity band) at ``warn_fraction`` of
           ``max_episode_wall_seconds``, then a breach (score 1.0) at the limit;
           a single delta that jumps straight past the limit fires only the
-          breach (mirrors TokenRunawayDetector's envelope ordering).
+          breach (mirrors TokenRunawayDetector's envelope ordering) -- and
+          suppresses the warning for good, so severity never runs backwards
+          after a breach (issue #224).
         """
         out: list[FailureRisk] = []
         # Inert unless one of the opt-in horizon knobs is set (issue #92). When
@@ -428,6 +430,13 @@ class Monitor:
             if budget is not None:
                 if not clock.breached and clock.elapsed >= budget:
                     clock.breached = True
+                    # The warning threshold was passed on the way to the
+                    # breach, so a jump straight past the budget must not
+                    # leave a stale warning to fire on the *next* step --
+                    # that downgraded a critical to a warning after the fact
+                    # and read "at N% of budget" for an episode already over
+                    # it (issue #224).
+                    clock.warned = True
                     out.append(
                         FailureRisk(
                             event.episode_id,

--- a/tests/test_horizon_time_axis.py
+++ b/tests/test_horizon_time_axis.py
@@ -289,3 +289,24 @@ def test_invalid_horizon_config_fails_loudly() -> None:
         Config(max_window=0)
     with pytest.raises(ValueError):
         Config(cusum_refit_every=-1)
+
+
+def test_jump_past_budget_emits_no_stale_warning_afterward() -> None:
+    """Issue #224: the breach fired, but ``clock.warned`` stayed False, so
+    the *next* step emitted the 0.7 pre-breach warning for an episode already
+    reported critical -- severity running backwards, with the self-contradicting
+    text "at 201% of its 100s wall-clock budget". A jump straight past the
+    budget now marks the warning threshold as passed, for good.
+    """
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=100.0, warn_fraction=0.8)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 200.0),  # jumps straight past the budget: breach only
+        _event("s3", 201.0),  # already breached -- no stale warning may fire
+        _event("s4", 202.0),
+    )
+    budget = [r for r in sink.risks if r.trigger == "wall_clock_budget"]
+    assert [(r.step_id, r.score) for r in budget] == [("s2", 1.0)]
+    assert budget[0].severity == "critical"

--- a/tests/test_horizon_time_axis.py
+++ b/tests/test_horizon_time_axis.py
@@ -152,6 +152,49 @@ def test_negative_delta_does_not_refund_budget() -> None:
     assert len(breaches) == 1
 
 
+def test_out_of_order_events_do_not_double_count_the_same_span() -> None:
+    """Issue #249: a negative delta was excluded from ``elapsed`` but still
+    rewound ``last_ts``, so the next event measured its delta from the moved-
+    back reference and counted an already-counted span a second time. Events
+    at ts 0, 60, 0, 60 -- a 60-second true span, the second half a skewed
+    replay of the same range -- used to yield ``elapsed == 120`` and breach a
+    100 s budget. ``last_ts`` must only move forward.
+    """
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=100.0)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 60.0),
+        _event("s3", 0.0),  # skewed backwards: rewinds nothing now
+        _event("s4", 60.0),  # delta measured from 60, not from 0
+    )
+    clock = m._clocks["ep1"]
+    assert clock.elapsed == 60.0, "the same wall-clock span was counted twice"
+    assert clock.last_ts == 60.0, "last_ts must not move backwards"
+    assert sink.risks == [], "60s of real time must not breach a 100s budget"
+
+
+def test_out_of_order_replay_still_counts_genuinely_new_time() -> None:
+    """The fix must not under-count either: after a backwards event, a delta
+    past the previous high-water mark is real new time and still spends
+    budget."""
+    sink = CapturingSink()
+    m = _monitor(sink, max_episode_wall_seconds=100.0)
+    _feed(
+        m,
+        _event("s1", 0.0),
+        _event("s2", 60.0),
+        _event("s3", 0.0),
+        _event("s4", 150.0),  # 90s past the high-water mark of 60
+    )
+    breaches = [
+        r for r in sink.risks if r.trigger == "wall_clock_budget" and r.score == 1.0
+    ]
+    assert len(breaches) == 1, "genuinely new time must still breach"
+    assert m._clocks["ep1"].elapsed == 150.0
+
+
 # --- determinism / fail-open / region contract ------------------------------
 
 


### PR DESCRIPTION
## Summary

When a single delta jumped straight past the budget, the breach fired (score 1.0, `critical`) but `clock.warned` stayed `False`. On the following step `clock.breached` made the first condition false, the `elif` was evaluated with `warned` still `False`, and the stale 0.7 warning fired:

```
1.0 critical episode exceeded its 100s wall-clock budget (200s observed)
0.7 warning  episode at 201% of its 100s wall-clock budget
```

Severity runs backwards — a dashboard sees `critical` downgraded to `warning` while the overrun keeps growing — and the warning's own text is self-contradictory.

The breach now marks the warning threshold as passed (`warned = True` alongside `breached`), so a jump straight past the limit emits only the breach, for good — matching what the method's docstring already promised. Issue #224 also suggested checking `TokenRunawayDetector` (cited as the model for this ordering): I verified its warning lives inside the `not-breached` block and cannot re-fire after its breach, so no change is needed there.

## Tests

`test_jump_past_budget_emits_no_stale_warning_afterward` — the issue's exact reproduction (jump to 200 s, then 201 s, 202 s); asserts exactly one `wall_clock_budget` risk: the breach, at `critical` (fails pre-fix, which emits the stale warning on the following step). Full gates pass locally: `pytest -q` (718 passed, 87.50% coverage), `mypy src tests`, `ruff check`, `ruff format --check`.

**Note:** this branch stacks on #256 (both touch `_advance_clock`); if #256 lands first this applies cleanly on top, otherwise it can be rebased.

Fixes #224
