### PR TITLE
fix(sink): preserve rate limiting across batch flushes

### DIFF
--- a/src/snagline/sinks/batching.py
+++ b/src/snagline/sinks/batching.py
@@ -44,6 +44,11 @@ class BatchingSink:
         self._min_gap = 1.0 / max_per_second if max_per_second else 0.0
         self._queue: collections.deque[FailureRisk] = collections.deque()
         self._lock = threading.Lock()
+        # Delivery pacing is shared across every batch and flush path. Keep it
+        # separate from the queue lock so sleeping or calling the wrapped sink
+        # never blocks ``emit``.
+        self._delivery_lock = threading.Lock()
+        self._last_delivery: float | None = None
         self._stop = threading.Event()
         # Set when the queue reaches ``max_batch`` (or on close) so the flusher
         # can wake early instead of sitting out the rest of the interval.
@@ -85,17 +90,20 @@ class BatchingSink:
         self._deliver(batch)
 
     def _deliver(self, batch: list[FailureRisk]) -> None:
-        last = 0.0
-        for risk in batch:
-            if self._min_gap:
-                now = time.monotonic()
-                wait = self._min_gap - (now - last)
-                if wait > 0:
-                    time.sleep(wait)
-                last = time.monotonic()
-            with contextlib.suppress(Exception):
-                # Fail-open: a delivery failure must not poison the queue.
-                self._sink.emit(risk)
+        with self._delivery_lock:
+            for risk in batch:
+                if self._min_gap:
+                    now = time.monotonic()
+                    if self._last_delivery is not None:
+                        wait = self._min_gap - (now - self._last_delivery)
+                        if wait > 0:
+                            time.sleep(wait)
+                    # Record the actual delivery start, including failed
+                    # attempts, so failures cannot create an unpaced burst.
+                    self._last_delivery = time.monotonic()
+                with contextlib.suppress(Exception):
+                    # Fail-open: a delivery failure must not poison the queue.
+                    self._sink.emit(risk)
 
     def flush_now(self) -> None:
         """Force an immediate flush (used at shutdown and in tests)."""

--- a/tests/test_batching_sink.py
+++ b/tests/test_batching_sink.py
@@ -74,6 +74,33 @@ def test_rate_limit_paces_delivery():
         sink.close()
 
 
+def test_rate_limit_persists_across_batches(monkeypatch):
+    inner = _RecordingSink()
+    now = [100.0]
+    sleeps: list[float] = []
+
+    def monotonic() -> float:
+        return now[0]
+
+    def sleep(seconds: float) -> None:
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    monkeypatch.setattr("snagline.sinks.batching.time.monotonic", monotonic)
+    monkeypatch.setattr("snagline.sinks.batching.time.sleep", sleep)
+    sink = BatchingSink(
+        inner, max_batch=1000, flush_interval=3600.0, max_per_second=10.0
+    )
+    try:
+        for i in range(3):
+            sink.emit(_risk(i))
+            sink.flush_now()
+        assert len(inner.emitted) == 3
+        assert sleeps == [0.1, 0.1]
+    finally:
+        sink.close()
+
+
 def _wait_for(predicate, timeout: float = 5.0) -> None:
     deadline = time.monotonic() + timeout
     while time.monotonic() < deadline:


### PR DESCRIPTION
## Summary

Fixes #276.

`BatchingSink(max_per_second=...)` previously reset its pacing timestamp for every `_deliver()` call. Separate batches could therefore be delivered back-to-back, bypassing the configured rate limit.

## Changes

- Persist the last delivery timestamp across batches.
- Serialize delivery scheduling and wrapped-sink calls so concurrent flush paths share one pacing sequence.
- Keep pacing state separate from the queue lock so `emit()` remains non-blocking.
- Add deterministic cross-batch regression coverage using a fake monotonic clock.

## Validation

- `pytest -q --no-cov tests/test_batching_sink.py` — 7 passed
- `PYTHONPATH=. pytest -q --no-cov` — 696 passed, 3 skipped
- `ruff check` and `ruff format --check` — passed
- `mypy src tests` — passed

Related issue: #276