### PR TITLE
fix(monitor): reject incompatible restore before mutation

### DIFF
--- a/tests/test_monitor_snapshot.py
+++ b/tests/test_monitor_snapshot.py
@@ -172,6 +172,40 @@ def test_composition_mismatch_strict_vs_tolerant(tmp_path):
     )  # cascade has no ep state yet
 
 
+def test_strict_restore_rejection_does_not_apply_detector_state(tmp_path):
+    """A rejected strict restore leaves the target monitor untouched."""
+    path = str(tmp_path / "state.json")
+    source = Monitor([LoopDetector(), ErrorCascadeDetector()], [ListSink()])
+    source.ingest(
+        StepEvent(
+            step_id="0",
+            episode_id="ep",
+            timestamp=0.0,
+            action_type="tool_call",
+            action_signature="q-a",
+            tool_name="search",
+        )
+    )
+    source.ingest(
+        StepEvent(
+            step_id="1",
+            episode_id="ep",
+            timestamp=1.0,
+            action_type="tool_call",
+            action_signature="q-a",
+            tool_name="search",
+        )
+    )
+    source.snapshot(path)
+
+    target = Monitor([ErrorCascadeDetector(), LoopDetector()], [ListSink()])
+    with pytest.raises(ValueError, match="composition mismatch"):
+        target.restore(path, strict_names=True)
+
+    loop = cast(LoopDetector, target._detectors[1])
+    assert loop._windows == {}
+
+
 def test_dedup_sink_cooldown_survives_round_trip(tmp_path):
     from snagline.risk import FailureRisk
 


### PR DESCRIPTION
## Summary

Fixes #236.

`Monitor.restore_dict(strict_names=True)` previously loaded matching detector state before validating the snapshot composition. A rejected restore could therefore leave the monitor partially mutated.

## Changes

- Validate the detector composition before calling any detector `load_state()` method.
- Preserve tolerant restore behavior when `strict_names=False`.
- Add a regression test proving a rejected restore leaves the target detector state empty.

## Validation

- `pytest -q --no-cov tests/test_monitor_snapshot.py` — 8 passed
- `ruff check src/snagline/monitor.py tests/test_monitor_snapshot.py` — passed
- `mypy src tests` — passed

Related issue: #236

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strict monitor state restoration now rejects detector-composition mismatches before applying any detector state.
  * Failed strict restores no longer leave the monitor partially updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->