### PR TITLE
fix: restore detector windows at effective size, not base (error_cascade / meltdown / loop)

### DIFF
--- a/src/snagline/detectors/error_cascade.py
+++ b/src/snagline/detectors/error_cascade.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from snagline.config import Config
 from snagline.detectors.base import snapshot_items
-from snagline.detectors.windowing import next_window
+from snagline.detectors.windowing import effective_window_size, next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -148,8 +148,22 @@ class ErrorCascadeDetector:
         }
 
     def load_state(self, state: dict[str, Any]) -> None:
+        # Restore each window at its effective size, not the base (issue
+        # #268): a snapshot taken mid-episode with auto-scaling on holds
+        # ``effective_window_size(...)`` flags, and a base-sized maxlen
+        # discards the oldest -- errors that lived inside the scaled window
+        # fall out of the density count exactly when a cascade is in
+        # progress. With scaling off the effective size is always the base.
         self._windows = {
-            ep: deque(flags, maxlen=self.window_size)
+            ep: deque(
+                flags,
+                maxlen=effective_window_size(
+                    self.window_size,
+                    int(state.get("counts", {}).get(ep, len(flags))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, flags in state.get("windows", {}).items()
         }
         # Tolerant .get(): pre-#92 snapshots carry no scaler positions.

--- a/src/snagline/detectors/loop.py
+++ b/src/snagline/detectors/loop.py
@@ -46,7 +46,7 @@ from typing import Any, cast
 
 from snagline.config import Config
 from snagline.detectors.base import snapshot_items
-from snagline.detectors.windowing import next_window
+from snagline.detectors.windowing import effective_window_size, next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk, TriggerType
 
@@ -398,31 +398,61 @@ class LoopDetector:
         }
 
     def load_state(self, state: dict[str, Any]) -> None:
-        self._windows = {
-            ep: deque(sigs, maxlen=self.window_size)
-            for ep, sigs in state.get("windows", {}).items()
-        }
+        # Restore each window at its effective size, not the base (issue
+        # #268): a snapshot taken mid-episode with auto-scaling on holds
+        # ``effective_window_size(...)`` signatures, and a base-sized maxlen
+        # discards the oldest occurrences -- a loop whose early repeats live
+        # inside the scaled window falls below threshold exactly when the
+        # live detector would escalate. With scaling off the effective size
+        # is always the base, so defaults are unchanged.
         # Tolerant .get() so pre-#92 snapshots restore cleanly; the counts only
         # position the auto-scaler and default to the window they imply.
-        self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
+        counts = state.get("counts", {})
+        self._windows = {
+            ep: deque(
+                sigs,
+                maxlen=effective_window_size(
+                    self.window_size,
+                    int(counts.get(ep, len(sigs))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
+            for ep, sigs in state.get("windows", {}).items()
+        }
+        self._counts = {ep: int(n) for ep, n in counts.items()}
         self._fired = {ep: set(sigs) for ep, sigs in state.get("fired", {}).items()}
+        near_counts = state.get("near_counts", {})
         self._near_windows = {
-            ep: deque(sigs, maxlen=self.window_size)
+            ep: deque(
+                sigs,
+                maxlen=effective_window_size(
+                    self.window_size,
+                    int(near_counts.get(ep, len(sigs))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, sigs in state.get("near_windows", {}).items()
         }
         self._near_fired = {
             ep: set(sigs) for ep, sigs in state.get("near_fired", {}).items()
         }
-        self._near_counts = {
-            ep: int(n) for ep, n in state.get("near_counts", {}).items()
-        }
+        self._near_counts = {ep: int(n) for ep, n in near_counts.items()}
+        cycle_counts = state.get("cycle_counts", {})
         self._cycle_windows = {
-            ep: deque(sigs, maxlen=self.loop_cycle_window_size)
+            ep: deque(
+                sigs,
+                maxlen=effective_window_size(
+                    self.loop_cycle_window_size,
+                    int(cycle_counts.get(ep, len(sigs))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, sigs in state.get("cycle_windows", {}).items()
         }
-        self._cycle_counts = {
-            ep: int(n) for ep, n in state.get("cycle_counts", {}).items()
-        }
+        self._cycle_counts = {ep: int(n) for ep, n in cycle_counts.items()}
         self._cycle_fired = dict(state.get("cycle_fired", {}))
         self._stall_sig = dict(state.get("stall_sig", {}))
         self._stall_count = dict(state.get("stall_count", {}))

--- a/src/snagline/detectors/meltdown.py
+++ b/src/snagline/detectors/meltdown.py
@@ -179,10 +179,23 @@ class MeltdownDetector:
         self._eps = {}
         for ep, keys in state.get("windows", {}).items():
             w = _EpisodeWindow()
+            # Tolerant .get(): pre-#92 snapshots carry no scaler positions.
+            n = int(state.get("counts", {}).get(ep, len(keys)))
+            # Restore at the window's effective size, not the base (issue
+            # #268): a snapshot taken mid-episode with auto-scaling on holds
+            # ``effective_window_size(...)`` identities, and pushing them
+            # through a base-sized cap discards exactly the history the
+            # scaler grew the window to preserve. ``observe`` then gates on
+            # ``len(w.window) < target`` and stays silent for the
+            # (effective - base) refill steps while entropy is actively
+            # collapsed. With scaling off the effective size is always the
+            # base, so defaults are unchanged.
+            target = effective_window_size(
+                self.window_size, n, self._scale_steps, self._max_window
+            )
             for key in keys:
-                w.push(key, self.window_size)
+                w.push(key, target)
             self._eps[ep] = w
-        # Tolerant .get(): pre-#92 snapshots carry no scaler positions.
         self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
         self._fired = {ep: bool(v) for ep, v in state.get("fired", {}).items()}
         self._clear_streak = {

--- a/tests/test_scaled_window_restore.py
+++ b/tests/test_scaled_window_restore.py
@@ -1,0 +1,236 @@
+"""Scaled-window snapshot/restore round-trip tests (issue #268).
+
+``load_state`` used to rebuild every detector window at the BASE
+``window_size`` even when auto-scaling (issue #92) had grown the live window
+to the effective size. The oldest items -- exactly the history scaling exists
+to preserve -- were silently truncated away, leaving the restored detector
+partially blind mid-episode: meltdown's full-window gate returned ``None``
+for the (effective - base) refill steps, and loop/error-cascade windows lost
+occurrences that lived inside the scaled window.
+
+These tests hold with ``window_scale_steps=0`` too (the default), but the
+defect only manifests with scaling on, so every detector is constructed with
+a scaling config and a steady-state episode long enough that the live window
+has grown past the base.
+"""
+
+from __future__ import annotations
+
+import json
+
+from snagline.config import Config
+from snagline.detectors.error_cascade import ErrorCascadeDetector
+from snagline.detectors.loop import LoopDetector
+from snagline.detectors.meltdown import MeltdownDetector
+from snagline.events import StepEvent
+
+
+def _cfg() -> Config:
+    # base 12, one scale step per 12 events, capped at 40: after 120+ events
+    # the effective window is 40 while the base is 12.
+    return Config(window_scale_steps=12, max_window=40)
+
+
+def _ev(
+    step: int,
+    *,
+    signature: str,
+    tool_name: str | None = "t",
+    action_type: str = "tool_call",
+    error: bool = False,
+) -> StepEvent:
+    return StepEvent(
+        step_id=str(step),
+        episode_id="ep",
+        timestamp=float(step),
+        action_type=action_type,
+        action_signature=signature,
+        tool_name=tool_name,
+        error=error,
+    )
+
+
+def _observe_all(det, events):
+    return [r for e in events if (r := det.observe(e)) is not None]
+
+
+def _round_trip(det):
+    det.load_state(json.loads(json.dumps(det.dump_state())))
+
+
+# --- meltdown: entropy collapsed at restore time -----------------------------
+
+
+def test_meltdown_scaled_window_survives_restore():
+    """A collapsed window is fully restored: the next step fires exactly as
+    the never-restarted twin does, with no refill blindness."""
+    live = MeltdownDetector(config=_cfg())
+    restored = MeltdownDetector(config=_cfg())
+    # 220 steps of one tool: effective window 40, entropy collapsed, but
+    # never fires (the episode is all one collapse from step 1, so fire the
+    # alarm is pre-latched) -- force the re-armed state a live monitor would
+    # have after a first alarm cleared.
+    collapse = [_ev(i, signature=f"sig-{i}", tool_name="search") for i in range(220)]
+    _observe_all(live, collapse)
+    _observe_all(restored, collapse)
+    for det in (live, restored):
+        det._fired["ep"] = False  # post-alarm re-armed, condition still active
+
+    restored.load_state(json.loads(json.dumps(restored.dump_state())))
+
+    nxt = [_ev(500 + i, signature=f"s5{i}", tool_name="search") for i in range(3)]
+    live_risks = _observe_all(live, nxt)
+    restored_risks = _observe_all(restored, nxt)
+    assert live_risks, "live detector must fire immediately on the active collapse"
+    assert restored_risks == live_risks, (
+        "restored detector must not be blinded by a base-sized window rebuild"
+    )
+
+
+def test_meltdown_restored_window_holds_effective_length():
+    live = MeltdownDetector(config=_cfg())
+    _observe_all(
+        live, [_ev(i, signature=f"sig-{i}", tool_name="t") for i in range(120)]
+    )
+    dumped = json.loads(json.dumps(live.dump_state()))
+    assert len(dumped["windows"]["ep"]) == 40, "live window must have scaled to 40"
+
+    restored = MeltdownDetector(config=_cfg())
+    restored.load_state(dumped)
+    assert len(restored._eps["ep"].window) == 40, (
+        "restored window must keep the effective length, not truncate to base 12"
+    )
+
+
+# --- loop: early occurrences inside the scaled window ------------------------
+
+
+def test_loop_scaled_window_survives_restore():
+    """Two early occurrences of a repeating signature -- inside the live
+    40-window, outside the base 12-tail -- must survive the restore so the
+    third occurrence fires, exactly like the never-restarted twin."""
+    events = []
+    step = 0
+    # 120 unique steps grow the effective window to 40.
+    for _ in range(120):
+        events.append(_ev(step, signature=f"unique-{step}"))
+        step += 1
+    # Two loop occurrences, then 13 fillers so both fall outside the base
+    # 12-tail but stay inside the scaled 40-window.
+    for _ in range(2):
+        events.append(_ev(step, signature="loopme"))
+        step += 1
+    for i in range(13):
+        events.append(_ev(step, signature=f"filler-{i}"))
+        step += 1
+
+    live = LoopDetector(config=_cfg())
+    restored = LoopDetector(config=_cfg())
+    for det in (live, restored):
+        _observe_all(det, events)
+    restored.load_state(json.loads(json.dumps(restored.dump_state())))
+
+    # The 3rd occurrence: 40/12 window holds all three for the live detector.
+    nxt = [_ev(step, signature="loopme")]
+    live_fired = _observe_all(live, nxt)
+    restored_fired = _observe_all(restored, nxt)
+    assert live_fired, "live detector must fire on the 3rd occurrence"
+    assert restored_fired == live_fired, (
+        "restored detector dropped the early occurrences via base-size truncation"
+    )
+
+
+def test_loop_restored_window_holds_effective_length():
+    live = LoopDetector(config=_cfg())
+    _observe_all(live, [_ev(i, signature=f"u-{i}") for i in range(120)])
+    dumped = json.loads(json.dumps(live.dump_state()))
+    assert len(dumped["windows"]["ep"]) == 40
+
+    restored = LoopDetector(config=_cfg())
+    restored.load_state(dumped)
+    assert restored._windows["ep"].maxlen == 40, (
+        "restored window maxlen must be the effective size, not the base 12"
+    )
+    assert len(restored._windows["ep"]) == 40
+
+
+# --- error_cascade: windowed density across the restart ----------------------
+
+
+def test_error_cascade_scaled_window_survives_restore():
+    """Errors that fell out of the base 12-tail but live in the scaled
+    40-window keep counting after restore, so the density alarm fires on
+    the same event the never-restarted twin fires on."""
+    events = []
+    step = 0
+    for _ in range(120):
+        events.append(_ev(step, signature=f"u-{step}", error=False))
+        step += 1
+    # Two counted errors, then 13 clean steps: outside the base tail,
+    # inside the scaled window.
+    for _ in range(2):
+        events.append(_ev(step, signature=f"e-{step}", error=True))
+        step += 1
+    for i in range(13):
+        events.append(_ev(step, signature=f"c-{i}", error=False))
+        step += 1
+
+    live = ErrorCascadeDetector(config=_cfg())
+    restored = ErrorCascadeDetector(config=_cfg())
+    for det in (live, restored):
+        _observe_all(det, events)
+    restored.load_state(json.loads(json.dumps(restored.dump_state())))
+
+    # 3rd error reaches cascade_error_threshold=3 inside the scaled window.
+    nxt = [_ev(step, signature="boom", error=True)]
+    live_fired = _observe_all(live, nxt)
+    restored_fired = _observe_all(restored, nxt)
+    assert live_fired, "live detector must fire on the 3rd error in window"
+    assert restored_fired == live_fired, (
+        "restored detector lost windowed errors via base-size truncation"
+    )
+
+
+def test_error_cascade_restored_window_holds_effective_length():
+    live = ErrorCascadeDetector(config=_cfg())
+    _observe_all(live, [_ev(i, signature=f"u-{i}") for i in range(120)])
+    dumped = json.loads(json.dumps(live.dump_state()))
+    assert len(dumped["windows"]["ep"]) == 40
+
+    restored = ErrorCascadeDetector(config=_cfg())
+    restored.load_state(dumped)
+    assert restored._windows["ep"].maxlen == 40, (
+        "restored window maxlen must be the effective size, not the base 10"
+    )
+    assert len(restored._windows["ep"]) == 40
+
+
+# --- scaling off: restore behavior unchanged ---------------------------------
+
+
+def test_no_scaling_restore_still_truncates_to_base():
+    """With scaling off (default) the effective size is the base, so the
+    tolerant-restore clamp behavior is preserved exactly."""
+    live = LoopDetector(config=Config())
+    _observe_all(live, [_ev(i, signature=f"u-{i}") for i in range(50)])
+    restored = LoopDetector(config=Config())
+    restored.load_state(json.loads(json.dumps(live.dump_state())))
+    assert restored._windows["ep"].maxlen == live.window_size
+
+
+# --- old snapshot payloads (pre-#92, no counts) still restore ----------------
+
+
+def test_pre92_payload_without_counts_restores_at_effective_size():
+    """Counts are absent in pre-#92 payloads: the fallback (window length)
+    still sizes the restore correctly for the truncated payload."""
+    live = LoopDetector(config=_cfg())
+    _observe_all(live, [_ev(i, signature=f"u-{i}") for i in range(120)])
+    dumped = json.loads(json.dumps(live.dump_state()))
+    del dumped["counts"]  # simulate a pre-#92 payload
+
+    restored = LoopDetector(config=_cfg())
+    restored.load_state(dumped)
+    assert len(restored._windows["ep"]) == 40, (
+        "fallback len(sigs) must still restore the full scaled window"
+    )


### PR DESCRIPTION
## Summary

With window auto-scaling on (`window_scale_steps > 0`, issue #92), live detector windows grow with the episode via `effective_window_size` — but `load_state` rebuilt every window at the **base** `self.window_size`, silently truncating the oldest items. A snapshot/restore mid-episode (monitor restart, sidecar handover, replay from snapshot) discarded exactly the history the scaler grew the window to preserve:

- **meltdown** (`meltdown.py`): `observe` gates on `len(w.window) < target`, so the restored detector returned `None` for `(effective − base)` refill steps while entropy was actively collapsed. Traced: live fires immediately, restored stays silent for +19 events.
- **loop** (`loop.py`): `_windows`, `_near_windows`, and `_cycle_windows` all truncated early occurrences out — a loop whose first repeats lived inside the scaled 40-window but outside the base 12-tail fell below `repeat_threshold` after restore. Traced: live fires on the 3rd occurrence, restored is silent.
- **error_cascade** (`error_cascade.py`): windowed density alarms lost errors living inside the scaled window.

## Fix

Each `load_state` now sizes the rebuilt window from the persisted per-episode counts — the same `effective_window_size(base, counts[ep], scale_steps, max_window)` the live path uses — falling back to `len(window)` for pre-#92 payloads that carry no counts. With scaling off (the default), the effective size is always the base, so default-config behavior is unchanged.

Same family as #218 / PR #219, which fixed `StagnationDetector` only; this covers the other three windowed detectors.

## Tests

New `tests/test_scaled_window_restore.py` (8 tests): JSON round-trip + live-vs-restored twin comparisons per detector with scaling on, restored-window length assertions, a scaling-off guard, and a pre-#92 payload fallback. **7 of 8 fail on pre-fix code** (verified by swapping in upstream files; the 8th asserts the unchanged scaling-off path and correctly passes both ways).

Full gates: `pytest -q` 723 passed / 87.51% coverage, `mypy src tests` clean, `ruff check` + `ruff format --check` clean, accuracy gate exit 0 (0 healthy-control firings).

Fixes #268


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Snapshot restoration now preserves the effective auto-scaled window sizes for error-cascade, loop, and meltdown detection.
  * Restored detectors retain historical events and continue detecting issues consistently after restart.
  * Older snapshots without scaling metadata remain compatible.
  * Fixed restoration behavior when auto-scaling is disabled so windows continue using their configured base size.

* **Tests**
  * Added coverage for scaled-window restoration, restart consistency, and legacy snapshot compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->