### PR TITLE
fix(monitor): enforce retention cap across snapshot restore

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -911,6 +911,7 @@ class Monitor:
             if callable(load) and dumped_sinks.get(key) is not None:
                 load(dumped_sinks[key])
         time_axis_data = data.get("time_axis")
+        restored_clocks: list[tuple[str, _EpisodeClock]] = []
         if isinstance(time_axis_data, dict):
             # Restore clocks in order of last_ts ascending so most recent
             # survives if we must evict under cap. Fall back to sorted keys
@@ -948,19 +949,52 @@ class Monitor:
                 clock.idle_fired = idle_fired
                 clock.warned = warned
                 clock.breached = breached
-                with self._live_lock:
-                    if episode_id in self._live_episodes:
-                        self._live_episodes.move_to_end(episode_id)
-                    else:
-                        self._live_episodes[episode_id] = None
-                        if len(self._live_episodes) > self._max_live_episodes:
-                            evicted, _ = self._live_episodes.popitem(last=False)
-                            with self._clocks_lock:
-                                self._clocks.pop(evicted, None)
-                    with self._clocks_lock:
-                        self._clocks[episode_id] = clock
-            # If we evicted due to cap, live_snapshot entries not in time_axis
-            # are already accounted for; no further action needed.
+                restored_clocks.append((episode_id, clock))
+        # Per-episode retention cap across restore (issue #273): every episode
+        # whose state was just loaded (detector windows and/or a restored
+        # clock) must be registered in the live LRU exactly as ``ingest``
+        # would, and over-cap ids must be torn down via the FULL eviction
+        # path (``_evict_episode``: detector reset + clock release), not a
+        # bare ``_clocks.pop``. Previously only time_axis ids were
+        # registered -- and only when the horizon knobs were on -- so
+        # restored detector state was invisible to the LRU: it survived
+        # every future eviction forever while ``retained_episodes``
+        # reported the cap. Clock ids (ordered oldest first) also provide
+        # the recency ordering; detector-only ids fall back to snapshot
+        # dict order, which is deterministic (sorted keys) since snapshots
+        # are written with sort_keys=True.
+        episode_ids: list[str] = [ep for ep, _ in restored_clocks]
+        for detector in self._detectors:
+            state = getattr(detector, "_windows", None)
+            if isinstance(state, dict):
+                for ep in state:
+                    if isinstance(ep, str) and ep not in episode_ids:
+                        episode_ids.append(ep)
+            eps = getattr(detector, "_eps", None)
+            if isinstance(eps, dict):
+                for ep in eps:
+                    if isinstance(ep, str) and ep not in episode_ids:
+                        episode_ids.append(ep)
+        for episode_id, clock in restored_clocks:
+            with self._clocks_lock:
+                self._clocks[episode_id] = clock
+        for episode_id in episode_ids:
+            evicted: str | None = None
+            with self._live_lock:
+                if episode_id in self._live_episodes:
+                    self._live_episodes.move_to_end(episode_id)
+                elif len(self._live_episodes) < self._max_live_episodes:
+                    self._live_episodes[episode_id] = None
+                else:
+                    self._live_episodes[episode_id] = None
+                    evicted, _ = self._live_episodes.popitem(last=False)
+            # Over cap: full teardown of the least-recently id, exactly as
+            # ``ingest`` does. Outside ``_live_lock`` to mirror ingest's
+            # eviction ordering (episode lock is acquired inside).
+            if evicted is not None and evicted != episode_id:
+                self._evict_episode(evicted)
+        # Episode state for ids the cap just dropped was loaded by the
+        # detector ``load_state`` calls above; the eviction pass reset it.
 
     def restore(self, path: str, strict_names: bool = False) -> None:
         """Load a JSON snapshot written by :meth:`snapshot`."""

--- a/tests/test_monitor_snapshot.py
+++ b/tests/test_monitor_snapshot.py
@@ -172,6 +172,40 @@ def test_composition_mismatch_strict_vs_tolerant(tmp_path):
     )  # cascade has no ep state yet
 
 
+def test_strict_restore_rejection_does_not_apply_detector_state(tmp_path):
+    """A rejected strict restore leaves the target monitor untouched."""
+    path = str(tmp_path / "state.json")
+    source = Monitor([LoopDetector(), ErrorCascadeDetector()], [ListSink()])
+    source.ingest(
+        StepEvent(
+            step_id="0",
+            episode_id="ep",
+            timestamp=0.0,
+            action_type="tool_call",
+            action_signature="q-a",
+            tool_name="search",
+        )
+    )
+    source.ingest(
+        StepEvent(
+            step_id="1",
+            episode_id="ep",
+            timestamp=1.0,
+            action_type="tool_call",
+            action_signature="q-a",
+            tool_name="search",
+        )
+    )
+    source.snapshot(path)
+
+    target = Monitor([ErrorCascadeDetector(), LoopDetector()], [ListSink()])
+    with pytest.raises(ValueError, match="composition mismatch"):
+        target.restore(path, strict_names=True)
+
+    loop = cast(LoopDetector, target._detectors[1])
+    assert loop._windows == {}
+
+
 def test_dedup_sink_cooldown_survives_round_trip(tmp_path):
     from snagline.risk import FailureRisk
 

