### PR TITLE
fix(auto): measure call latency on perf_counter, not the wall clock (Fixes #280)

### DIFF
--- a/src/snagline/auto/anthropic.py
+++ b/src/snagline/auto/anthropic.py
@@ -9,6 +9,15 @@ Global mode (issue #270) patches the *resource classes* --
 walking ``Anthropic.messages``: on modern Anthropic SDKs the client attribute
 is a ``functools.cached_property`` descriptor, so the old class-attribute
 walk resolved a descriptor, not a resource, and silently wrapped nothing.
+
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
+clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
+interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
+a clock step mid-call fabricates negative or huge latencies.
+``perf_counter`` has no meaningful epoch, so these timestamps are only
+comparable within one process; detectors consume them solely as in-process
+latency differences.
 """
 
 from __future__ import annotations
@@ -30,15 +39,15 @@ logger = logging.getLogger("snagline")
 
 
 def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
-    latency = (time.time() - start) * 1000.0
+    now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id="anthropic-auto",
-        timestamp=time.time(),
+        timestamp=now,
         action_type="tool_call",
         action_signature=make_signature("anthropic_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=latency,
+        latency_ms=(now - start) * 1000.0,
         error=error,
     )
     monitor.ingest(event)
@@ -66,7 +75,7 @@ def _wrap_one(monitor, original, tool_name):
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         error = False
         try:
             result = original(*args, **kwargs)
@@ -80,7 +89,7 @@ def _wrap_one(monitor, original, tool_name):
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         error = False
         try:
             result = await original(*args, **kwargs)

--- a/src/snagline/auto/langchain.py
+++ b/src/snagline/auto/langchain.py
@@ -3,6 +3,15 @@
 Wraps the common ``invoke`` / ``generate`` entrypoints on a LangChain model
 or chain so each call emits a ``StepEvent``. Import-safe: a no-op when
 LangChain is absent, and handles synchronous and asynchronous methods.
+
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
+clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
+interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
+a clock step mid-call fabricates negative or huge latencies.
+``perf_counter`` has no meaningful epoch, so these timestamps are only
+comparable within one process; detectors consume them solely as in-process
+latency differences.
 """
 
 from __future__ import annotations
@@ -21,15 +30,15 @@ _LANGCHAIN_METHODS = ("invoke", "generate", "ainvoke", "agenerate")
 
 
 def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
-    latency = (time.time() - start) * 1000.0
+    now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id="langchain-auto",
-        timestamp=time.time(),
+        timestamp=now,
         action_type="tool_call",
         action_signature=make_signature("langchain_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=latency,
+        latency_ms=(now - start) * 1000.0,
         error=error,
     )
     monitor.ingest(event)
@@ -45,7 +54,7 @@ def _wrap_one(monitor, original, tool_name):
         model_name = getattr(model, "model_name", None) or getattr(
             model, "model", "langchain"
         )
-        start = time.time()
+        start = time.perf_counter()
         error = False
         try:
             result = original(*args, **kwargs)
@@ -62,7 +71,7 @@ def _wrap_one(monitor, original, tool_name):
         model_name = getattr(model, "model_name", None) or getattr(
             model, "model", "langchain"
         )
-        start = time.time()
+        start = time.perf_counter()
         error = False
         try:
             result = await original(*args, **kwargs)

--- a/src/snagline/auto/openai.py
+++ b/src/snagline/auto/openai.py
@@ -15,6 +15,15 @@ Global mode (issue #270) patches the *resource classes* -- ``Completions`` and
 old class-attribute walk resolved a descriptor, not a resource, and silently
 wrapped nothing. The resource classes' ``create`` is what every instance call
 dispatches to, so patching them covers all clients, current and future.
+
+Latency measurement and event timestamps use :func:`time.perf_counter`, not
+:func:`time.time`, mirroring the explicit adapters (issue #155): the wall
+clock advances in ~15.6 ms ticks on Windows on supported 3.10--3.12
+interpreters, quantizing sub-tick latencies to zero, and is non-monotonic, so
+a clock step mid-call fabricates negative or huge latencies.
+``perf_counter`` has no meaningful epoch, so these timestamps are only
+comparable within one process; detectors consume them solely as in-process
+latency differences.
 """
 
 from __future__ import annotations
@@ -36,15 +45,15 @@ logger = logging.getLogger("snagline")
 
 
 def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
-    latency = (time.time() - start) * 1000.0
+    now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
         episode_id="openai-auto",
-        timestamp=time.time(),
+        timestamp=now,
         action_type="tool_call",
         action_signature=make_signature("openai_call", model, sig_text),
         tool_name=tool_name,
-        latency_ms=latency,
+        latency_ms=(now - start) * 1000.0,
         error=error,
     )
     monitor.ingest(event)
@@ -73,7 +82,7 @@ def _wrap_one(monitor, original, tool_name):
     def _sync(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         error = False
         try:
             result = original(*args, **kwargs)
@@ -87,7 +96,7 @@ def _wrap_one(monitor, original, tool_name):
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
-        start = time.time()
+        start = time.perf_counter()
         error = False
         try:
             result = await original(*args, **kwargs)

--- a/tests/test_auto_perf_counter_clock.py
+++ b/tests/test_auto_perf_counter_clock.py
@@ -1,0 +1,134 @@
+"""Issue #155 follow-up: the ``snagline.auto`` wrappers measure on perf_counter.
+
+PR #161 migrated every module in ``snagline.adapters`` off ``time.time()``
+(issue #155): on Windows the wall clock advances in ~15.6 ms ticks on the
+supported 3.10--3.12 interpreters, so a call shorter than one tick recorded
+``latency_ms == 0.0`` and starved the CUSUM latency detector of usable
+samples. The auto-instrumentation wrappers were never part of that audit and
+kept reading ``time.time``.
+
+These tests reuse the deterministic scripted-clock pattern from
+``tests/adapters/test_perf_counter_clock.py``: script ``time.perf_counter``
+itself and never touch ``time.time``. If a wrapper ever reads the wall clock,
+the scripted readings are never consumed and the assertions fail, so the
+regression cannot hide behind platform timing or Python-version clock
+precision.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+from snagline.auto.anthropic import wrap_client as wrap_anthropic
+from snagline.auto.langchain import wrap_client as wrap_langchain
+from snagline.auto.openai import wrap_client as wrap_openai
+
+
+class _SpyMonitor:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def ingest(self, event: Any) -> None:
+        self.events.append(event)
+
+
+def _script(*values: float):
+    """Scripted clock: one value per expected reading, then fail loudly."""
+    reads = iter(values)
+    return lambda: next(reads)
+
+
+# Sub-millisecond deltas built from binary-exact floats (mirrors the adapters'
+# regression tests): 2**-10 seconds is exactly representable, so the asserted
+# latency_ms holds bit-for-bit on every platform.
+T0 = 1024.0
+SUB_MS_S = 2**-10  # 0.9765625 ms
+
+
+def test_openai_auto_wrapper_preserves_sub_ms_latency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Read order per successful call: start, then one reading in _emit shared
+    # by the latency delta and the event timestamp.
+    monkeypatch.setattr(time, "perf_counter", _script(T0, T0 + SUB_MS_S))
+    mon = _SpyMonitor()
+
+    class _Completions:
+        def create(self, **kw: Any) -> str:
+            return "ok"
+
+    class _Client:
+        chat = type("C", (), {"completions": _Completions()})()
+
+    client = wrap_openai(mon, _Client())
+    client.chat.completions.create(model="gpt-4o", messages=[{"role": "user"}])
+
+    e = mon.events[0]
+    assert e.latency_ms == pytest.approx(SUB_MS_S * 1000.0, rel=1e-12)
+    assert e.latency_ms > 0.0  # exactly what the Windows tick quantized to zero
+    assert e.timestamp == T0 + SUB_MS_S
+
+
+def test_anthropic_auto_wrapper_preserves_sub_ms_latency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(time, "perf_counter", _script(T0, T0 + SUB_MS_S))
+    mon = _SpyMonitor()
+
+    class _Messages:
+        def create(self, **kw: Any) -> str:
+            return "ok"
+
+    client = wrap_anthropic(mon, type("C", (), {"messages": _Messages()})())
+    client.messages.create(model="claude", messages=[{"role": "user"}])
+
+    e = mon.events[0]
+    assert e.latency_ms == pytest.approx(SUB_MS_S * 1000.0, rel=1e-12)
+    assert e.latency_ms > 0.0
+    assert e.timestamp == T0 + SUB_MS_S
+
+
+def test_langchain_auto_wrapper_preserves_sub_ms_latency(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(time, "perf_counter", _script(T0, T0 + SUB_MS_S))
+    mon = _SpyMonitor()
+
+    class _Chain:
+        def invoke(self, *args: Any, **kw: Any) -> str:
+            return "ok"
+
+    client = wrap_langchain(mon, _Chain())
+    client.invoke({"input": "hi"})
+
+    e = mon.events[0]
+    assert e.latency_ms == pytest.approx(SUB_MS_S * 1000.0, rel=1e-12)
+    assert e.latency_ms > 0.0
+    assert e.timestamp == T0 + SUB_MS_S
+
+
+def test_openai_auto_wrapper_error_path_reads_perf_counter(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The finally-emitted event on a raising call must also come from the
+    # monotonic clock: a wall clock that stepped backwards mid-call would
+    # fabricate a negative latency (issue #155's second failure mode).
+    monkeypatch.setattr(time, "perf_counter", _script(T0, T0 + SUB_MS_S))
+    mon = _SpyMonitor()
+
+    class _Boom:
+        def create(self, **kw: Any) -> str:
+            raise RuntimeError("boom")
+
+    client = wrap_openai(
+        mon, type("C", (), {"chat": type("B", (), {"completions": _Boom()})()})()
+    )
+    with pytest.raises(RuntimeError):
+        client.chat.completions.create(model="gpt-4o", messages=[{"role": "user"}])
+
+    e = mon.events[0]
+    assert e.error is True
+    assert e.latency_ms == pytest.approx(SUB_MS_S * 1000.0, rel=1e-12)


### PR DESCRIPTION
## Summary of Changes

All three `snagline.auto` auto-instrumentation wrappers (`openai`, `anthropic`, `langchain`) still measured call latency and event timestamps with `time.time()`. They now use `time.perf_counter`, taking a single reading in `_emit` shared by the latency delta and the event timestamp, exactly mirroring the explicit adapters.

## Justification

Issue #155 fixed this defect class for `src/snagline/adapters/` (PR #161) and its proposal explicitly asked to audit other modules for the same pattern — but the `snagline.auto` wrappers were never audited. Consequences for every `instrument_openai` / `instrument_anthropic` / `instrument_langchain` user (the zero-call-site-edits attach path):

- On Windows (Python 3.10–3.12, the supported interpreters before CPython switched to `GetSystemTimePreciseAsFileTime`), the wall clock advances in ~15.6 ms ticks, so every auto-instrumented call shorter than one tick records `latency_ms == 0.0` — the CUSUM latency detector is starved of usable samples exactly as documented in #155.
- On every platform, `time.time()` is non-monotonic: an NTP correction or manual date change during a call fabricates a negative or hugely inflated latency.

Closes #280.

## Kind of Contribution

Bug Fix

## Benchmark (for Performance Improvements)

N/A — no detection-path change; the wrappers swap one clock call for another of equal cost. `snagline bench` measures `Monitor.ingest`, which this change does not touch.

## Unit Tests:

`tests/test_auto_perf_counter_clock.py` (new, 4 tests) reuses the deterministic scripted-clock pattern from `tests/adapters/test_perf_counter_clock.py`: `time.perf_counter` is scripted with binary-exact sub-millisecond readings and `time.time` is never touched, so any wrapper that falls back to the wall clock fails deterministically regardless of platform timing or Python-version clock precision:

- success-path sub-ms latency + timestamp assertions for each of the three wrappers,
- error-path assertion (a raising `create` must still emit a latency from the monotonic clock — the path where a backwards wall-clock step fabricates negative latencies).

All four tests fail on unmodified `master` (`540955d`) and pass with this change.

## Execution Tests

- `pytest tests/ -q --cov-fail-under=0` on Windows 11 / Python 3.13: **808 passed, 2 skipped** (full suite, includes the 23 pre-existing `test_auto_*` tests plus the 4 new ones).
- `ruff check` and `ruff format --check` clean on all touched files.
- `mypy src tests`: only the pre-existing Windows-only `signal.SIGKILL` error in `tests/test_hook_bridge.py:779` (POSIX-only attribute; CI runs mypy on Linux legs only).
- The standalone repro from issue #280 (scripted `perf_counter`, fake client) now asserts `latency_ms == 0.9765625` exactly.

Note: textually adjacent to open PR #255 (stream-emission deferral in the same two files) but orthogonal — #255 restructures emission timing and keeps `time.time`; this PR changes only the clock. Happy to rebase if #255 lands first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved latency measurements and event timestamps for AI integrations, including more accurate sub-millisecond timing.
  * Prevented incorrect or negative latency values caused by system clock adjustments or coarse clock resolution.
  * Preserved accurate error-event reporting while allowing original errors to propagate normally.

* **Documentation**
  * Clarified timestamp behavior and limitations.

* **Tests**
  * Added coverage for timing accuracy across OpenAI, Anthropic, and LangChain integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->