### PR TITLE
fix(monitor): enforce per-episode retention cap across snapshot restore (#273)

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -758,11 +758,14 @@ class Monitor:
                 "warned": clock.warned,
                 "breached": clock.breached,
             }
+        with self._live_lock:
+            live_episodes = list(self._live_episodes.keys())
         return {
             "format_version": SNAPSHOT_FORMAT_VERSION,
             "detectors": detectors,
             "sinks": sinks,
             "time_axis": time_axis,
+            "live_episodes": live_episodes,
         }
 
     def snapshot(self, path: str) -> None:
@@ -843,21 +846,7 @@ class Monitor:
                 load(dumped_sinks[key])
         time_axis_data = data.get("time_axis")
         if isinstance(time_axis_data, dict):
-            # Restore clocks in order of last_ts ascending so most recent
-            # survives if we must evict under cap. Fall back to sorted keys
-            # for deterministic behavior when last_ts is missing.
-            try:
-                ordered = sorted(
-                    time_axis_data.items(),
-                    key=lambda kv: (
-                        float(kv[1].get("last_ts", 0.0))  # type: ignore[arg-type]
-                        if isinstance(kv[1], dict)
-                        else 0.0
-                    ),
-                )
-            except Exception:
-                ordered = sorted(time_axis_data.items())
-            for episode_id, clock_data in ordered:
+            for episode_id, clock_data in time_axis_data.items():
                 if not isinstance(episode_id, str) or not isinstance(clock_data, dict):
                     continue
                 try:
@@ -879,17 +868,82 @@ class Monitor:
                 clock.idle_fired = idle_fired
                 clock.warned = warned
                 clock.breached = breached
-                with self._live_lock:
-                    if episode_id in self._live_episodes:
-                        self._live_episodes.move_to_end(episode_id)
-                    else:
-                        self._live_episodes[episode_id] = None
-                        if len(self._live_episodes) > self._max_live_episodes:
-                            evicted, _ = self._live_episodes.popitem(last=False)
-                            self._clocks.pop(evicted, None)
-                    self._clocks[episode_id] = clock
-            # If we evicted due to cap, live_snapshot entries not in time_axis
-            # are already accounted for; no further action needed.
+                self._clocks[episode_id] = clock
+
+        # Issue #273: Gather restored episode ids in ascending LRU order and
+        # register them in _live_episodes so the per-episode retention cap
+        # (#184) holds across restore and over-cap detector state is evicted.
+        ordered_episodes: list[str] = []
+        seen_episodes: set[str] = set()
+
+        recorded_live = data.get("live_episodes")
+        if isinstance(recorded_live, list):
+            for ep in recorded_live:
+                if isinstance(ep, str) and ep not in seen_episodes:
+                    seen_episodes.add(ep)
+                    ordered_episodes.append(ep)
+
+        if isinstance(time_axis_data, dict):
+            try:
+                sorted_clocks = sorted(
+                    time_axis_data.items(),
+                    key=lambda kv: (
+                        float(kv[1].get("last_ts", 0.0))
+                        if isinstance(kv[1], dict)
+                        else 0.0
+                    ),
+                )
+            except Exception:
+                sorted_clocks = sorted(time_axis_data.items())
+            for ep, _ in sorted_clocks:
+                if isinstance(ep, str) and ep not in seen_episodes:
+                    seen_episodes.add(ep)
+                    ordered_episodes.append(ep)
+
+        # Inspect loaded detectors for any remaining episodes (e.g. snapshots
+        # taken when horizon knobs were off or from older snapshot versions)
+        for detector in self._detectors:
+            for attr in (
+                "_windows",
+                "_counts",
+                "_fired",
+                "_near_windows",
+                "_cycle_windows",
+                "_tokens",
+                "_last",
+                "_live",
+                "_eps",
+                "_episodes",
+            ):
+                mapping = getattr(detector, attr, None)
+                if isinstance(mapping, dict):
+                    for ep in mapping.keys():
+                        if isinstance(ep, str) and ep not in seen_episodes:
+                            seen_episodes.add(ep)
+                            ordered_episodes.append(ep)
+            states = getattr(detector, "_states", None)
+            if isinstance(states, dict):
+                for key in states.keys():
+                    ep = key[0] if isinstance(key, tuple) else key
+                    if isinstance(ep, str) and ep not in seen_episodes:
+                        seen_episodes.add(ep)
+                        ordered_episodes.append(ep)
+
+        # Register restored episodes in _live_episodes and enforce retention cap
+        to_evict: list[str] = []
+        with self._live_lock:
+            self._live_episodes.clear()
+            for ep in ordered_episodes:
+                if ep in self._live_episodes:
+                    self._live_episodes.move_to_end(ep)
+                else:
+                    self._live_episodes[ep] = None
+            while len(self._live_episodes) > self._max_live_episodes:
+                evicted, _ = self._live_episodes.popitem(last=False)
+                to_evict.append(evicted)
+
+        for evicted in to_evict:
+            self._evict_episode(evicted)
 
     def restore(self, path: str, strict_names: bool = False) -> None:
         """Load a JSON snapshot written by :meth:`snapshot`."""

