### PR TITLE
fix(cli): watch finalizes ingested episode ids, not the filename

### DIFF
--- a/src/snagline/cli.py
+++ b/src/snagline/cli.py
@@ -213,7 +213,8 @@ def _build_parser() -> argparse.ArgumentParser:
     p_watch.add_argument(
         "--episode-id",
         default=None,
-        help="Episode id override [default: from the events / file name].",
+        help="Episode id to attribute events to [default: each event's own "
+        "episode_id; a synthesized id otherwise].",
     )
     p_watch.add_argument(
         "--sink",
@@ -548,6 +549,12 @@ def _cmd_watch(args: argparse.Namespace) -> int:
         heartbeat.touch()  # evidence of life from startup
     episode = args.episode_id or (args.file or "stdin")
     steps = 0
+    # Finalize every episode actually ingested, not the filename (issue
+    # #225): end_episode must be asked about the ids the events carried or
+    # finalize-based detectors (silent_abort) can never fire in watch. A
+    # set, like replay, so a multi-episode file/follow session finalizes
+    # each one exactly once.
+    episodes: set = set()
     try:
         with suppress(KeyboardInterrupt):
             for line in _iter_lines(
@@ -568,11 +575,20 @@ def _cmd_watch(args: argparse.Namespace) -> int:
                     )
                     continue
                 monitor.ingest(event)
+                episodes.add(event.episode_id)
                 steps += 1
                 if heartbeat is not None:
                     heartbeat.touch()
     finally:
-        monitor.end_episode(episode)
+        # Fail-open teardown (issue #225): finalize every episode that was
+        # actually ingested; ``episode`` (the override, the filename or
+        # "stdin") is still finalized so the zero-events case -- and any
+        # operator override -- keeps today's behaviour. Finalize-based
+        # detectors see the right ids; an id already in the set is harmless
+        # (end_episode is idempotent for unknown ids).
+        for episode_id in episodes | {episode}:
+            with suppress(Exception):
+                monitor.end_episode(episode_id)
     print(f"snagline watch: ingested {steps} step(s)", file=sys.stderr)
     return 0
 

--- a/tests/test_watch_cli.py
+++ b/tests/test_watch_cli.py
@@ -94,3 +94,107 @@ def test_iter_lines_calls_on_wait_while_following(tmp_path):
         pass
     assert consumed == ['{"step_id": "s1"}']
     assert len(waits) == 3
+
+
+# --- issue #225: finalize-based detectors must see the real episode ids -------
+
+
+def _event_line(step_id: str, episode_id: str, action_type: str) -> str:
+    from snagline.events import make_signature
+
+    return json.dumps(
+        {
+            "step_id": step_id,
+            "episode_id": episode_id,
+            "timestamp": 1718300000.0 + float(step_id),
+            "action_type": action_type,
+            "action_signature": make_signature(action_type, "t"),
+            "tool_name": "t",
+        }
+    )
+
+
+def test_watch_finalizes_ingested_episode_ids_not_the_filename(
+    tmp_path, capsys, monkeypatch
+):
+    """The issue #225 repro, as a test: same events, same config, watch must
+    report the silent_abort that replay reports. Pre-#225, end_episode was
+    called with the *filename*, so the detector was asked about an episode
+    that never existed and nothing was emitted.
+    """
+    path = tmp_path / "ep.jsonl"
+    # An episode ending on a tool_call (not an output step) and not on an
+    # error: exactly the silent-abort shape.
+    path.write_text(
+        _event_line("1", "real-ep", "message")
+        + "\n"
+        + _event_line("2", "real-ep", "tool_call")
+        + "\n"
+    )
+    monkeypatch.setenv("SNAGLINE_SILENT_ABORT_ENABLED", "1")
+    rc = main(["watch", "--file", str(path)])
+    assert rc == 0
+    err = capsys.readouterr().err
+    risks = [
+        json.loads(line)
+        for line in err.splitlines()
+        if line.startswith("{") and '"trigger"' in line
+    ]
+    assert any(
+        r["trigger"] == "silent_abort" and r["episode_id"] == "real-ep" for r in risks
+    ), err
+
+
+def test_watch_finalizes_every_episode_in_a_multi_episode_file(
+    tmp_path, capsys, monkeypatch
+):
+    """A multi-episode file finalizes each episode at teardown (issue #225's
+    follow-session note): both ingested ids fire, exactly once each."""
+    path = tmp_path / "multi.jsonl"
+    lines = [
+        _event_line("1", "ep-a", "message"),
+        _event_line("2", "ep-a", "tool_call"),
+        _event_line("3", "ep-b", "message"),
+        _event_line("4", "ep-b", "tool_call"),
+    ]
+    path.write_text("\n".join(lines) + "\n")
+    monkeypatch.setenv("SNAGLINE_SILENT_ABORT_ENABLED", "1")
+    rc = main(["watch", "--file", str(path)])
+    assert rc == 0
+    err = capsys.readouterr().err
+    risks = [
+        json.loads(line)
+        for line in err.splitlines()
+        if line.startswith("{") and '"trigger"' in line
+    ]
+    aborts = [r for r in risks if r["trigger"] == "silent_abort"]
+    assert {r["episode_id"] for r in aborts} == {"ep-a", "ep-b"}
+    assert len(aborts) == 2, err
+
+
+def test_watch_episode_id_override_still_fires_for_overridden_id(
+    tmp_path, capsys, monkeypatch
+):
+    """--episode-id keeps working: events carry ids of their own here, but the
+    override id is still finalized (zero-events fallback, issue #225)."""
+    path = tmp_path / "ep.jsonl"
+    path.write_text(
+        _event_line("1", "real-ep", "message")
+        + "\n"
+        + _event_line("2", "real-ep", "tool_call")
+        + "\n"
+    )
+    monkeypatch.setenv("SNAGLINE_SILENT_ABORT_ENABLED", "1")
+    rc = main(["watch", "--file", str(path), "--episode-id", "real-ep"])
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert '"trigger": "silent_abort"' in err
+
+
+def test_watch_zero_events_still_finalizes_the_fallback_id(capsys, monkeypatch):
+    """No events ingested: the synthesized id is finalized as before (no
+    regression in the empty-file/stdin case, issue #225)."""
+    monkeypatch.setattr("sys.stdin", _FakeStdin([]))
+    rc = main(["watch"])
+    assert rc == 0
+    assert "ingested 0 step(s)" in capsys.readouterr().err


### PR DESCRIPTION
## Problem

`_cmd_watch` called `monitor.end_episode()` with an id derived from the **filename** (or `--episode-id` / `"stdin"`) — never with the episode ids actually carried by the ingested events:

```python
episode = args.episode_id or (args.file or "stdin")
...
finally:
    monitor.end_episode(episode)
```

`end_episode("/tmp/ep.jsonl")` finalizes an episode that never existed, so every finalize-based detector is dead in `watch`: `SilentAbortDetector.finalize` is asked about the wrong key while the real episode is never finalized. Same events, same config, same monitor composition: `replay` reports the silent abort, `watch` reports nothing — unless the operator happens to pass `--episode-id` matching the id inside the file.

Relatedly, the `--episode-id` help text promised `[default: from the events / file name]` — nothing ever read the id "from the events".

## Fix

Mirror what `_cmd_replay` already does correctly:

- collect `event.episode_id` into a set as events are ingested;
- in the `finally` teardown, finalize each of those ids (with `suppress(Exception)` so teardown stays fail-open);
- still finalize the override/filename fallback id, so the zero-events case and operator overrides keep today's behaviour.

A `--follow` session that sees several episodes now finalizes all of them at exit — that is the intended behaviour (per the issue's note) and is covered by a test.

The help text now says each event's own `episode_id` is the default attribution.

## Tests

Four regression tests in `tests/test_watch_cli.py`; the two core ones fail on `master` (vacuity-verified by reverting `cli.py` and re-running):

- `test_watch_finalizes_ingested_episode_ids_not_the_filename` — the issue's exact repro shape: two events ending on a `tool_call` with `SNAGLINE_SILENT_ABORT_ENABLED=1` fire `silent_abort` for `real-ep` in `watch --file` (silent on master);
- `test_watch_finalizes_every_episode_in_a_multi_episode_file` — two episodes in one file both fire, exactly once each;
- `test_watch_episode_id_override_still_fires_for_overridden_id` — `--episode-id` keeps working;
- `test_watch_zero_events_still_finalizes_the_fallback_id` — empty stdin case unchanged.

Gates: 719 passed / 2 skipped, coverage 87.51%, `mypy src tests` clean, `ruff check` + `ruff format --check` clean.

Fixes #225
