### PR TITLE
fix(auto): defer stream emission to exhaustion in openai/anthropic wrappers

### DIFF
--- a/src/snagline/auto/anthropic.py
+++ b/src/snagline/auto/anthropic.py
@@ -22,10 +22,12 @@ latency differences.
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 import itertools
 import logging
 import time
+from typing import Any
 
 from snagline.events import StepEvent, make_signature
 
@@ -38,7 +40,18 @@ except Exception:  # pragma: no cover - exercised only without the Anthropic SDK
 logger = logging.getLogger("snagline")
 
 
-def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
+def _emit(
+    monitor,
+    counter,
+    model,
+    tool_name,
+    sig_text,
+    start,
+    error,
+    error_type=None,
+    tokens_in=None,
+    tokens_out=None,
+) -> None:
     now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
@@ -49,8 +62,185 @@ def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
         tool_name=tool_name,
         latency_ms=(now - start) * 1000.0,
         error=error,
+        error_type=error_type,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
     )
     monitor.ingest(event)
+
+
+def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
+    try:
+        usage = getattr(result, "usage", None)
+        if usage is None and isinstance(result, dict):
+            usage = result.get("usage")
+        if usage is None:
+            return None, None
+        if isinstance(usage, dict):
+            return usage.get("input_tokens"), usage.get("output_tokens")
+        return getattr(usage, "input_tokens", None), getattr(
+            usage, "output_tokens", None
+        )
+    except Exception:
+        return None, None
+
+
+def _is_stream_request(kwargs: dict) -> bool:
+    return kwargs.get("stream") is True
+
+
+def _is_stream_like(obj: Any) -> bool:
+    return (
+        hasattr(obj, "__iter__")
+        or hasattr(obj, "__next__")
+        or hasattr(obj, "__aiter__")
+        or hasattr(obj, "__anext__")
+    )
+
+
+class _SyncStreamWrapper:
+    """Iterate the wrapped stream, emitting one event at exhaustion.
+
+    Streaming calls (``stream=True``) must NOT emit at ``create()`` return
+    time -- that would record a ~0ms success before the first chunk arrives
+    (issue #242). The event fires once the stream is exhausted, closed, or
+    fails mid-flight, mirroring the explicit adapters.
+    """
+
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        self._iter = iter(stream)  # type: ignore[call-overload]
+        self._last: Any = None
+        self._emitted = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> Any:
+        if self._emitted:
+            raise StopIteration
+        try:
+            chunk = next(self._iter)
+            self._last = chunk
+            return chunk
+        except StopIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    def close(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
+
+
+class _AsyncStreamWrapper:
+    """Async twin of :class:`_SyncStreamWrapper`."""
+
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        try:
+            self._aiter = stream.__aiter__()  # type: ignore[union-attr]
+        except Exception:
+            self._aiter = aiter(stream)  # type: ignore[arg-type]
+        self._last: Any = None
+        self._emitted = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._emitted:
+            raise StopAsyncIteration
+        try:
+            chunk = await anext(self._aiter)  # type: ignore[arg-type]
+            self._last = chunk
+            return chunk
+        except StopAsyncIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    async def aclose(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "aclose", None) or getattr(
+            self._stream, "close", None
+        )
+        if callable(close):
+            with contextlib.suppress(Exception):
+                res = close()
+                if inspect.isawaitable(res):
+                    await res
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
 
 
 def _is_async_call(original) -> bool:
@@ -76,28 +266,51 @@ def _wrap_one(monitor, original, tool_name):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
         start = time.perf_counter()
-        error = False
         try:
             result = original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            # Defer telemetry until exhaustion, close, or iteration error.
+            return _SyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or args)
         model = kwargs.get("model", "unknown")
         start = time.perf_counter()
-        error = False
         try:
             result = await original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            return _AsyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     return _async if is_async else _sync

--- a/src/snagline/auto/openai.py
+++ b/src/snagline/auto/openai.py
@@ -28,10 +28,12 @@ latency differences.
 
 from __future__ import annotations
 
+import contextlib
 import inspect
 import itertools
 import logging
 import time
+from typing import Any
 
 from snagline.events import StepEvent, make_signature
 
