### PR TITLE
fix(adapter): serialize HookTracker state shared by the sidecar's threads

### DIFF
--- a/src/snagline/adapters/claude_code.py
+++ b/src/snagline/adapters/claude_code.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 
 import contextlib
 import json
+import threading
 import time
 import uuid
 from typing import Any
@@ -59,6 +60,11 @@ class HookTracker:
 
     Stateful companion for a long-lived bridge (the sidecar server). Kept tiny
     and defensive: malformed payloads never raise out of ``note``/``latency``.
+    The sidecar's threaded handler workers share one tracker, so every access
+    to ``_starts`` is serialized by a lock (issue #245): without it, eviction
+    iterated/rebound the dict while other threads inserted -- raising
+    ``RuntimeError: dictionary changed size during iteration`` and silently
+    dropping latency samples.
     """
 
     def __init__(
@@ -69,6 +75,7 @@ class HookTracker:
     ) -> None:
         self._clock = clock or time.monotonic
         self._starts: dict[str, float] = {}
+        self._lock = threading.Lock()
         self._ttl = ttl_seconds
         self._max_pending = max_pending
 
@@ -83,12 +90,13 @@ class HookTracker:
         if not isinstance(tool_use_id, str):
             return
         now = self._clock()
-        if event == "PreToolUse":
-            self._starts[tool_use_id] = now
-        else:
-            self._starts.pop(tool_use_id, None)
-        if len(self._starts) > self._max_pending:
-            self._evict(now)
+        with self._lock:
+            if event == "PreToolUse":
+                self._starts[tool_use_id] = now
+            else:
+                self._starts.pop(tool_use_id, None)
+            if len(self._starts) > self._max_pending:
+                self._evict(now)
 
     def _evict(self, now: float) -> None:
         """Bound memory by age, so a tool still running keeps its start.
@@ -97,19 +105,26 @@ class HookTracker:
         dropped hook) would otherwise leak. Drop those by age first; only if
         nothing is actually stale do we shed the oldest half, which keeps the
         newest -- still pairable -- starts.
+
+        Caller must hold ``self._lock``. The table is drained *in place* --
+        keys are deleted, never rebound -- so the dict identity other threads
+        hold references to stays valid (issue #245).
         """
         cutoff = now - self._ttl
         for key in [k for k, started in self._starts.items() if started < cutoff]:
             del self._starts[key]
         if len(self._starts) > self._max_pending:
             by_age = sorted(self._starts.items(), key=lambda kv: kv[1])
-            self._starts = dict(by_age[len(by_age) // 2 :])
+            keep = dict(by_age[len(by_age) // 2 :])
+            self._starts.clear()
+            self._starts.update(keep)
 
     def latency_ms(self, payload: dict) -> float | None:
         tool_use_id = payload.get("tool_use_id")
         if not isinstance(tool_use_id, str):
             return None
-        start = self._starts.get(tool_use_id)
+        with self._lock:
+            start = self._starts.get(tool_use_id)
         if start is None:
             return None
         return (self._clock() - start) * 1000.0

--- a/tests/adapters/test_claude_code_adapter.py
+++ b/tests/adapters/test_claude_code_adapter.py
@@ -279,3 +279,79 @@ def test_pre_and_post_have_distinct_signatures() -> None:
     pre2 = payload_to_event(_tool_payload("PreToolUse", tool_use_id="other"))
     assert pre2 is not None
     assert pre2.action_signature == pre.action_signature
+
+
+# --- thread safety of the shared tracker (issue #245) -------------------------
+
+
+def test_tracker_concurrent_note_never_raises_and_keeps_working() -> None:
+    """One HookTracker is shared by every handler thread of the threaded
+    sidecar. Under load, note() iterated and *rebound* ``_starts`` while other
+    threads inserted: eviction raised ``RuntimeError: dictionary changed size
+    during iteration`` (silently swallowed downstream) and the rebind
+    discarded concurrent inserts. Everything is serialized by a lock now."""
+    import threading
+
+    tracker = HookTracker(max_pending=8, ttl_seconds=1.0)
+    errors: list[Exception] = []
+
+    def worker(tag: str) -> None:
+        try:
+            for i in range(2000):
+                tracker.note(_tool_payload("PreToolUse", tool_use_id=f"{tag}-{i}"))
+        except Exception as exc:  # pragma: no cover - only on a broken fix
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker, args=(f"w{t}",)) for t in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=30)
+        assert not t.is_alive(), "a worker deadlocked inside the tracker"
+    assert not errors, errors
+
+    # The table must still pair afterwards.
+    clock = {"now": 100.0}
+    paired = HookTracker(clock=lambda: clock["now"], ttl_seconds=600.0)
+    paired.note(_tool_payload("PreToolUse", tool_use_id="pair-me"))
+    clock["now"] = 100.5
+    ev = payload_to_event(_tool_payload("PostToolUse", tool_use_id="pair-me"), paired)
+    assert ev is not None
+    assert ev.latency_ms == 500.0
+
+
+def test_tracker_eviction_under_concurrency_keeps_table_bounded() -> None:
+    """Eviction must drain under load instead of failing forever on an
+    over-cap table (issue #245)."""
+    import threading
+
+    tracker = HookTracker(max_pending=16, ttl_seconds=1e9)  # nothing stale
+    stop = threading.Event()
+
+    def worker(tag: str) -> None:
+        i = 0
+        while not stop.is_set() and i < 4000:
+            tracker.note(_tool_payload("PreToolUse", tool_use_id=f"{tag}-{i}"))
+            i += 1
+
+    threads = [threading.Thread(target=worker, args=(f"e{t}",)) for t in range(6)]
+    for t in threads:
+        t.start()
+    stop.set()
+    for t in threads:
+        t.join(timeout=30)
+    tracker.note(_tool_payload("PreToolUse", tool_use_id="post-drain"))
+    assert len(tracker._starts) <= 2 * tracker._max_pending, (
+        f"table stayed at {len(tracker._starts)} entries"
+    )
+
+
+def test_tracker_eviction_preserves_table_identity() -> None:
+    """Eviction drains the same dict in place -- the object identity never
+    changes, so concurrent holders of the reference keep seeing inserts."""
+    tracker = HookTracker(max_pending=4, ttl_seconds=1e9)
+    ref = tracker._starts
+    for i in range(20):
+        tracker.note(_tool_payload("PreToolUse", tool_use_id=f"k-{i}"))
+    assert tracker._starts is ref
+    assert len(tracker._starts) <= 2 * tracker._max_pending


### PR DESCRIPTION
Fixes #245. Supersedes #258 (stale: conflicts vs merged #250, unaddressed).

## Summary

`make_handler` creates one `HookTracker` shared by every worker of the threaded sidecar, but `note()` mutated `_starts` with no lock. Past `max_pending`, eviction iterated the dict while other threads inserted (`RuntimeError: dictionary changed size during iteration`, swallowed by the sidecar's suppress) and rebound `_starts`, silently discarding concurrent inserts.

## Changes

- Every `_starts` access serialized by a lock; eviction drains in place (clear+update, never rebind)
- Regression tests: concurrent note storm, bounded table under eviction load, table identity

## Validation

- `pytest tests/adapters/test_claude_code_adapter.py` - 20 passed
- `ruff check` + `ruff format --check` + `mypy` clean