### PR TITLE
fix(bench): derive the trigger column width instead of hardcoding 16

### DIFF
--- a/benchmarks/detection_accuracy.py
+++ b/benchmarks/detection_accuracy.py
@@ -435,14 +435,27 @@ def score(outcomes: Sequence[EpisodeOutcome]) -> ScoreReport:
 
 
 def format_table(report: ScoreReport) -> str:
+    # Width is derived, not hardcoded (issue #223): side_effect_duplicate (21)
+    # and wall_clock_budget (17) both overflowed the old fixed 16-char column
+    # and pushed their numeric columns out of alignment with the header and
+    # rules. Deriving from every row's trigger keeps the table aligned as
+    # triggers are added.
+    width = max(
+        len("trigger"),
+        *(len(t) for t in SHIPPED_TRIGGERS),
+        *(len(t) for t in report.per_trigger),
+    )
     lines: list[str] = []
-    header = f"{'trigger':<16} {'TP':>4} {'FP':>4} {'FN':>4} {'precision':>10} {'recall':>8} {'f1':>7}"
+    header = (
+        f"{'trigger':<{width}} {'TP':>4} {'FP':>4} {'FN':>4}"
+        f" {'precision':>10} {'recall':>8} {'f1':>7}"
+    )
     lines.append(header)
     lines.append("-" * len(header))
     for trig in SHIPPED_TRIGGERS:
         s = report.per_trigger.get(trig, TriggerStats())
         lines.append(
-            f"{trig:<16} {s.tp:>4} {s.fp:>4} {s.fn:>4}"
+            f"{trig:<{width}} {s.tp:>4} {s.fp:>4} {s.fn:>4}"
             f" {s.precision:>10.3f} {s.recall:>8.3f} {s.f1:>7.3f}"
         )
     # Triggers outside the shipped vocabulary still get honest rows.
@@ -450,7 +463,7 @@ def format_table(report: ScoreReport) -> str:
     for trig in extra:
         s = report.per_trigger[trig]
         lines.append(
-            f"{trig:<16} {s.tp:>4} {s.fp:>4} {s.fn:>4}"
+            f"{trig:<{width}} {s.tp:>4} {s.fp:>4} {s.fn:>4}"
             f" {s.precision:>10.3f} {s.recall:>8.3f} {s.f1:>7.3f}"
         )
     lines.append("-" * len(header))

--- a/tests/test_detection_accuracy.py
+++ b/tests/test_detection_accuracy.py
@@ -741,3 +741,74 @@ def test_cli_exit_zero_on_committed_fixtures(harness) -> None:
     table = stdout.getvalue()
     assert "macro-F1" in table
     assert "silent_abort" in table
+
+
+# --- issue #223: table alignment must survive long trigger names -------------
+
+
+def _table_rows(harness, report):
+    """Return (header, trigger_rows): only the rows carrying per-trigger stats."""
+    table = harness.format_table(report)
+    lines = table.splitlines()
+    header = lines[0]
+    trig_rows = [
+        ln
+        for ln in lines[2:]
+        if ln
+        and not ln.startswith("-")
+        and not ln.startswith(("macro-F1", "episodes", "confusion", "  "))
+        and "healthy controls that fired" not in ln
+    ]
+    return header, trig_rows
+
+
+def test_format_table_aligns_columns_for_long_trigger_names(harness) -> None:
+    """side_effect_duplicate (21 chars) and wall_clock_budget (17) must not
+    push their numeric columns out of line (issue #223): every trigger row and
+    the header share one derived trigger-column width, so all numeric columns
+    start at the same offset everywhere."""
+    report = harness.ScoreReport(
+        per_trigger={},
+        confusion={},
+        healthy_fired=0,
+        n_labeled=0,
+        n_healthy=0,
+    )
+    header, rows = _table_rows(harness, report)
+    assert set(harness.SHIPPED_TRIGGERS) >= {
+        "side_effect_duplicate",
+        "wall_clock_budget",
+    }
+    # The numeric block (TP FP FN precision recall f1) must begin at the same
+    # offset in the header and in EVERY trigger row: on master the two long
+    # names pushed their numbers right, off the header's grid.
+    offset = header.index("TP")
+    for row in rows:
+        assert row[: offset - 1].strip() in harness.SHIPPED_TRIGGERS, row
+        numeric = row[offset:]
+        assert numeric.startswith(" "), row  # TP is right-aligned in 4 cols
+        assert numeric[:4].strip().isdigit(), row
+    # And the rules still span exactly the header width.
+    lines = harness.format_table(report).splitlines()
+    assert lines[1] == "-" * len(header)
+
+
+def test_format_table_extra_trigger_widens_the_column(harness) -> None:
+    """An out-of-vocabulary trigger longer than every shipped one still gets
+    an aligned row: the width derives from all rows, not just SHIPPED_TRIGGERS
+    (issue #223's "as triggers are added")."""
+    stats = harness.TriggerStats(tp=1, fp=0, fn=0)
+    report = harness.ScoreReport(
+        per_trigger={"a_very_long_unshipped_trigger_name": stats},
+        confusion={},
+        healthy_fired=0,
+        n_labeled=1,
+        n_healthy=0,
+    )
+    header, rows = _table_rows(harness, report)
+    offset = header.index("TP")
+    extra = next(ln for ln in rows if ln.startswith("a_very_long"))
+    # The long name fits in the cell (no truncation) and its TP column starts
+    # at the header's TP offset.
+    assert extra[: offset - 1].strip() == "a_very_long_unshipped_trigger_name"
+    assert extra[offset : offset + 4].strip() == "1"


### PR DESCRIPTION
## Problem

The `--format table` renderer in `benchmarks/detection_accuracy.py` padded the trigger column to a hardcoded 16 characters, but two shipped trigger names are longer:

- `side_effect_duplicate` — 21 chars
- `wall_clock_budget` — 17 chars

Both overflowed the cell, pushing their numeric columns right and breaking alignment with the header and the `-----` rules (issue #223):

```
stagnation          4    0    0      1.000    1.000   1.000
side_effect_duplicate    4    0    0      1.000    1.000   1.000
```

The width predates the newer triggers in `SHIPPED_TRIGGERS`.

## Fix

Derive the width instead of hardcoding it — from `SHIPPED_TRIGGERS` **and** any out-of-vocabulary rows the report carries, so an extra-long unshipped trigger also gets an aligned row:

```python
width = max(
    len("trigger"),
    *(len(t) for t in SHIPPED_TRIGGERS),
    *(len(t) for t in report.per_trigger),
)
```

Used in the header and both row templates; the rules already follow `len(header)`. After (from this branch):

```
trigger                 TP   FP   FN  precision   recall      f1
----------------------------------------------------------------
side_effect_duplicate    4    0    0      1.000    1.000   1.000
wall_clock_budget        4    0    0      1.000    1.000   1.000
```

## Tests

Two regression tests in `tests/test_detection_accuracy.py`, both failing on `master` (vacuity-verified by reverting the benchmark file and re-running):

- `test_format_table_aligns_columns_for_long_trigger_names` — the numeric block begins at the same offset in the header and in **every** shipped trigger row, and the rules still span exactly the header width;
- `test_format_table_extra_trigger_widens_the_column` — a 32-char unshipped trigger name fits untruncated and its TP column aligns with the header's.

Gates: 717 passed / 2 skipped, coverage 87.50%, `mypy src tests` clean, `ruff check` + `ruff format --check` clean, accuracy gate (`detection_accuracy.py --fixtures benchmarks/fixtures`) exits 0 (healthy controls that fired: 0).

Fixes #223
