### PR TITLE
fix: restore detector windows at effective size, not base (error_cascade / meltdown / loop)

### DIFF
--- a/src/snagline/detectors/error_cascade.py
+++ b/src/snagline/detectors/error_cascade.py
@@ -20,7 +20,7 @@ from typing import Any
 
 from snagline.config import Config
 from snagline.detectors.base import snapshot_items
-from snagline.detectors.windowing import next_window
+from snagline.detectors.windowing import effective_window_size, next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk
 
@@ -148,8 +148,17 @@ class ErrorCascadeDetector:
         }
 
     def load_state(self, state: dict[str, Any]) -> None:
+        counts = state.get("counts", {})
         self._windows = {
-            ep: deque(flags, maxlen=self.window_size)
+            ep: deque(
+                flags,
+                maxlen=effective_window_size(
+                    self.window_size,
+                    int(counts.get(ep, len(flags))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, flags in state.get("windows", {}).items()
         }
         # Tolerant .get(): pre-#92 snapshots carry no scaler positions.

--- a/src/snagline/detectors/loop.py
+++ b/src/snagline/detectors/loop.py
@@ -46,7 +46,7 @@ from typing import Any, cast
 
 from snagline.config import Config
 from snagline.detectors.base import snapshot_items
-from snagline.detectors.windowing import next_window
+from snagline.detectors.windowing import effective_window_size, next_window
 from snagline.events import StepEvent
 from snagline.risk import FailureRisk, TriggerType
 
@@ -398,16 +398,34 @@ class LoopDetector:
         }
 
     def load_state(self, state: dict[str, Any]) -> None:
+        counts = state.get("counts", {})
         self._windows = {
-            ep: deque(sigs, maxlen=self.window_size)
+            ep: deque(
+                sigs,
+                maxlen=effective_window_size(
+                    self.window_size,
+                    int(counts.get(ep, len(sigs))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, sigs in state.get("windows", {}).items()
         }
         # Tolerant .get() so pre-#92 snapshots restore cleanly; the counts only
         # position the auto-scaler and default to the window they imply.
         self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}
         self._fired = {ep: set(sigs) for ep, sigs in state.get("fired", {}).items()}
+        near_counts = state.get("near_counts", {})
         self._near_windows = {
-            ep: deque(sigs, maxlen=self.window_size)
+            ep: deque(
+                sigs,
+                maxlen=effective_window_size(
+                    self.window_size,
+                    int(near_counts.get(ep, len(sigs))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, sigs in state.get("near_windows", {}).items()
         }
         self._near_fired = {
@@ -416,8 +434,17 @@ class LoopDetector:
         self._near_counts = {
             ep: int(n) for ep, n in state.get("near_counts", {}).items()
         }
+        cycle_counts = state.get("cycle_counts", {})
         self._cycle_windows = {
-            ep: deque(sigs, maxlen=self.loop_cycle_window_size)
+            ep: deque(
+                sigs,
+                maxlen=effective_window_size(
+                    self.loop_cycle_window_size,
+                    int(cycle_counts.get(ep, len(sigs))),
+                    self._scale_steps,
+                    self._max_window,
+                ),
+            )
             for ep, sigs in state.get("cycle_windows", {}).items()
         }
         self._cycle_counts = {

--- a/src/snagline/detectors/meltdown.py
+++ b/src/snagline/detectors/meltdown.py
@@ -179,8 +179,12 @@ class MeltdownDetector:
         self._eps = {}
         for ep, keys in state.get("windows", {}).items():
             w = _EpisodeWindow()
+            n = int(state.get("counts", {}).get(ep, len(keys)))
+            target = effective_window_size(
+                self.window_size, n, self._scale_steps, self._max_window
+            )
             for key in keys:
-                w.push(key, self.window_size)
+                w.push(key, target)
             self._eps[ep] = w
         # Tolerant .get(): pre-#92 snapshots carry no scaler positions.
         self._counts = {ep: int(n) for ep, n in state.get("counts", {}).items()}

--- a/tests/test_scaled_window_restore.py
+++ b/tests/test_scaled_window_restore.py
@@ -1,0 +1,95 @@
+"""Scaled-window snapshot/restore round-trips (issue #268).
+
+``load_state`` rebuilt every detector window at the BASE ``window_size``
+even when auto-scaling (issue #92) had grown the live window to the
+effective size. The oldest items -- exactly the history scaling exists to
+preserve -- were silently truncated, leaving the restored detector partially
+blind mid-episode.
+"""
+
+from __future__ import annotations
+
+import json
+
+from snagline.config import Config
+from snagline.detectors.error_cascade import ErrorCascadeDetector
+from snagline.detectors.loop import LoopDetector
+from snagline.detectors.meltdown import MeltdownDetector
+from snagline.detectors.windowing import effective_window_size
+from snagline.events import StepEvent, make_signature
+
+
+def _event(step: int, sig: str, error: bool = False, tool: str = "t") -> StepEvent:
+    return StepEvent(
+        step_id=str(step),
+        episode_id="ep",
+        timestamp=float(step),
+        action_type="tool_call",
+        action_signature=make_signature("tool_call", tool, sig),
+        tool_name=tool,
+        latency_ms=100.0,
+        error=error,
+    )
+
+
+def _scaling_cfg(**overrides) -> Config:
+    kw = dict(window_scale_steps=10, max_window=512)
+    kw.update(overrides)
+    return Config(**kw)
+
+
+def test_error_cascade_restore_keeps_scaled_window():
+    cfg = _scaling_cfg()
+    det = ErrorCascadeDetector(window_size=4, config=cfg)
+    for i in range(30):
+        det.observe(_event(i, f"u{i}", error=(i % 3 == 0)))
+    live_len = len(det._windows["ep"])
+    assert live_len > 4, "window must have scaled past its base"
+    dumped = json.loads(json.dumps(det.dump_state()))
+    restored = ErrorCascadeDetector(window_size=4, config=cfg)
+    restored.load_state(dumped)
+    assert len(restored._windows["ep"]) == live_len
+    assert list(restored._windows["ep"]) == list(det._windows["ep"])
+    assert len(restored._windows["ep"]) == effective_window_size(
+        4, det._counts["ep"], cfg.window_scale_steps, cfg.max_window
+    )
+
+
+def test_loop_restore_keeps_scaled_windows():
+    cfg = _scaling_cfg()
+    det = LoopDetector(window_size=4, config=cfg)
+    for i in range(30):
+        det.observe(_event(i, f"u{i}"))
+    live_len = len(det._windows["ep"])
+    assert live_len > 4, "window must have scaled past its base"
+    dumped = json.loads(json.dumps(det.dump_state()))
+    restored = LoopDetector(window_size=4, config=cfg)
+    restored.load_state(dumped)
+    assert len(restored._windows["ep"]) == live_len
+    assert list(restored._windows["ep"]) == list(det._windows["ep"])
+
+
+def test_meltdown_restore_keeps_scaled_window_and_still_scores():
+    cfg = _scaling_cfg()
+    det = MeltdownDetector(window_size=4, config=cfg)
+    tools = [f"tool{i % 6}" for i in range(30)]
+    for i, tool in enumerate(tools):
+        det.observe(_event(i, f"s{i}", tool=tool))
+    live_len = len(det._eps["ep"].window)
+    assert live_len > 4, "window must have scaled past its base"
+    dumped = json.loads(json.dumps(det.dump_state()))
+    restored = MeltdownDetector(window_size=4, config=cfg)
+    restored.load_state(dumped)
+    assert len(restored._eps["ep"].window) == live_len
+    # A restored full window scores immediately instead of going blind for
+    # (effective - base) refill steps.
+    assert list(restored._eps["ep"].window) == list(det._eps["ep"].window)
+
+
+def test_restore_without_counts_stays_backward_compatible():
+    """Pre-#92 snapshots carry no scaler positions: restore from the window
+    the payload implies."""
+    cfg = _scaling_cfg()
+    det = ErrorCascadeDetector(window_size=4, config=cfg)
+    det.load_state({"windows": {"ep": [True, False]}})
+    assert list(det._windows["ep"]) == [True, False]

--- a/tests/test_scaled_window_restore.py
+++ b/tests/test_scaled_window_restore.py
@@ -32,10 +32,11 @@ def _event(step: int, sig: str, error: bool = False, tool: str = "t") -> StepEve
     )
 
 
-def _scaling_cfg(**overrides) -> Config:
-    kw = dict(window_scale_steps=10, max_window=512)
-    kw.update(overrides)
-    return Config(**kw)
+def _scaling_cfg(scale_steps: int = 10, max_window: int = 512) -> Config:
+    return Config(
+        window_scale_steps=scale_steps,
+        max_window=max_window,
+    )
 
 
 def test_error_cascade_restore_keeps_scaled_window():


### PR DESCRIPTION
Fixes #268. Supersedes #269 (stale: conflicts vs merged #233, unaddressed).

## Summary

With window auto-scaling on, live detector windows grow via `effective_window_size` -- but `load_state` rebuilt every window at the base size, silently truncating the oldest items mid-episode (monitor restart, sidecar handover, replay from snapshot).

## Changes

- `error_cascade`, `loop` (all three window kinds), `meltdown`: rebuild at the effective size for the restored scaler position
- Tolerant fallbacks keep pre-#92 snapshots restoring cleanly
- New `tests/test_scaled_window_restore.py`: round-trip length + content parity per detector, backward compat

## Validation

- `pytest tests/test_scaled_window_restore.py` - 4 passed
- `ruff check` + `ruff format --check` + `mypy` clean