--- a/tests/test_per_episode_cap.py
+++ b/tests/test_per_episode_cap.py
@@ -159,3 +159,62 @@ def test_bounded_memory_repro() -> None:
         )
     )
     assert mon.retained_episodes == 10000
+
+
+def test_cap_enforced_across_restore_and_detector_freed(tmp_path) -> None:
+    """Issue #273: restore() must enforce retention cap and evict detector state."""
+    path = str(tmp_path / "snapshot.json")
+
+    # Source monitor with high cap ingests 5 episodes A..E
+    source = Monitor.default(
+        config=Config(max_live_episodes=100, max_episode_wall_seconds=1000), sinks=[]
+    )
+    for i, ep in enumerate(["A", "B", "C", "D", "E"]):
+        source.ingest(_event(ep, ts=float(i + 1)))
+    source.snapshot(path)
+
+    # Destination monitor has cap of 2
+    target = Monitor.default(
+        config=Config(max_live_episodes=2, max_episode_wall_seconds=1000), sinks=[]
+    )
+    target.restore(path)
+
+    # Live episodes and retained count must be capped at 2, preserving the newest ('D', 'E')
+    assert target.retained_episodes == 2
+    assert target.metrics()["retained_episodes"] == 2
+    assert list(target._live_episodes.keys()) == ["D", "E"]
+
+    # Over-cap episodes' detector state ('A', 'B', 'C') must be completely evicted
+    for det in target._detectors:
+        if hasattr(det, "_windows"):
+            windows = det._windows
+            assert "A" not in windows
+            assert "B" not in windows
+            assert "C" not in windows
+            assert "D" in windows
+            assert "E" in windows
+
+    # Clocks must also reflect only 'D' and 'E'
+    assert set(target._clocks.keys()) == {"D", "E"}
+
+
+def test_cap_enforced_across_restore_without_horizon_knobs(tmp_path) -> None:
+    """Issue #273: restore() enforces cap even when horizon time-axis is inactive."""
+    path = str(tmp_path / "snapshot_nohorizon.json")
+
+    source = Monitor.default(
+        config=Config(max_live_episodes=100, max_episode_wall_seconds=None), sinks=[]
+    )
+    for i, ep in enumerate(["A", "B", "C", "D", "E"]):
+        source.ingest(_event(ep, ts=float(i + 1)))
+    source.snapshot(path)
+
+    target = Monitor.default(
+        config=Config(max_live_episodes=2, max_episode_wall_seconds=None), sinks=[]
+    )
+    target.restore(path)
+
+    assert target.retained_episodes == 2
+    for det in target._detectors:
+        if hasattr(det, "_windows"):
+            assert len(det._windows) == 2


### PR DESCRIPTION
Closes #273

## Summary
When restoring a snapshot, `Monitor.restore_dict()` previously loaded detector state for all episodes without registering them into the `_live_episodes` LRU if the horizon time-axis was inactive. Furthermore, the eviction logic only cleared `self._clocks[evicted]` instead of executing `self._evict_episode(evicted)`. This caused over-cap restored episodes to linger indefinitely in detector memory while `retained_episodes` reported only the cap.

## Changes
- **`snapshot_dict()`**: Persists `"live_episodes": list(self._live_episodes.keys())` to preserve exact LRU ordering across restarts.
- **`restore_dict()`**:
  - Gathers all restored episode IDs in ascending LRU order across `live_episodes`, `time_axis` (ordered by `last_ts`), and loaded detectors.
  - Registers them in `_live_episodes` and pops over-cap episodes oldest-first.
  - Calls `self._evict_episode(evicted)` for each over-cap ID, executing `detector.reset(ep)` across all detectors and releasing clocks/locks.
- **Tests**: Added `test_cap_enforced_across_restore_and_detector_freed` and `test_cap_enforced_across_restore_without_horizon_knobs` in `tests/test_per_episode_cap.py` matching the reproduction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restoring saved monitor state now correctly rebuilds active episode tracking.
  * Per-episode retention limits are enforced during restore, removing excess episode data and associated detector state.
  * Episode clocks and detector windows now remain consistent with the retained episodes, including when horizon limits are disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->