### PR TITLE
fix: global-mode auto-instrumentation actually patches modern SDKs

### DIFF
--- a/src/snagline/auto/anthropic.py
+++ b/src/snagline/auto/anthropic.py
@@ -3,6 +3,12 @@
 Mirrors ``snagline.auto.openai``: wraps ``client.messages.create`` so each
 call emits a ``StepEvent``. Import-safe (no-op when the SDK is absent) and
 handles sync and async clients.
+
+Global mode (issue #270) patches the *resource classes* --
+``anthropic.resources.messages.{Messages, AsyncMessages}`` -- rather than
+walking ``Anthropic.messages``: on modern Anthropic SDKs the client attribute
+is a ``functools.cached_property`` descriptor, so the old class-attribute
+walk resolved a descriptor, not a resource, and silently wrapped nothing.
 """
 
 from __future__ import annotations
@@ -38,9 +44,24 @@ def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
     monitor.ingest(event)
 
 
+def _is_async_call(original) -> bool:
+    """True if calling ``original`` returns a coroutine that must be awaited.
+
+    ``inspect.iscoroutinefunction`` alone misses async methods that carry a
+    decorator (the SDK wraps ``create`` with ``@required_args``), which would
+    misclassify them as sync: the wrapper would never await the call, record
+    only the coroutine-creation latency, and report ``error=False`` for every
+    failure. ``inspect.unwrap`` sees through ``__wrapped__`` chains; on plain
+    (including undecorated async) functions it is the identity.
+    """
+    return inspect.iscoroutinefunction(original) or inspect.iscoroutinefunction(
+        inspect.unwrap(original)
+    )
+
+
 def _wrap_one(monitor, original, tool_name):
     counter = itertools.count()
-    is_async = inspect.iscoroutinefunction(original)
+    is_async = _is_async_call(original)
 
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
@@ -77,21 +98,68 @@ def wrap_client(monitor, client):
     """Wrap ``client.messages.create`` in place. Returns the same client."""
     cur = getattr(client, "messages", None)
     if cur is None:
+        logger.warning(
+            "snagline.auto: wrap_client found no messages resource on %r", client
+        )
         return client
     method = getattr(cur, "create", None)
     if method is None or not callable(method):
+        logger.warning("snagline.auto: wrap_client found no create method on %r", cur)
         return client
     cur.create = _wrap_one(monitor, method, "anthropic.messages.create")
     return client
+
+
+def _patch_resource_classes(monitor) -> int:
+    """Patch ``Messages`` / ``AsyncMessages`` resource classes globally (#270).
+
+    ``anthropic.resources.messages.Messages.create`` is what every
+    ``Anthropic`` / ``AsyncAnthropic`` instance dispatches to, so wrapping it
+    covers all clients, present and future, without touching the clients'
+    ``cached_property`` surface.
+    Returns the number of methods newly wrapped. Classes that already carry
+    a snagline wrapper are skipped (re-instrumenting would double-count every
+    call), so a second call against the same SDK returns -1 (already done).
+    """
+    patched = 0
+    seen_wrapped = False
+    try:
+        from anthropic.resources.messages import (  # type: ignore
+            AsyncMessages,
+            Messages,
+        )
+    except Exception:  # pragma: no cover - defensive against SDK reshuffles
+        Messages = AsyncMessages = None
+
+    for cls in (Messages, AsyncMessages):
+        if cls is None:
+            continue
+        original = cls.__dict__.get("create")
+        if original is None or not callable(original):
+            continue
+        if getattr(original, "__snagline_wrapped__", False):
+            seen_wrapped = True
+            continue  # already instrumented; re-instrumenting would double-count
+        wrapper = _wrap_one(monitor, original, "anthropic.messages.create")
+        wrapper.__snagline_wrapped__ = True  # type: ignore[attr-defined]
+        wrapper.__snagline_original__ = original  # type: ignore[attr-defined]
+        cls.create = wrapper
+        patched += 1
+    # 0 new wraps + at least one already-wrapped class = fully instrumented,
+    # not a failure. Distinguish that from "found nothing to patch at all".
+    if patched == 0 and seen_wrapped:
+        return -1
+    return patched
 
 
 def instrument_anthropic(monitor, client=None) -> bool:
     """Instrument the Anthropic SDK.
 
     If ``client`` is provided, only that instance is wrapped. Otherwise the
-    installed ``anthropic.Anthropic`` / ``anthropic.AsyncAnthropic`` classes
-    are patched globally. Returns True if anything was patched, False if the
-    SDK is not importable.
+    SDK's resource classes (``Messages`` / ``AsyncMessages``) are patched
+    globally, so every client -- present or future -- is observed. Returns
+    True if anything was patched, False if the SDK is not importable or
+    nothing could be patched.
     """
     if client is not None:
         wrap_client(monitor, client)
@@ -99,7 +167,11 @@ def instrument_anthropic(monitor, client=None) -> bool:
     if Anthropic is None:
         logger.warning("snagline.auto: Anthropic SDK not installed; nothing to patch")
         return False
-    wrap_client(monitor, Anthropic)
-    if AsyncAnthropic is not None:
-        wrap_client(monitor, AsyncAnthropic)
+    patched = _patch_resource_classes(monitor)
+    if patched == 0:
+        logger.warning(
+            "snagline.auto: Anthropic SDK present but no create method could "
+            "be patched; clients are NOT monitored"
+        )
+        return False
     return True

--- a/src/snagline/auto/openai.py
+++ b/src/snagline/auto/openai.py
@@ -8,6 +8,13 @@ per-call instrumentation.
 The module is import-safe: it imports fine without the OpenAI SDK installed,
 and ``instrument_openai`` only patches the SDK when it is actually present (or
 when a client is passed explicitly). Sync and async clients are both handled.
+
+Global mode (issue #270) patches the *resource classes* -- ``Completions`` and
+``AsyncCompletions`` -- rather than walking ``OpenAI.chat``: since OpenAI SDK
+1.0 the client attributes are ``functools.cached_property`` descriptors, so the
+old class-attribute walk resolved a descriptor, not a resource, and silently
+wrapped nothing. The resource classes' ``create`` is what every instance call
+dispatches to, so patching them covers all clients, current and future.
 """
 
 from __future__ import annotations
@@ -43,9 +50,25 @@ def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
     monitor.ingest(event)
 
 
+def _is_async_call(original) -> bool:
+    """True if calling ``original`` returns a coroutine that must be awaited.
+
+    ``inspect.iscoroutinefunction`` alone misses async methods that carry a
+    decorator (the OpenAI/Anthropic SDKs wrap ``create`` with
+    ``@required_args``), which would misclassify them as sync: the wrapper
+    would never await the call, record only the coroutine-creation latency,
+    and report ``error=False`` for every failure. ``inspect.unwrap`` sees
+    through ``__wrapped__`` chains; on plain (including undecorated async)
+    functions it is the identity.
+    """
+    return inspect.iscoroutinefunction(original) or inspect.iscoroutinefunction(
+        inspect.unwrap(original)
+    )
+
+
 def _wrap_one(monitor, original, tool_name):
     counter = itertools.count()
-    is_async = inspect.iscoroutinefunction(original)
+    is_async = _is_async_call(original)
 
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
@@ -85,6 +108,7 @@ def wrap_client(monitor, client):
     (whichever exist) so each call emits a ``StepEvent``. Returns the same
     client for chaining.
     """
+    patched = 0
     for path in ("chat.completions.create", "completions.create"):
         cur = client
         ok = True
@@ -95,20 +119,88 @@ def wrap_client(monitor, client):
                 break
         if not ok:
             continue
-        method = getattr(cur, path.split(".")[-1], None)
+        name = path.split(".")[-1]
+        method = getattr(cur, name, None)
         if method is None or not callable(method):
             continue
-        setattr(cur, path.split(".")[-1], _wrap_one(monitor, method, "openai." + path))
+        setattr(cur, name, _wrap_one(monitor, method, "openai." + path))
+        patched += 1
+    if patched == 0:
+        logger.warning(
+            "snagline.auto: wrap_client found no create method to patch on %r",
+            client,
+        )
     return client
+
+
+def _patch_resource_classes(monitor) -> int:
+    """Patch the SDK's resource classes globally (issue #270).
+
+    ``openai.resources.chat.completions.completions.{Completions,
+    AsyncCompletions}`` and the legacy ``completions`` pair are the classes
+    every ``OpenAI`` / ``AsyncOpenAI`` instance dispatches ``create`` to, so
+    wrapping their methods covers all current and future clients without
+    touching the clients' ``cached_property`` surface.
+
+    Returns the number of methods newly wrapped. Classes that already carry
+    a snagline wrapper are skipped (re-instrumenting would double-count every
+    call), so a second call against the same SDK returns 0.
+    """
+    patched = 0
+    seen_wrapped = False
+    try:
+        from openai.resources.chat.completions.completions import (  # type: ignore
+            AsyncCompletions as ChatAsync,
+        )
+        from openai.resources.chat.completions.completions import (
+            Completions as ChatSync,
+        )
+    except Exception:  # pragma: no cover - defensive against SDK reshuffles
+        ChatSync = ChatAsync = None
+    try:
+        from openai.resources.completions import (  # type: ignore
+            AsyncCompletions as LegacyAsync,
+        )
+        from openai.resources.completions import (
+            Completions as LegacySync,
+        )
+    except Exception:  # pragma: no cover - defensive against SDK reshuffles
+        LegacySync = LegacyAsync = None
+
+    for cls, tool_name in [
+        (ChatSync, "openai.chat.completions.create"),
+        (ChatAsync, "openai.chat.completions.create"),
+        (LegacySync, "openai.completions.create"),
+        (LegacyAsync, "openai.completions.create"),
+    ]:
+        if cls is None:
+            continue
+        original = cls.__dict__.get("create")
+        if original is None or not callable(original):
+            continue
+        if getattr(original, "__snagline_wrapped__", False):
+            seen_wrapped = True
+            continue  # already instrumented; re-instrumenting would double-count
+        wrapper = _wrap_one(monitor, original, tool_name)
+        wrapper.__snagline_wrapped__ = True  # type: ignore[attr-defined]
+        wrapper.__snagline_original__ = original  # type: ignore[attr-defined]
+        cls.create = wrapper
+        patched += 1
+    # 0 new wraps + at least one already-wrapped class = fully instrumented,
+    # not a failure. Distinguish that from "found nothing to patch at all".
+    if patched == 0 and seen_wrapped:
+        return -1
+    return patched
 
 
 def instrument_openai(monitor, client=None) -> bool:
     """Instrument the OpenAI SDK.
 
     If ``client`` is provided, only that instance is wrapped. Otherwise the
-    installed ``openai.OpenAI`` / ``openai.AsyncOpenAI`` classes are patched
-    globally (so every future client is observed). Returns True if anything
-    was patched, False if the SDK is not importable.
+    SDK's resource classes (``Completions`` / ``AsyncCompletions`` for both
+    chat and legacy completions) are patched globally, so every client --
+    present or future -- is observed. Returns True if anything was patched,
+    False if the SDK is not importable or nothing could be patched.
     """
     if client is not None:
         wrap_client(monitor, client)
@@ -116,7 +208,11 @@ def instrument_openai(monitor, client=None) -> bool:
     if OpenAI is None:
         logger.warning("snagline.auto: OpenAI SDK not installed; nothing to patch")
         return False
-    wrap_client(monitor, OpenAI)
-    if AsyncOpenAI is not None:
-        wrap_client(monitor, AsyncOpenAI)
+    patched = _patch_resource_classes(monitor)
+    if patched == 0:
+        logger.warning(
+            "snagline.auto: OpenAI SDK present but no create method could be "
+            "patched; clients are NOT monitored"
+        )
+        return False
     return True

--- a/tests/test_auto_global_mode.py
+++ b/tests/test_auto_global_mode.py
@@ -1,0 +1,310 @@
+"""Global-mode auto-instrumentation tests (issue #270).
+
+The real OpenAI/Anthropic SDKs expose their resources through
+``functools.cached_property`` descriptors on the client classes
+(``OpenAI.chat``, ``Anthropic.messages``), and wrap ``create`` with
+decorators like ``@required_args`` that hide the underlying ``async def``.
+``instrument_openai`` / ``instrument_anthropic`` in global mode used to walk
+the *client* class attributes, which resolves a descriptor (not a resource),
+wraps nothing, and still returns ``True`` -- a completely unmonitored process
+reporting success.
+
+These tests reproduce both SDK shapes with local fakes (no SDK install
+needed): a ``cached_property`` client surface and decorated ``create``
+methods carrying ``__wrapped__``. They pin the fixed behavior: global mode
+patches the resource classes' ``create``, sync and async calls both emit
+events with correct error flags, and re-instrumenting is idempotent.
+
+Fresh resource classes are minted per test: the wrapper sets a
+``__snagline_wrapped__`` marker on the class attribute, so reusing one class
+across tests would leak "already instrumented" state.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import inspect
+import sys
+import types
+
+import pytest
+
+import snagline.auto.anthropic as anth_mod
+import snagline.auto.openai as oai_mod
+from snagline.auto.anthropic import instrument_anthropic
+from snagline.auto.openai import instrument_openai
+
+
+class _SpyMonitor:
+    def __init__(self):
+        self.events: list = []
+
+    def ingest(self, event) -> None:
+        self.events.append(event)
+
+
+def _required_args_fake(fn):
+    """Stand-in for the SDKs' ``@required_args``: a decorator that hides the
+    wrapped function's coroutine nature from ``iscoroutinefunction``."""
+
+    def inner(*args, **kwargs):
+        return fn(*args, **kwargs)
+
+    inner.__wrapped__ = fn  # type: ignore[attr-defined]
+    return inner
+
+
+def _fresh_resource_classes():
+    """A fresh sync/async resource-class pair with the SDK's real shape."""
+
+    class Sync:
+        @_required_args_fake
+        def create(self, *, model="gpt", messages=None, **kw):
+            return "sync-ok"
+
+    class Async:
+        @_required_args_fake
+        async def create(self, *, model="gpt", messages=None, **kw):
+            await asyncio.sleep(0)
+            return "async-ok"
+
+    return Sync, Async
+
+
+class _ChatHolder:
+    def __init__(self, resource):
+        self.completions = resource
+
+
+class _FakeSdkClient:
+    """Client whose resource access mirrors the cached_property shape."""
+
+    def __init__(self, resource):
+        self._resource = resource
+
+    @functools.cached_property
+    def chat(self):
+        return _ChatHolder(self._resource)
+
+    @functools.cached_property
+    def messages(self):
+        return self._resource
+
+
+@pytest.fixture
+def fake_openai_sdk(monkeypatch):
+    """Install a fake ``openai`` package shaped like the real one."""
+    sync_cls, async_cls = _fresh_resource_classes()
+    chat_mod = types.ModuleType("openai.resources.chat.completions.completions")
+    chat_mod.Completions = sync_cls  # type: ignore[attr-defined]
+    chat_mod.AsyncCompletions = async_cls  # type: ignore[attr-defined]
+    legacy_mod = types.ModuleType("openai.resources.completions")
+    legacy_mod.Completions = sync_cls  # type: ignore[attr-defined]
+    legacy_mod.AsyncCompletions = async_cls  # type: ignore[attr-defined]
+    for name in (
+        "openai",
+        "openai.resources",
+        "openai.resources.chat",
+        "openai.resources.chat.completions",
+        "openai.resources.chat.completions.completions",
+        "openai.resources.completions",
+    ):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    monkeypatch.setitem(
+        sys.modules, "openai.resources.chat.completions.completions", chat_mod
+    )
+    monkeypatch.setitem(sys.modules, "openai.resources.completions", legacy_mod)
+    return chat_mod, legacy_mod
+
+
+@pytest.fixture
+def fake_anthropic_sdk(monkeypatch):
+    sync_cls, async_cls = _fresh_resource_classes()
+    mod = types.ModuleType("anthropic.resources.messages")
+    mod.Messages = sync_cls  # type: ignore[attr-defined]
+    mod.AsyncMessages = async_cls  # type: ignore[attr-defined]
+    for name in (
+        "anthropic",
+        "anthropic.resources",
+        "anthropic.resources.messages",
+    ):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    monkeypatch.setitem(sys.modules, "anthropic.resources.messages", mod)
+    return mod
+
+
+@pytest.fixture
+def openai_present(monkeypatch):
+    """Make the module-level SDK sentinels non-None so global mode runs."""
+    monkeypatch.setattr(oai_mod, "OpenAI", object)
+    monkeypatch.setattr(oai_mod, "AsyncOpenAI", object)
+
+
+@pytest.fixture
+def anthropic_present(monkeypatch):
+    monkeypatch.setattr(anth_mod, "Anthropic", object)
+    monkeypatch.setattr(anth_mod, "AsyncAnthropic", object)
+
+
+# --- _is_async_call sees through decorators ----------------------------------
+
+
+def test_is_async_call_detects_decorated_async():
+    @_required_args_fake
+    async def f():
+        return None
+
+    assert inspect.iscoroutinefunction(f) is False, "fixture must hide async-ness"
+    assert oai_mod._is_async_call(f) is True
+    assert anth_mod._is_async_call(f) is True
+
+
+def test_is_async_call_plain_sync_and_async():
+    def s():
+        return 1
+
+    async def a():
+        return 1
+
+    assert oai_mod._is_async_call(s) is False
+    assert oai_mod._is_async_call(a) is True
+
+
+# --- wrap_client warns when it patches nothing -------------------------------
+
+
+def test_wrap_client_warns_when_nothing_patched(caplog):
+    class _Bare:
+        pass
+
+    with caplog.at_level("WARNING", logger="snagline"):
+        oai_mod.wrap_client(None, _Bare())
+    assert any("no create method" in r.message for r in caplog.records)
+
+
+# --- global mode: patches the resource classes, not the client walk ----------
+
+
+def test_instrument_openai_global_patches_resource_classes(
+    fake_openai_sdk, openai_present
+):
+    mon = _SpyMonitor()
+    # The pre-#270 walk resolved the cached_property descriptor and wrapped
+    # nothing; the fixed global mode patches the resource classes.
+    assert instrument_openai(mon) is True
+    chat, legacy = fake_openai_sdk
+    assert "create" in chat.Completions.__dict__
+    assert getattr(chat.Completions.create, "__snagline_wrapped__", False) is True
+    assert getattr(chat.AsyncCompletions.create, "__snagline_wrapped__", False) is True
+    assert getattr(legacy.Completions.create, "__snagline_wrapped__", False) is True
+
+    # Sync calls through resource instances emit events.
+    out = chat.Completions().create(model="gpt", messages=[{"role": "user"}])
+    assert out == "sync-ok"
+    assert len(mon.events) == 1
+    assert mon.events[0].error is False
+    assert mon.events[0].tool_name == "openai.chat.completions.create"
+
+    # Async leg: the wrapper must await the decorated async create.
+    result = asyncio.run(chat.AsyncCompletions().create(model="gpt", messages=[]))
+    assert result == "async-ok"
+    assert len(mon.events) == 2
+    assert mon.events[1].error is False
+
+
+def test_instrument_openai_global_async_error_flag(fake_openai_sdk, openai_present):
+    """A failing decorated async create must surface error=True: the sync
+    misclassification would have swallowed it (never awaited, never raised)."""
+    chat, _ = fake_openai_sdk
+
+    class _Boom:
+        @_required_args_fake
+        async def create(self, **kw):
+            raise RuntimeError("boom")
+
+    chat.AsyncCompletions = _Boom
+    mon = _SpyMonitor()
+    assert instrument_openai(mon) is True
+    with pytest.raises(RuntimeError):
+        asyncio.run(chat.AsyncCompletions().create(model="gpt", messages=[]))
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+
+
+def test_instrument_openai_global_is_idempotent(fake_openai_sdk, openai_present):
+    mon = _SpyMonitor()
+    assert instrument_openai(mon) is True
+    # First wrap count: one wrapper layer on each class create.
+    chat, _ = fake_openai_sdk
+    assert chat.Completions.create.__qualname__.count("_wrap_one") == 1
+
+    # Re-instrumenting must not double-wrap (double events per call).
+    assert instrument_openai(_SpyMonitor()) is True
+    assert chat.Completions.create.__qualname__.count("_wrap_one") == 1
+    chat.Completions().create(model="gpt", messages=[])
+    assert len(mon.events) == 1, "single event per call, not one per wrapper layer"
+
+
+def test_instrument_anthropic_global_patches_resource_classes(
+    fake_anthropic_sdk, anthropic_present
+):
+    mon = _SpyMonitor()
+    assert instrument_anthropic(mon) is True
+    resource = fake_anthropic_sdk
+    assert getattr(resource.Messages.create, "__snagline_wrapped__", False) is True
+    assert getattr(resource.AsyncMessages.create, "__snagline_wrapped__", False) is True
+
+    out = resource.Messages().create(model="claude", messages=[{"role": "user"}])
+    assert out == "sync-ok"
+    assert len(mon.events) == 1
+    assert mon.events[0].tool_name == "anthropic.messages.create"
+
+    result = asyncio.run(resource.AsyncMessages().create(model="claude", messages=[]))
+    assert result == "async-ok"
+    assert len(mon.events) == 2
+
+
+def test_instrument_global_returns_false_when_nothing_patchable(
+    monkeypatch, openai_present, caplog
+):
+    # SDK sentinel present, but resource classes carry no create method.
+    resource = types.ModuleType("openai.resources.chat.completions.completions")
+    resource.Completions = type("NoCreate", (), {})  # type: ignore[attr-defined]
+    resource.AsyncCompletions = type("NoCreate", (), {})  # type: ignore[attr-defined]
+    legacy = types.ModuleType("openai.resources.completions")
+    legacy.Completions = type("NoCreate", (), {})  # type: ignore[attr-defined]
+    legacy.AsyncCompletions = type("NoCreate", (), {})  # type: ignore[attr-defined]
+    for name in (
+        "openai",
+        "openai.resources",
+        "openai.resources.chat",
+        "openai.resources.chat.completions",
+        "openai.resources.chat.completions.completions",
+        "openai.resources.completions",
+    ):
+        monkeypatch.setitem(sys.modules, name, types.ModuleType(name))
+    monkeypatch.setitem(
+        sys.modules, "openai.resources.chat.completions.completions", resource
+    )
+    monkeypatch.setitem(sys.modules, "openai.resources.completions", legacy)
+
+    with caplog.at_level("WARNING", logger="snagline"):
+        result = instrument_openai(_SpyMonitor())
+    assert result is False, "must not claim success when nothing was patched"
+    assert any("NOT monitored" in r.message for r in caplog.records)
+
+
+def test_instrument_global_does_not_walk_client_cached_property(
+    fake_openai_sdk, openai_present
+):
+    """The exact #270 failure shape: a client whose resource attribute is a
+    cached_property descriptor. The fixed global mode patches the resource
+    classes, so calls through a descriptor-shaped client still emit."""
+    mon = _SpyMonitor()
+    chat, _ = fake_openai_sdk
+    assert instrument_openai(mon) is True
+    client = _FakeSdkClient(chat.Completions())
+    out = client.chat.completions.create(model="gpt", messages=[])
+    assert out == "sync-ok"
+    assert len(mon.events) == 1


### PR DESCRIPTION
## Summary

Global-mode `instrument_openai` / `instrument_anthropic` walked the *client* classes' attributes — but since OpenAI SDK 1.0 and current Anthropic SDKs, `OpenAI.chat` / `Anthropic.messages` are `functools.cached_property` **descriptors**. The walk resolved a descriptor, wrapped nothing, and still returned `True`. The documented P0 one-liner (`docs/INTEGRATION_MATRIX.md`) produced a completely unmonitored process reporting success.

Verified against the real SDKs: `openai` 3.8.0 — `type(openai.OpenAI.__dict__['chat'])` is `functools.cached_property`, `instrument_openai(monitor)` returns `True`, yet `client.chat.completions.create.__qualname__` stays `'Completions.create'` and zero events reach the monitor. Same for `anthropic` 1.4.0.

## Fixes

1. **Patch the resource classes, not the client surface.** Global mode now wraps `Completions`/`AsyncCompletions` (chat + legacy) and `Messages`/`AsyncMessages` — the classes every instance dispatches `create` to. Covers all clients, present and future.
2. **Honest return values.** Re-instrumenting an already-wrapped SDK returns `True` (idempotent — wrappers are marked and skipped so calls never double-count); a genuinely unpatchable SDK returns `False` with a warning instead of a silent success. `wrap_client` also warns when it patches nothing.
3. **Async detection through decorators.** Both SDKs decorate `create` with `@required_args`, which hides the coroutine from `iscoroutinefunction` — so `_wrap_one` picked the sync wrapper, never awaited the call, recorded coroutine-creation latency, and reported `error=False` for every failure. `_wrap_one` now also checks `inspect.unwrap`.

## Tests

New `tests/test_auto_global_mode.py` (9 tests): fake SDK modules with the real-world shapes (`cached_property` client surface, decorated `create` with `__wrapped__`) — resource-class patching, sync + async event emission, async error propagation, idempotency, unpatchable-SDK `False`, and the exact #270 client-walk failure shape. **All 9 substantive tests fail on pre-fix code** (vacuity-verified by swapping in upstream files).

End-to-end verified on real `openai` 3.8.0 and `anthropic` 1.4.0 (sync + async legs, correct `error` flags, idempotent second call).

Full gates: `pytest -q` 732 passed / 87.99% coverage, `mypy src tests` clean, `ruff check` + `ruff format --check` clean, accuracy gate exit 0.

Fixes #270