--- a/tests/test_per_episode_cap.py
+++ b/tests/test_per_episode_cap.py
@@ -159,3 +159,94 @@ def test_bounded_memory_repro() -> None:
         )
     )
     assert mon.retained_episodes == 10000
+
+
+# --- Restore and the cap (issue #273) ----------------------------------------
+#
+# restore_dict used to apply every snapshot episode's detector state without
+# registering ids in the live LRU (and its time-axis loop, the only part that
+# did register, merely popped _clocks without the detector reset). So
+# restored episodes' state was invisible to the LRU: it survived every future
+# eviction forever while retained_episodes reported the cap.
+
+
+def _event_full(episode_id: str, step: int, sig: str, ts: float) -> StepEvent:
+    return StepEvent(
+        step_id=f"{episode_id}-{step}",
+        episode_id=episode_id,
+        timestamp=ts,
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", "t", sig),
+        tool_name="t",
+        latency_ms=10.0,
+    )
+
+
+def _restore_source_and_target(cap: int, horizon: bool, tmp_path):
+    """Snapshot a 5-episode monitor; restore into one capped at ``cap``."""
+
+    cfg_src = Config(max_live_episodes=100)
+    cfg_dst = Config(max_live_episodes=cap)
+    if horizon:
+        cfg_src = Config(max_live_episodes=100, max_episode_wall_seconds=1000)
+        cfg_dst = Config(max_live_episodes=cap, max_episode_wall_seconds=1000)
+    src = Monitor.default(config=cfg_src, sinks=[])
+    for ep in "ABCDE":
+        for i in range(5):
+            src.ingest(_event_full(ep, i, f"{ep}-sig-{i}", float(i)))
+    path = str(tmp_path / "snap.json")
+    src.snapshot(path)
+    dst = Monitor.default(config=cfg_dst, sinks=[])
+    dst.restore(path)
+    return dst
+
+
+def _loop_windows(mon: Monitor) -> set[str]:
+    for det in mon._detectors:
+        if getattr(det, "name", "") == "loop":
+            return set(det._windows.keys())  # type: ignore[attr-defined]
+    raise AssertionError("loop detector not found")
+
+
+def test_restore_applies_cap_to_restored_state(tmp_path) -> None:
+    """Restored detector state must respect the target monitor's cap, in
+    both horizon configurations: the over-cap ids' windows are gone."""
+    for horizon in (True, False):
+        dst = _restore_source_and_target(cap=2, horizon=horizon, tmp_path=tmp_path)
+        assert dst.metrics()["retained_episodes"] == 2
+        assert _loop_windows(dst) == {"D", "E"}, f"horizon={horizon}"
+
+
+def test_restore_eviction_is_full_teardown_not_clock_pop(tmp_path) -> None:
+    """Over-cap restored ids must run the real eviction path: detector
+    state reset (not just the clock dropped) and the LRU honest. The
+    pre-fix code only popped the clock, leaving detector windows for the
+    evicted ids live."""
+    dst = _restore_source_and_target(cap=2, horizon=True, tmp_path=tmp_path)
+    # Most-recent clock survives; evicted ids' clocks are gone too...
+    assert set(dst._clocks.keys()) == {"D", "E"}
+    # ...and so is their DETECTOR state -- the part the pre-fix time-axis
+    # eviction never touched.
+    assert _loop_windows(dst) == {"D", "E"}
+    # Detector and clock state for the evicted ids is gone, proving the full
+    # teardown path ran rather than only popping clocks.
+
+
+def test_restored_state_survives_no_future_eviction_leak(tmp_path) -> None:
+    """The issue's permanent-leak shape: feeding many new episodes used to
+    evict only the new ids, so restored over-cap state (A/B/C) survived
+    forever. With the fix they were torn down at restore time."""
+    dst = _restore_source_and_target(cap=2, horizon=False, tmp_path=tmp_path)
+    for n in range(10):
+        for i in range(5):
+            dst.ingest(_event_full(f"new{n}", i, f"n{n}-{i}", float(i)))
+    survivors = _loop_windows(dst) & {"A", "B", "C"}
+    assert survivors == set(), "restored over-cap ids must not outlive restore"
+
+
+def test_restore_under_cap_keeps_all_state(tmp_path) -> None:
+    """Sanity: restoring below the cap changes nothing vs pre-fix behavior
+    (the round-trip parity tests pin that separately)."""
+    dst = _restore_source_and_target(cap=10, horizon=False, tmp_path=tmp_path)
+    assert dst.metrics()["retained_episodes"] == 5
+    assert _loop_windows(dst) == {"A", "B", "C", "D", "E"}


### PR DESCRIPTION
Fixes #273.

Restored detector state must obey the target monitor's per-episode retention cap. This change:

- discovers restored episodes from clocks and detector state;
- rebuilds the live LRU and preserves clock recency;
- evicts over-cap episodes through `_evict_episode()` so detector and clock state are fully released;
- covers horizon-enabled and horizon-disabled restores, cleanup, leak prevention, and under-cap compatibility.

This is based on current `master` and addresses the implementation/rebase issues in the existing #275 attempt.

Validation: focused retention and snapshot tests (24 passed), Ruff check/format, and compileall. Mypy currently reports pre-existing errors in `src/snagline/auto/openai.py` unrelated to this change.