### PR TITLE
fix(monitor): enforce per-episode retention cap across snapshot restore (#273)

### DIFF
--- a/src/snagline/monitor.py
+++ b/src/snagline/monitor.py
@@ -806,6 +806,10 @@ class Monitor:
         # a snapshot is a point-in-time read either way.
         with self._clocks_lock:
             clocks = list(self._clocks.items())
+        # Persist the live-episode LRU order (issue #273) so restore can
+        # re-register restored episodes and enforce the retention cap.
+        with self._live_lock:
+            live_episodes = list(self._live_episodes.keys())
         for episode_id, clock in clocks:
             time_axis[episode_id] = {
                 "last_ts": clock.last_ts,
@@ -819,6 +823,7 @@ class Monitor:
             "detectors": detectors,
             "sinks": sinks,
             "time_axis": time_axis,
+            "live_episodes": live_episodes,
         }
 
     def snapshot(self, path: str) -> None:
@@ -912,21 +917,7 @@ class Monitor:
                 load(dumped_sinks[key])
         time_axis_data = data.get("time_axis")
         if isinstance(time_axis_data, dict):
-            # Restore clocks in order of last_ts ascending so most recent
-            # survives if we must evict under cap. Fall back to sorted keys
-            # for deterministic behavior when last_ts is missing.
-            try:
-                ordered = sorted(
-                    time_axis_data.items(),
-                    key=lambda kv: (
-                        float(kv[1].get("last_ts", 0.0))  # type: ignore[arg-type]
-                        if isinstance(kv[1], dict)
-                        else 0.0
-                    ),
-                )
-            except Exception:
-                ordered = sorted(time_axis_data.items())
-            for episode_id, clock_data in ordered:
+            for episode_id, clock_data in time_axis_data.items():
                 if not isinstance(episode_id, str) or not isinstance(clock_data, dict):
                     continue
                 try:
@@ -948,19 +939,76 @@ class Monitor:
                 clock.idle_fired = idle_fired
                 clock.warned = warned
                 clock.breached = breached
-                with self._live_lock:
-                    if episode_id in self._live_episodes:
-                        self._live_episodes.move_to_end(episode_id)
-                    else:
-                        self._live_episodes[episode_id] = None
-                        if len(self._live_episodes) > self._max_live_episodes:
-                            evicted, _ = self._live_episodes.popitem(last=False)
-                            with self._clocks_lock:
-                                self._clocks.pop(evicted, None)
-                    with self._clocks_lock:
-                        self._clocks[episode_id] = clock
-            # If we evicted due to cap, live_snapshot entries not in time_axis
-            # are already accounted for; no further action needed.
+                with self._clocks_lock:
+                    self._clocks[episode_id] = clock
+        # Rebuild the live-episode LRU and enforce the retention cap
+        # (issue #273): previously restored episodes were never registered,
+        # and eviction dropped only the clock while detector state lingered.
+        ordered_episodes: list[str] = []
+        seen_episodes: set[str] = set()
+        recorded_live = data.get("live_episodes")
+        if isinstance(recorded_live, list):
+            for ep in recorded_live:
+                if isinstance(ep, str) and ep not in seen_episodes:
+                    seen_episodes.add(ep)
+                    ordered_episodes.append(ep)
+        if isinstance(time_axis_data, dict):
+            try:
+                sorted_clocks = sorted(
+                    time_axis_data.items(),
+                    key=lambda kv: (
+                        float(kv[1].get("last_ts", 0.0))
+                        if isinstance(kv[1], dict)
+                        else 0.0
+                    ),
+                )
+            except Exception:
+                sorted_clocks = sorted(time_axis_data.items())
+            for ep, _ in sorted_clocks:
+                if isinstance(ep, str) and ep not in seen_episodes:
+                    seen_episodes.add(ep)
+                    ordered_episodes.append(ep)
+        # Episodes present only in detector state (horizon knobs were off,
+        # or older snapshot versions) still count as live.
+        for detector in self._detectors:
+            for attr in (
+                "_windows",
+                "_counts",
+                "_fired",
+                "_near_windows",
+                "_cycle_windows",
+                "_tokens",
+                "_last",
+                "_live",
+                "_eps",
+                "_episodes",
+            ):
+                mapping = getattr(detector, attr, None)
+                if isinstance(mapping, dict):
+                    for ep in mapping:
+                        if isinstance(ep, str) and ep not in seen_episodes:
+                            seen_episodes.add(ep)
+                            ordered_episodes.append(ep)
+            states = getattr(detector, "_states", None)
+            if isinstance(states, dict):
+                for key in states:
+                    ep = key[0] if isinstance(key, tuple) else key
+                    if isinstance(ep, str) and ep not in seen_episodes:
+                        seen_episodes.add(ep)
+                        ordered_episodes.append(ep)
+        to_evict: list[str] = []
+        with self._live_lock:
+            self._live_episodes.clear()
+            for ep in ordered_episodes:
+                if ep in self._live_episodes:
+                    self._live_episodes.move_to_end(ep)
+                else:
+                    self._live_episodes[ep] = None
+            while len(self._live_episodes) > self._max_live_episodes:
+                evicted, _ = self._live_episodes.popitem(last=False)
+                to_evict.append(evicted)
+        for evicted in to_evict:
+            self._evict_episode(evicted)
 
     def restore(self, path: str, strict_names: bool = False) -> None:
         """Load a JSON snapshot written by :meth:`snapshot`."""

--- a/tests/test_per_episode_cap.py
+++ b/tests/test_per_episode_cap.py
@@ -159,3 +159,60 @@ def test_bounded_memory_repro() -> None:
         )
     )
     assert mon.retained_episodes == 10000