@@ -44,7 +46,18 @@ except Exception:  # pragma: no cover - exercised only without the OpenAI SDK
 logger = logging.getLogger("snagline")
 
 
-def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
+def _emit(
+    monitor,
+    counter,
+    model,
+    tool_name,
+    sig_text,
+    start,
+    error,
+    error_type=None,
+    tokens_in=None,
+    tokens_out=None,
+) -> None:
     now = time.perf_counter()
     event = StepEvent(
         step_id=str(next(counter)),
@@ -55,8 +68,185 @@ def _emit(monitor, counter, model, tool_name, sig_text, start, error) -> None:
         tool_name=tool_name,
         latency_ms=(now - start) * 1000.0,
         error=error,
+        error_type=error_type,
+        tokens_in=tokens_in,
+        tokens_out=tokens_out,
     )
     monitor.ingest(event)
+
+
+def _extract_tokens(result: Any) -> tuple[int | None, int | None]:
+    try:
+        usage = getattr(result, "usage", None)
+        if usage is None and isinstance(result, dict):
+            usage = result.get("usage")
+        if usage is None:
+            return None, None
+        if isinstance(usage, dict):
+            return usage.get("prompt_tokens"), usage.get("completion_tokens")
+        return getattr(usage, "prompt_tokens", None), getattr(
+            usage, "completion_tokens", None
+        )
+    except Exception:
+        return None, None
+
+
+def _is_stream_request(kwargs: dict) -> bool:
+    return kwargs.get("stream") is True
+
+
+def _is_stream_like(obj: Any) -> bool:
+    return (
+        hasattr(obj, "__iter__")
+        or hasattr(obj, "__next__")
+        or hasattr(obj, "__aiter__")
+        or hasattr(obj, "__anext__")
+    )
+
+
+class _SyncStreamWrapper:
+    """Iterate the wrapped stream, emitting one event at exhaustion.
+
+    Streaming calls (``stream=True``) must NOT emit at ``create()`` return
+    time -- that would record a ~0ms success before the first chunk arrives
+    (issue #242). The event fires once the stream is exhausted, closed, or
+    fails mid-flight, mirroring the explicit adapters.
+    """
+
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        self._iter = iter(stream)  # type: ignore[call-overload]
+        self._last: Any = None
+        self._emitted = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self) -> Any:
+        if self._emitted:
+            raise StopIteration
+        try:
+            chunk = next(self._iter)
+            self._last = chunk
+            return chunk
+        except StopIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    def close(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "close", None)
+        if callable(close):
+            with contextlib.suppress(Exception):
+                close()
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
+
+
+class _AsyncStreamWrapper:
+    """Async twin of :class:`_SyncStreamWrapper`."""
+
+    def __init__(self, monitor, counter, model, tool_name, sig_text, start, stream):
+        self._monitor = monitor
+        self._counter = counter
+        self._model = model
+        self._tool_name = tool_name
+        self._sig_text = sig_text
+        self._start = start
+        self._stream = stream
+        try:
+            self._aiter = stream.__aiter__()  # type: ignore[union-attr]
+        except Exception:
+            self._aiter = aiter(stream)  # type: ignore[arg-type]
+        self._last: Any = None
+        self._emitted = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._emitted:
+            raise StopAsyncIteration
+        try:
+            chunk = await anext(self._aiter)  # type: ignore[arg-type]
+            self._last = chunk
+            return chunk
+        except StopAsyncIteration:
+            self._emit(error=False, error_type=None)
+            raise
+        except Exception as e:
+            self._emit(error=True, error_type=type(e).__name__)
+            raise
+
+    async def aclose(self) -> None:
+        if not self._emitted:
+            self._emit(error=False, error_type=None)
+        close = getattr(self._stream, "aclose", None) or getattr(
+            self._stream, "close", None
+        )
+        if callable(close):
+            with contextlib.suppress(Exception):
+                res = close()
+                if inspect.isawaitable(res):
+                    await res
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._stream, name)
+
+    def _emit(self, *, error: bool, error_type: str | None) -> None:
+        if self._emitted:
+            return
+        self._emitted = True
+        tokens_in, tokens_out = (None, None)
+        if not error and self._last is not None:
+            tokens_in, tokens_out = _extract_tokens(self._last)
+            if tokens_in is None and tokens_out is None:
+                tokens_in, tokens_out = _extract_tokens(self._stream)
+        _emit(
+            self._monitor,
+            self._counter,
+            self._model,
+            self._tool_name,
+            self._sig_text,
+            self._start,
+            error,
+            error_type=error_type,
+            tokens_in=tokens_in,
+            tokens_out=tokens_out,
+        )
 
 
 def _is_async_call(original) -> bool:
@@ -83,28 +273,51 @@ def _wrap_one(monitor, original, tool_name):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
         start = time.perf_counter()
-        error = False
         try:
             result = original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            # Defer telemetry until exhaustion, close, or iteration error.
+            return _SyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     async def _async(*args, **kwargs):
         sig_text = str(kwargs.get("messages") or kwargs.get("prompt") or args)
         model = kwargs.get("model", "unknown")
         start = time.perf_counter()
-        error = False
         try:
             result = await original(*args, **kwargs)
-        except Exception:
-            error = True
+        except Exception as e:
+            _emit(
+                monitor,
+                counter,
+                model,
+                tool_name,
+                sig_text,
+                start,
+                True,
+                error_type=type(e).__name__,
+            )
             raise
-        finally:
-            _emit(monitor, counter, model, tool_name, sig_text, start, error)
+        if _is_stream_request(kwargs) and _is_stream_like(result):
+            return _AsyncStreamWrapper(
+                monitor, counter, model, tool_name, sig_text, start, result
+            )
+        _emit(monitor, counter, model, tool_name, sig_text, start, False)
         return result
 
     return _async if is_async else _sync

--- a/tests/test_auto_stream.py
+++ b/tests/test_auto_stream.py
@@ -1,0 +1,189 @@
+"""Issue #242: auto wrappers must defer emission to stream exhaustion.
+
+With ``stream=True``, ``create()`` returns almost immediately, so emitting
+in a ``finally`` at return time recorded a ~0ms success before the first
+chunk arrived -- and the raw stream came back unwrapped, so mid-iteration
+failures were never observed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from snagline.auto.anthropic import wrap_client as wrap_anthropic
+from snagline.auto.openai import wrap_client as wrap_openai
+
+
+class _SpyMonitor:
+    def __init__(self) -> None:
+        self.events: list[Any] = []
+
+    def ingest(self, event: Any) -> None:
+        self.events.append(event)
+
+
+class _SyncStream:
+    def __init__(self, chunks: list[Any], fail_after: int | None = None) -> None:
+        self._chunks = chunks
+        self._fail_after = fail_after
+        self._yielded = 0
+        self.closed = False
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._fail_after is not None and self._yielded >= self._fail_after:
+            raise RuntimeError("mid-iteration boom")
+        if not self._chunks:
+            raise StopIteration
+        self._yielded += 1
+        return self._chunks.pop(0)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class _AsyncStream:
+    def __init__(self, chunks: list[Any]) -> None:
+        self._chunks = chunks
+        self.closed = False
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._chunks:
+            raise StopAsyncIteration
+        return self._chunks.pop(0)
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _openai_client(stream: Any):
+    class _Completions:
+        def create(self, **kw: Any) -> Any:
+            return stream
+
+    class _Client:
+        chat = type("C", (), {"completions": _Completions()})()
+
+    return _Client()
+
+
+def _anthropic_client(stream: Any):
+    class _Messages:
+        def create(self, **kw: Any) -> Any:
+            return stream
+
+    return type("C", (), {"messages": _Messages()})()
+
+
+def test_openai_stream_emits_nothing_until_exhausted() -> None:
+    mon = _SpyMonitor()
+    client = wrap_openai(mon, _openai_client(_SyncStream(["a", "b"])))
+    out = client.chat.completions.create(model="m", messages=[], stream=True)
+    assert mon.events == [], "emit at stream-open records a ~0ms false success"
+    assert list(out) == ["a", "b"]
+    assert len(mon.events) == 1
+    assert mon.events[0].error is False
+    assert mon.events[0].latency_ms >= 0.0
+
+
+def test_openai_stream_failure_is_observed() -> None:
+    mon = _SpyMonitor()
+    client = wrap_openai(mon, _openai_client(_SyncStream(["a"], fail_after=1)))
+    out = client.chat.completions.create(model="m", messages=[], stream=True)
+    assert next(out) == "a"
+    try:
+        next(out)
+        raise AssertionError("stream should have raised")
+    except RuntimeError:
+        pass
+    assert len(mon.events) == 1
+    assert mon.events[0].error is True
+    assert mon.events[0].error_type == "RuntimeError"
+
+
+def test_openai_stream_close_emits_once_and_delegates() -> None:
+    mon = _SpyMonitor()
+    inner = _SyncStream(["a", "b"])
+    client = wrap_openai(mon, _openai_client(inner))
+    out = client.chat.completions.create(model="m", messages=[], stream=True)
+    out.close()
+    assert inner.closed
+    assert len(mon.events) == 1
+    assert mon.events[0].error is False
+
+
+def test_anthropic_stream_emits_nothing_until_exhausted() -> None:
+    mon = _SpyMonitor()
+    client = wrap_anthropic(mon, _anthropic_client(_SyncStream(["x"])))
+    out = client.messages.create(model="m", messages=[], stream=True)
+    assert mon.events == []
+    assert list(out) == ["x"]
+    assert len(mon.events) == 1
+    assert mon.events[0].error is False
+
+
+def test_non_stream_calls_still_emit_immediately() -> None:
+    mon = _SpyMonitor()
+    client = wrap_openai(mon, _openai_client({"ok": True}))
+    assert client.chat.completions.create(model="m", messages=[]) == {"ok": True}
+    assert len(mon.events) == 1
+
+
+def test_async_stream_defers_to_exhaustion() -> None:
+    async def go() -> None:
+        mon = _SpyMonitor()
+        writes: list[str] = []
+
+        class _AStream:
+            def __init__(self) -> None:
+                self._n = 0
+
+            def __aiter__(self):
+                return self
+
+            async def __anext__(self):
+                self._n += 1
+                if self._n > 2:
+                    raise StopAsyncIteration
+                writes.append(f"c{self._n}")
+                return writes[-1]
+
+        async def _create(**kw: Any) -> Any:
+            return _AStream()
+
+        from snagline.auto.openai import _wrap_one
+
+        wrapped = _wrap_one(mon, _create, "openai.messages.create")
+        out = await wrapped(model="m", messages=[], stream=True)
+        assert mon.events == []
+        seen = [c async for c in out]
+        assert seen == ["c1", "c2"]
+        assert len(mon.events) == 1
+        assert mon.events[0].error is False
+
+    asyncio.run(go())
+
+
+def test_async_stream_close_emits() -> None:
+    async def go() -> None:
+        mon = _SpyMonitor()
+        inner = _AsyncStream(["z"])
+
+        async def _create(**kw: Any) -> Any:
+            return inner
+
+        from snagline.auto.openai import _wrap_one
+
+        wrapped = _wrap_one(mon, _create, "openai.messages.create")
+        out = await wrapped(model="m", messages=[], stream=True)
+        await out.aclose()
+        assert inner.closed
+        assert len(mon.events) == 1
+
+    asyncio.run(go())


### PR DESCRIPTION
Fixes #242. Supersedes #255 (stale: conflicts vs merged #271, unaddressed) -- re-applied onto the current wrappers (resource-class patching + perf_counter clock preserved).

## Summary

The wrappers emitted their `StepEvent` in a `finally` immediately after `create()` returned. With `stream=True` that is stream-open time: `latency_ms ~= 0`, no tokens, `error=False` -- and the raw stream came back unwrapped, so failures during iteration were never observed.

## Changes

- `_SyncStreamWrapper` / `_AsyncStreamWrapper` in both modules (mirroring the explicit adapters): emit once at exhaustion, close, or mid-flight failure, with end-of-stream token extraction
- Non-stream calls emit exactly as before; create-time failures emit with `error_type`
- New `tests/test_auto_stream.py`: deferred emission, mid-iteration failure observed, close-once semantics, async paths

## Validation

- 30 passed across the auto suites; `ruff check` + `ruff format --check` + `mypy` clean