### PR TITLE
fix(config): reject invalid boolean environment values

### DIFF
--- a/src/snagline/config.py
+++ b/src/snagline/config.py
@@ -53,7 +53,12 @@ def _coercible_hint(hint: Any) -> Any:
 
 def _coerce(hint: type, value: str) -> Any:
     if hint is bool:
-        return value.strip().lower() in ("1", "true", "yes", "on", "t")
+        normalized = value.strip().lower()
+        if normalized in ("1", "true", "yes", "on", "t"):
+            return True
+        if normalized in ("0", "false", "no", "off", "f"):
+            return False
+        raise ValueError(f"invalid boolean value: {value!r}")
     if hint is int:
         return int(value)
     if hint is float:

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -40,6 +40,27 @@ def test_from_env_skips_uncoercible_values():
     assert cfg.cusum_k == 0.5  # default unchanged, no raise
 
 
+def test_from_env_skips_uncoercible_boolean_values():
+    env = {"SNAGLINE_FAIL_OPEN": "flase"}
+    overrides = Config.from_env_overrides(environ=env)
+    assert "fail_open" not in overrides
+    assert Config.from_env(environ=env).fail_open is True
+
+
+def test_from_env_accepts_false_boolean_aliases():
+    for value in ("0", "false", "no", "off", "f"):
+        assert Config.from_env(environ={"SNAGLINE_FAIL_OPEN": value}).fail_open is False
+
+
+def test_resolve_invalid_boolean_env_keeps_file_value(tmp_path):
+    path = tmp_path / "cfg.json"
+    path.write_text(json.dumps({"fail_open": False}))
+    cfg = Config.resolve(
+        path=str(path), environ={"SNAGLINE_FAIL_OPEN": "definitely-not-a-bool"}
+    )
+    assert cfg.fail_open is False
+
+
 def test_load_file_json(tmp_path):
     path = tmp_path / "cfg.json"
     path.write_text(


### PR DESCRIPTION
Environment boolean coercion currently maps every unrecognized value to false. A typo such as SNAGLINE_FAIL_OPEN=flase therefore silently disables fail-open behavior instead of being ignored as documented for values that fail to coerce.

This change accepts explicit true/false aliases and raises ValueError for unknown boolean strings, allowing the existing environment loader to warn and ignore invalid overrides. It adds coverage for invalid values, false aliases, and preserving a config-file value when an invalid environment override is supplied.

Validation: 19 config-loader tests, 697 full-suite tests + 3 skipped, Ruff, mypy src tests, and git diff --check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Invalid boolean configuration values are no longer silently interpreted as `False`.
  - Unrecognized boolean values are rejected, preserving the existing configured value instead of overriding it.
  - Additional accepted false-value aliases include `0`, `false`, `no`, `off`, and `f`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->