+
+
+def test_restore_registers_episodes_and_enforces_cap(tmp_path) -> None:
+    """Issue #273: restore_dict loaded detector state for every episode
+    without registering into the live-episode LRU, and eviction dropped only
+    the clock while detector memory lingered. After restore, retained count
+    must equal the cap and over-cap episodes must be fully evicted."""
+    from snagline.monitor import Monitor as Mon
+
+    cap = 3
+    src = Mon.default(config=Config(max_live_episodes=100), sinks=[])
+    for i in range(5):
+        src.ingest(_event(f"ep-{i}", ts=float(i)))
+    path = str(tmp_path / "state.json")
+    src.snapshot(path)
+
+    dst = Mon.default(config=Config(max_live_episodes=cap), sinks=[])
+    dst.restore(path)
+    assert dst.retained_episodes == cap
+    assert len(dst._live_episodes) == cap
+    # Evicted episodes leave no detector or clock residue behind.
+    live = set(dst._live_episodes.keys())
+    assert live == {"ep-2", "ep-3", "ep-4"}
+    for ep in ("ep-0", "ep-1"):
+        assert ep not in dst._clocks
+        for det in dst._detectors:
+            for attr in ("_windows", "_counts", "_live", "_episodes", "_last"):
+                mapping = getattr(det, attr, None)
+                if isinstance(mapping, dict):
+                    assert ep not in mapping, (det, attr, ep)
+
+
+def test_restore_without_live_episodes_key_stays_backward_compatible(
+    tmp_path,
+) -> None:
+    """Snapshots written before live_episodes was persisted (or with the
+    horizon knobs off) still restore: episodes are recovered from clocks and
+    detector state in deterministic order."""
+    import json
+
+    from snagline.monitor import Monitor as Mon
+
+    src = Mon.default(config=Config(max_live_episodes=100), sinks=[])
+    for i in range(3):
+        src.ingest(_event(f"ep-{i}", ts=float(i)))
+    path = str(tmp_path / "state.json")
+    src.snapshot(path)
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+    data.pop("live_episodes", None)
+    with open(path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh)
+
+    dst = Mon.default(config=Config(max_live_episodes=100), sinks=[])
+    dst.restore(path)
+    assert dst.retained_episodes == 3
+    assert set(dst._live_episodes.keys()) == {"ep-0", "ep-1", "ep-2"}


### PR DESCRIPTION
Fixes #273. Supersedes #275 (stale: SIM118 lint failures + conflicts, unaddressed).

## Summary

When restoring a snapshot, `Monitor.restore_dict()` loaded detector state for all episodes without registering them into the `_live_episodes` LRU, and the eviction logic only cleared the clock instead of running full `_evict_episode`. Over-cap restored episodes lingered in detector memory while `retained_episodes` reported only the cap.

## Changes

- `snapshot_dict()` persists `live_episodes` LRU order
- restore rebuilds the LRU (recorded order, then clock order, then detector-state sweep for older snapshots) and evicts over-cap episodes via full `_evict_episode`
- Regression tests: cap enforcement + full eviction after restore, backward compat without the new key

## Validation

- `pytest tests/test_per_episode_cap.py` - 10 passed
- `ruff check` + `ruff format --check` + `mypy` clean