### PR TITLE
ci: guard the automerge approval call so enableAutoMerge is reached

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -26,14 +26,25 @@ jobs:
             });
             const alreadyApproved = reviews.some((r) => r.user.login === "github-actions[bot]" && r.state === "APPROVED");
             if (!alreadyApproved) {
-              await github.rest.pulls.createReview({
-                owner,
-                repo,
-                pull_number: prNumber,
-                event: "APPROVE",
-                body: "Dependabot dependency bump approved automatically. Merging once all required checks pass.",
-              });
-              console.log(`Approved Dependabot PR #${prNumber}`);
+              // Guarded (issue #266): repositories with "Allow GitHub Actions
+              // to create and approve pull requests" disabled (the default
+              // off) reject this call with 422, which used to crash the job
+              // before enableAutoMerge was ever reached -- so auto-merge was
+              // silently never enabled and every bump needed a manual merge.
+              // Approval is advisory; branch protection still enforces any
+              // required reviews. Keep going either way.
+              try {
+                await github.rest.pulls.createReview({
+                  owner,
+                  repo,
+                  pull_number: prNumber,
+                  event: "APPROVE",
+                  body: "Dependabot dependency bump approved automatically. Merging once all required checks pass.",
+                });
+                console.log(`Approved Dependabot PR #${prNumber}`);
+              } catch (error) {
+                console.log(`Could not approve #${prNumber} (${error.message}); continuing without the bot review.`);
+              }
             }
 
             try {


### PR DESCRIPTION
## Problem

`.github/workflows/dependabot-auto-merge.yml` wrapped only the `enableAutoMerge` call in a try/catch — the `createReview` (APPROVE) call above it was unguarded. On this repository the approval call fails with an unhandled error (issue #266):

```
##[error]Unhandled error: HttpError: Unprocessable Entity:
"GitHub Actions is not permitted to approve pull requests."
```

The job **crashes before the try block is ever entered**, so `enableAutoMerge` is never called. Net effect: auto-merge is silently never enabled for dependabot PRs and every bump needs a manual merge —

- **#220** (ruff 0.16.4): its automerge run failed with this exact error; the PR was merged manually a day after CI went green.
- **#234** (ruff 0.16.5): the same failure is attached to it now; the PR sits green-but-stuck.

The run log proves the crash point: zero runtime `console.log` lines — neither `Approved Dependabot PR #234` nor even the existing catch's `Could not enable auto-merge on #234: ...` ever printed. Crash is in the `if (!alreadyApproved)` branch, before the guarded call.

The repository setting `Settings > Actions > General > "Allow GitHub Actions to create and approve pull requests"` is off — a legitimate hardening default that the workflow should tolerate.

## Fix

Guard the approval attempt with the same fail-soft posture already used for `enableAutoMerge`, logging why it was skipped and continuing to enable auto-merge either way:

```js
try {
  await github.rest.pulls.createReview({ ... });
  console.log(`Approved Dependabot PR #${prNumber}`);
} catch (error) {
  console.log(`Could not approve #${prNumber} (${error.message}); continuing without the bot review.`);
}
```

Safety notes:

- **This does not bypass review requirements.** `enableAutoMerge` respects branch protection: if a branch requires N approvals, the PR waits for them rather than merging unreviewed. On this repo `master` has no approval requirement (#220 merged with no reviews), so the bot approval was advisory anyway — the guard just makes the workflow functional.
- A repo admin could alternatively flip the Actions-approval setting on to keep the approval behavior; the workflow fix is worth having regardless, since the setting is default-off for forks and future repos.
- A comment in the script documents why the guard exists (issue #266).

## Verification

- The edited YAML parses (`yaml.safe_load`) with the job/step structure intact.
- The embedded script is extracted and passes `node --check` (JS syntax valid), with exactly two `try`/`catch` blocks.
- Python suite unaffected: 715 passed, 2 skipped, coverage 87.50%.
- Live behavior: on merge, the next dependabot PR's automerge run should log `Could not approve ...; continuing without the bot review.` followed by `Auto-merge enabled for PR #N` instead of failing.

Fixes #266
